### PR TITLE
jsonata-js 2.2.1 Phase 1: signature engine rewrite for +/- support

### DIFF
--- a/docs/superpowers/plans/2026-07-04-jsonata-2.2.1-phase1-signatures.md
+++ b/docs/superpowers/plans/2026-07-04-jsonata-2.2.1-phase1-signatures.md
@@ -1,0 +1,1145 @@
+# jsonata-js 2.2.1 Phase 1: Signature Engine Rewrite — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump the `tests/jsonata-js` reference submodule to `v2.2.1` and rewrite `src/signature.rs`'s function-signature matching engine so it correctly supports the `+` (one-or-more repeat) and `-` (context-fallback) signature modifiers, bringing the reference suite from 1268/1274 to 1274/1274.
+
+**Architecture:** `src/parser.rs`'s signature-literal tokenizer gets one new token arm (`+`). `src/signature.rs`'s matcher is rewritten from a hand-rolled recursive-descent zip (params 1:1 with args) to a regex-based engine mirroring `signature.js`: each parameter contributes a regex fragment (base char-class plus an optional `?`/`+` quantifier or `-`'s context-fallback marker), the whole signature compiles to one anchored regex, and actual call arguments are matched by building a one-char-per-argument "type symbol string" and running it through that regex. Matched capture groups are split back into validated/coerced argument values. `crate::signature::Signature::validate_and_coerce`'s public signature gains a `context: &JValue` parameter (needed for `-`'s context-fallback, which the current code has never actually implemented — it was a silent no-op) — this requires updating its 4 call sites in `src/evaluator.rs`.
+
+**Tech Stack:** Rust, `regex` crate (already a dependency, no `Cargo.toml` change), `cargo test`, `pytest` reference suite.
+
+## Global Constraints
+
+- Rust 2021 edition, stable channel only (no nightly features). `cargo fmt` and `cargo clippy -- -D warnings` must stay clean throughout (zero-warnings policy).
+- `Signature::parse`, `Signature::validate_arg_count`, `SignatureError` must keep their existing variants usable by current callers — this is an internal rewrite, not a breaking redesign, except for the one deliberate, necessary addition: `validate_and_coerce` gains a `context: &JValue` parameter, and a new `SignatureError::ContextTypeMismatch` variant is added (additive, does not remove or rename any existing variant).
+- No new Cargo dependencies. No signature-parse caching (a global regex cache was considered and explicitly rejected — see the "Non-goals" section below).
+- Full test suite (`uv run pytest tests/python/test_reference_suite.py`) must be 1274/1274 passing when this phase is done. `cargo test` must stay green throughout.
+- Do not touch `vm.rs`/`compiler.rs`: confirmed during design that any lambda with a declared signature (`stored.signature.is_some()`) always routes through the tree-walker's `invoke_lambda_with_env`/`invoke_lambda_body_for_tco` (see `src/evaluator.rs:2467` `invoke_stored_lambda`'s fast-path gate), never the compiled VM path. This phase's fix is entirely in `signature.rs`, `parser.rs`, and 4 call sites in `evaluator.rs`.
+
+## Non-goals (explicitly out of scope for this task)
+
+- **No signature-parse caching.** The current code already re-parses a lambda's signature string on every single invocation (see `evaluator.rs:8146` `invoke_lambda_with_env` and `evaluator.rs:8366` `invoke_lambda_body_for_tco` — both call `crate::signature::Signature::parse(sig_str)` fresh every call). Switching the internal matcher to regex-based doesn't change this pre-existing per-call-reparse characteristic — it's a constant-factor cost, not a new architectural regression, and there's no benchmark showing it matters. If it turns out to matter, the correct fix is caching the *parsed* `Signature` on `StoredLambda` at lambda-definition time (parse once, reuse many times) — not a runtime global cache. That's a separate, unstarted piece of work; do not add one as part of this task.
+- **The 'j' (any-JSON-type) signature character** exists in `signature.js` but is not supported by our current `ParamType::from_char`, is not used by any builtin signature literal in this codebase, and is not exercised by any reference-suite test (existing or new). Do not add it — it would be speculative, untested code.
+- **Builtins that bypass the generic `Signature` engine entirely** (e.g. `$length`, `$substringBefore`, `$substringAfter` — these have hand-written arg-count/type checks directly in their `evaluator.rs` dispatch arms, not routed through `crate::signature::Signature` at all) are unrelated to this rewrite and must not be touched. Their existing T0411 reference-suite tests (`function-length/case013`, `case014`, `transform/case076`, `case084`) pass today via the lenient test harness (it accepts any thrown error when it can't parse a specific code from the message) and are unaffected by this work.
+- **The JSONata "implicit context as missing argument" feature for `.`/`~>`-chained calls** (verified empirically: `(99).function($a,$b)<n-n:n>{$a+$b}(6)` returns `105`, using `99` as `$a`, entirely independent of whether the signature has a `-` at all — a bare top-level call with the same signature and short args always fails with `ArgumentCountMismatch` regardless of context) is a separate, already-working, pre-existing mechanism unrelated to `signature.rs`. Do not touch it; this plan's new tests for `-`/context-fallback specifically use **bare, non-chained** lambda calls so they actually exercise `signature.rs`'s own context-substitution path rather than that unrelated mechanism.
+
+---
+
+## Task 1: Establish the branch and the failing baseline
+
+**Files:**
+- Modify: `tests/jsonata-js` (submodule pointer)
+- No source files touched in this task.
+
+**Interfaces:** None — this task only establishes the starting git state and confirms the known failure set.
+
+- [ ] **Step 1: Create the working branch off current `main`**
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/jsonata-2.2.1-signatures
+```
+
+Do **not** branch from or merge `sync/jsonata-2.2.1` or `sync/jsonata-2.2.0` — both forked from a very old point in `main`'s history (around version 2.1.4) and predate the Null/Undefined tree-walker migration, the `lambda_id` fix, and various CI fixes. Their only content not already on `main` is the submodule pointer bump itself.
+
+- [ ] **Step 2: Bump the submodule to v2.2.1**
+
+```bash
+cd tests/jsonata-js
+git fetch origin --tags
+git checkout v2.2.1
+cd ../..
+git add tests/jsonata-js
+git status --short
+```
+
+Expected: `git status --short` shows ` M tests/jsonata-js` (pointer bump only — no other files should be staged; if you see hundreds of modified files inside the submodule, that's pre-existing CRLF/line-ending noise in a *dirty working tree*, not something this checkout caused — investigate with `cd tests/jsonata-js && git status --short` before proceeding, and do not run `git add -A` inside the submodule).
+
+- [ ] **Step 3: Run the reference suite to confirm the known failure set**
+
+```bash
+uv run pytest tests/python/test_reference_suite.py -q 2>&1 | tail -20
+```
+
+Expected: `6 failed, 1268 passed`, with the 6 failures being exactly:
+```
+FAILED tests/python/test_reference_suite.py::test_reference_suite[function-signatures/case035]
+FAILED tests/python/test_reference_suite.py::test_reference_suite[function-signatures/case036]
+FAILED tests/python/test_reference_suite.py::test_reference_suite[function-signatures/case037]
+FAILED tests/python/test_reference_suite.py::test_reference_suite[function-signatures/case038]
+FAILED tests/python/test_reference_suite.py::test_reference_suite[function-signatures/case039]
+FAILED tests/python/test_reference_suite.py::test_reference_suite[function-signatures/case040]
+```
+All 6 fail with `Parse error: Unexpected token: Unexpected token in signature: Plus`. If you see a *different* failure set, stop and re-diagnose before continuing — the rest of this plan assumes exactly this baseline.
+
+- [ ] **Step 4: Commit the submodule bump**
+
+```bash
+git commit -m "$(cat <<'EOF'
+chore: bump jsonata-js submodule to v2.2.1
+
+Baseline: 1268/1274 reference-suite tests pass. The 6 failures are
+all in function-signatures (case035-040), tracing to the signature
+parser rejecting the '+' repeat modifier. Fixed in follow-up commits
+on this branch.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Delete the stale sync branches (repo hygiene)**
+
+```bash
+git push origin --delete sync/jsonata-2.2.1 sync/jsonata-2.2.0
+```
+
+If this fails due to permissions or the user wants to review first, skip it and flag it in the PR description instead — it's not a blocker for the rest of this plan.
+
+---
+
+## Task 2: Parser fix — accept `+` in signature literals
+
+**Files:**
+- Modify: `src/parser.rs:793-798` (the `_` catch-all arm in `parse_signature`'s token-collecting loop)
+- Test: `src/parser.rs` (add to the existing `#[cfg(test)] mod tests` block — check the end of the file for its exact location with `grep -n "mod tests" src/parser.rs`)
+
+**Interfaces:**
+- Consumes: `Token::Plus` (already exists in the `Token` enum, used elsewhere for the `+` arithmetic operator — see `src/parser.rs:711` `Token::Plus | Token::Minus => Some((50, 51))`).
+- Produces: `parse_signature(&mut self) -> Result<String, ParserError>` now returns a signature string that may contain a literal `+` character, e.g. `"<n+n:o>"`. No other code depends on this yet — Task 3 depends on it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `src/parser.rs`'s existing test module:
+
+```rust
+    #[test]
+    fn test_signature_with_repeat_modifier_parses() {
+        // A lambda literal with a '+' (one-or-more) signature modifier must parse
+        // without error. This was rejected before jsonata-js 2.2.1 compatibility work
+        // ("Unexpected token in signature: Plus").
+        let result = parse("λ($arg1, $arg2)<n+n:o>{{\"a\": $arg1, \"b\": $arg2}}(1, 2, 3)");
+        assert!(result.is_ok(), "expected parse to succeed, got {:?}", result);
+    }
+```
+
+(If the top-level parse entrypoint in this file is not named `parse`, use `grep -n "pub fn parse" src/parser.rs` to find the exact public function name and adjust the call accordingly — it should take a `&str` and return `Result<AstNode, ParserError>`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cargo test --lib test_signature_with_repeat_modifier_parses -- --nocapture
+```
+
+Expected: FAIL, with the assertion message showing `Err(UnexpectedToken("Unexpected token in signature: Plus"))`.
+
+- [ ] **Step 3: Fix `parse_signature`**
+
+In `src/parser.rs`, find the token-collecting match inside `parse_signature` (around line 747-800). Add a new arm for `Token::Plus` alongside the existing `Token::Minus`/`Token::Question` arms:
+
+```rust
+                Token::Minus => {
+                    signature.push('-');
+                    self.advance()?;
+                }
+                Token::Plus => {
+                    signature.push('+');
+                    self.advance()?;
+                }
+                Token::Colon => {
+```
+
+(Insert the new `Token::Plus` arm directly after the existing `Token::Minus` arm — the exact surrounding code is at `src/parser.rs:761-768`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cargo test --lib test_signature_with_repeat_modifier_parses -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/parser.rs
+git commit -m "$(cat <<'EOF'
+fix: accept '+' repeat modifier in signature literals
+
+The signature-literal tokenizer only recognized '-', '?', ':', and
+type characters, rejecting '+' (one-or-more repeat) with "Unexpected
+token in signature: Plus". This is step 1 of 2 toward supporting
+repeat params — the matching engine itself (signature.rs) doesn't
+understand '+' yet, that's the next commit.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Signature data model — regex fragments per parameter
+
+**Files:**
+- Modify: `src/signature.rs` (the `Parameter`, `Signature` structs, `Signature::new`, `Signature::parse`, `Signature::parse_params`; the existing `#[cfg(test)] mod tests` at the bottom)
+- No new files.
+
+**Interfaces:**
+- Consumes: `regex::Regex` (already a dependency in `Cargo.toml`, not previously imported into `signature.rs`).
+- Produces (for Task 4 to consume):
+  - `Parameter { pub param_type: ParamType, pub optional: bool, regex: String, repeatable: bool, context: bool, context_regex: Option<String> }` — note `regex`, `repeatable`, `context`, `context_regex` are **not** `pub` (only used inside `signature.rs`).
+  - `Signature { pub params: Vec<Parameter>, pub return_type: Option<ParamType>, full_regex: Regex }` — `full_regex` is **not** `pub`.
+  - `Parameter::new(param_type: ParamType, optional: bool) -> Parameter` (new helper, replaces direct struct-literal construction in tests).
+  - `fn type_char(t: &ParamType) -> char` (new free function, module-private).
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the existing test in `src/signature.rs`'s `mod tests` (currently using a raw `Parameter { param_type, optional }` struct literal, which will not compile once `Parameter` gains new required-by-construction fields) with:
+
+```rust
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signature_validation() {
+        let sig = Signature::new(
+            vec![
+                Parameter::new(ParamType::String, false),
+                Parameter::new(ParamType::Number, true),
+            ],
+            Some(ParamType::String),
+        );
+
+        // Valid: 1 required arg provided
+        assert!(sig.validate_arg_count(1).is_ok());
+
+        // Valid: both args provided
+        assert!(sig.validate_arg_count(2).is_ok());
+
+        // Invalid: too few args
+        assert!(sig.validate_arg_count(0).is_err());
+
+        // Invalid: too many args
+        assert!(sig.validate_arg_count(3).is_err());
+    }
+
+    #[test]
+    fn test_parse_signature_with_repeat_modifier() {
+        // "<n+n:o>" must parse into exactly 2 params: a repeatable number,
+        // then a required number.
+        let sig = Signature::parse("<n+n:o>").expect("valid signature");
+        assert_eq!(sig.params.len(), 2);
+        assert_eq!(sig.params[0].param_type, ParamType::Number);
+        assert!(!sig.params[0].optional);
+        assert_eq!(sig.params[1].param_type, ParamType::Number);
+        assert!(!sig.params[1].optional);
+    }
+
+    #[test]
+    fn test_repeat_param_allows_more_args_than_declared_slots() {
+        // "<n+n>" (2 type-slots, one repeatable) must accept 3 args, whereas
+        // "<nn>" (2 required, non-repeatable slots) must reject 3 args.
+        let repeating = Signature::parse("<n+n:o>").expect("valid signature");
+        assert!(repeating.validate_arg_count(3).is_ok());
+
+        let non_repeating = Signature::parse("<nn:o>").expect("valid signature");
+        assert!(non_repeating.validate_arg_count(3).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cargo test --lib signature:: -- --nocapture
+```
+
+Expected: compile error (`Parameter::new` doesn't exist yet; `Signature::parse("<n+n:o>")` doesn't handle `+`).
+
+- [ ] **Step 3: Add `type_char` and rewrite `Parameter`**
+
+In `src/signature.rs`, add this free function right after the `ParamType` enum's `matches` impl block ends (after line 83, before `pub struct Parameter`):
+
+```rust
+/// Map a ParamType back to its single-character signature symbol.
+/// Used to rebuild a union type's regex character class from its parsed
+/// component types.
+fn type_char(t: &ParamType) -> char {
+    match t {
+        ParamType::String => 's',
+        ParamType::Number => 'n',
+        ParamType::Boolean => 'b',
+        ParamType::Null => 'l',
+        ParamType::Object => 'o',
+        ParamType::Array(_) => 'a',
+        ParamType::Function(_) => 'f',
+        ParamType::Any => 'x',
+        // Unreachable in practice: signature.js does not nest unions inside
+        // unions, and our parser never constructs one this way either.
+        ParamType::Union(_) => 'x',
+    }
+}
+
+/// Get the single-character type symbol for a value, mirroring signature.js's
+/// getSymbol(): used to build the "supplied signature" string that gets
+/// matched against a Signature's compiled regex.
+fn type_symbol(value: &JValue) -> char {
+    match value {
+        JValue::Null => 'l',
+        JValue::Bool(_) => 'b',
+        JValue::Number(_) => 'n',
+        JValue::String(_) => 's',
+        JValue::Array(_) => 'a',
+        JValue::Object(_) => 'o',
+        JValue::Undefined => 'm',
+        JValue::Lambda { .. } => 'f',
+        JValue::Builtin { .. } => 'f',
+        JValue::Regex { .. } => 'o',
+    }
+}
+```
+
+Replace the existing `Parameter` struct definition (lines 85-90) with:
+
+```rust
+/// Function parameter definition
+#[derive(Debug, Clone)]
+pub struct Parameter {
+    pub param_type: ParamType,
+    pub optional: bool,
+    /// Regex fragment for this parameter, e.g. "[nm]", "[nm]+", "[sm]?".
+    /// Combined across all params to build a Signature's full_regex.
+    regex: String,
+    /// True if this parameter was declared with the '+' (one-or-more) modifier.
+    repeatable: bool,
+    /// True if this parameter was declared with the '-' modifier: when the
+    /// caller omits this argument, substitute the evaluation context value
+    /// instead (if its type is compatible).
+    context: bool,
+    /// Regex fragment (without the '-'-induced trailing '?') used to test
+    /// whether the context value's type is compatible, when `context` is true.
+    context_regex: Option<String>,
+}
+
+impl Parameter {
+    /// Construct a Parameter directly (not via signature-string parsing).
+    /// Used by tests and by Signature::new. Produces a non-repeatable,
+    /// non-context parameter with the standard base regex for its type.
+    #[allow(dead_code)]
+    pub fn new(param_type: ParamType, optional: bool) -> Self {
+        let mut regex = Self::base_regex(&param_type);
+        if optional {
+            regex.push('?');
+        }
+        Parameter {
+            param_type,
+            optional,
+            regex,
+            repeatable: false,
+            context: false,
+            context_regex: None,
+        }
+    }
+
+    /// The base (unquantified) regex character class for a parameter type,
+    /// mirroring signature.js's per-symbol regex assignment.
+    fn base_regex(param_type: &ParamType) -> String {
+        match param_type {
+            ParamType::Array(_) => "[asnblfom]".to_string(),
+            ParamType::Function(_) => "f".to_string(),
+            ParamType::Any => "[asnblfom]".to_string(),
+            ParamType::String => "[sm]".to_string(),
+            ParamType::Number => "[nm]".to_string(),
+            ParamType::Boolean => "[bm]".to_string(),
+            ParamType::Null => "[lm]".to_string(),
+            ParamType::Object => "[om]".to_string(),
+            ParamType::Union(types) => {
+                let chars: String = types.iter().map(type_char).collect();
+                format!("[{}m]", chars)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Rewrite `Signature` struct, `new`, and `parse`**
+
+Replace the existing `Signature` struct (lines 92-98) with:
+
+```rust
+/// Function signature
+#[derive(Debug, Clone)]
+pub struct Signature {
+    pub params: Vec<Parameter>,
+    #[allow(dead_code)]
+    pub return_type: Option<ParamType>,
+    /// The compiled regex matching this signature's full parameter list
+    /// against a "supplied signature" type-symbol string, e.g. "^([nm]+)([nm])$".
+    full_regex: Regex,
+}
+```
+
+Replace `Signature::new` (lines 100-108) with:
+
+```rust
+    /// Create a new signature
+    #[allow(dead_code)]
+    pub fn new(params: Vec<Parameter>, return_type: Option<ParamType>) -> Self {
+        let full_regex = Self::compile_full_regex(&params);
+        Signature {
+            params,
+            return_type,
+            full_regex,
+        }
+    }
+
+    /// Build the anchored whole-signature regex from each parameter's fragment.
+    fn compile_full_regex(params: &[Parameter]) -> Regex {
+        let pattern: String = std::iter::once("^".to_string())
+            .chain(params.iter().map(|p| format!("({})", p.regex)))
+            .chain(std::iter::once("$".to_string()))
+            .collect();
+        Regex::new(&pattern).unwrap_or_else(|e| {
+            panic!("generated signature regex `{}` is invalid: {}", pattern, e)
+        })
+    }
+```
+
+Replace the last few lines of `Signature::parse` (the `Ok(Signature { params, return_type })` at the end, around line 146-149) with:
+
+```rust
+        let full_regex = Self::compile_full_regex(&params);
+
+        Ok(Signature {
+            params,
+            return_type,
+            full_regex,
+        })
+```
+
+- [ ] **Step 5: Rewrite `parse_params` to build regex fragments and handle `+`/`-`**
+
+Replace the entire `parse_params` function (lines 167-196) with:
+
+```rust
+    /// Parse parameter types from string like "n-n" or "a<s>s?" or "n+n"
+    fn parse_params(param_str: &str) -> Result<Vec<Parameter>, SignatureError> {
+        let mut params = Vec::new();
+        let mut chars = param_str.chars().peekable();
+
+        while chars.peek().is_some() {
+            let param_type = Self::parse_type_chars(&mut chars)?;
+            let mut regex = Parameter::base_regex(&param_type);
+            let mut optional = false;
+            let mut repeatable = false;
+            let mut context = false;
+            let mut context_regex = None;
+
+            match chars.peek() {
+                Some('?') => {
+                    chars.next();
+                    regex.push('?');
+                    optional = true;
+                }
+                Some('+') => {
+                    chars.next();
+                    regex.push('+');
+                    repeatable = true;
+                }
+                Some('-') => {
+                    chars.next();
+                    context = true;
+                    context_regex = Some(regex.clone());
+                    regex.push('?');
+                    optional = true;
+                }
+                _ => {}
+            }
+
+            params.push(Parameter {
+                param_type,
+                optional,
+                regex,
+                repeatable,
+                context,
+                context_regex,
+            });
+        }
+
+        Ok(params)
+    }
+```
+
+Note: `parse_type_chars` (the existing recursive helper handling union types `(ns)` and subtypes `a<s>`/`f<n:n>`) is **not modified** — it already correctly produces a `ParamType`, and this rewrite only changes what happens *after* a type is parsed (building the regex fragment and checking for a trailing modifier), not the type-parsing itself.
+
+- [ ] **Step 6: Add the `use regex::Regex;` import**
+
+At the top of `src/signature.rs`, after the existing `use` lines:
+
+```rust
+use crate::value::JValue;
+use regex::Regex;
+use thiserror::Error;
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+cargo build --lib 2>&1 | tail -30
+```
+
+Expected: the crate should compile now (note `validate_and_coerce` in the same file still references the *old* `Parameter`/matching logic and will need Task 4's rewrite before it compiles cleanly against the new `Parameter` fields — if `cargo build` fails here on `validate_and_coerce`/`validate_arg_count`, that's expected; proceed directly to Task 4's Step 1, which fixes those next. Do not consider this task done until Task 4 also compiles.)
+
+- [ ] **Step 8: Commit**
+
+Commit together with Task 4 (the crate won't compile with Task 3 alone, since `validate_and_coerce` needs updating too — see Task 4).
+
+---
+
+## Task 4: Matching algorithm rewrite — the correctness gate
+
+**Why this task matters most:** the reference suite barely exercises the new matching logic. Tracing all 6 target cases (035-040) through the design: five of them (035, 036, 037, 039, 040) only need the parser to accept `+`/`-` and the arg-count check to tolerate repeats — the actual regex-splitting/coercion logic isn't load-bearing for their *results*, because lambda-argument binding only uses the first N validated values (N = declared param count) regardless of how many extra values the repeat logic produces. **Only case038 exercises the context-substitution success path.** None of the 6 exercises: a type mismatch *within* a repeated position, a context type *mismatch*, or an array-subtype check *within* a repeated position. The unit tests in this task are what actually prove the rewrite is correct — treat them as the real gate, not a nice-to-have.
+
+**Files:**
+- Modify: `src/signature.rs` (`validate_arg_count`, `validate_and_coerce`, `SignatureError` enum, `#[cfg(test)] mod tests`)
+- No new files.
+
+**Interfaces:**
+- Consumes: `type_symbol` and `Parameter`'s new fields (`regex`, `repeatable`, `context`, `context_regex`) from Task 3.
+- Produces: `pub fn validate_and_coerce(&self, args: &[JValue], context: &JValue) -> Result<Vec<JValue>, SignatureError>` — **signature changed from Task 3's starting point**: adds a `context: &JValue` parameter. This is consumed by Task 5's evaluator.rs call-site updates. New enum variant: `SignatureError::ContextTypeMismatch { index: usize, expected: String }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to `src/signature.rs`'s `mod tests` (after the tests added in Task 3):
+
+```rust
+    #[test]
+    fn test_repeat_param_coerces_all_matched_args() {
+        // <n+n:o> called with (1, 2, 3): the repeat consumes 2 numbers, the
+        // final required slot consumes the 3rd. All 3 must appear in order.
+        let sig = Signature::parse("<n+n:o>").expect("valid signature");
+        let args = vec![JValue::Number(1.0), JValue::Number(2.0), JValue::Number(3.0)];
+        let coerced = sig
+            .validate_and_coerce(&args, &JValue::Undefined)
+            .expect("should validate");
+        assert_eq!(coerced, args);
+    }
+
+    #[test]
+    fn test_repeat_param_rejects_wrong_type_within_repeat() {
+        // <n+> with (1, 2, "x"): the 3rd arg breaks the all-numbers repeat,
+        // and there's nothing else in the signature to absorb a string, so
+        // the whole match fails -> T0410-class error (ArgumentTypeMismatch).
+        let sig = Signature::parse("<n+:o>").expect("valid signature");
+        let args = vec![
+            JValue::Number(1.0),
+            JValue::Number(2.0),
+            JValue::string("x"),
+        ];
+        let result = sig.validate_and_coerce(&args, &JValue::Undefined);
+        assert!(
+            matches!(result, Err(SignatureError::ArgumentTypeMismatch { .. })),
+            "expected ArgumentTypeMismatch, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_context_substitution_success() {
+        // <n+s-:a<n>> called with (1, 2) and a string context: the omitted
+        // 3rd (context-fallback) argument should be filled from the context.
+        let sig = Signature::parse("<n+s-:a<n>>").expect("valid signature");
+        let args = vec![JValue::Number(1.0), JValue::Number(2.0)];
+        let context = JValue::string("b");
+        let coerced = sig
+            .validate_and_coerce(&args, &context)
+            .expect("should validate using context fallback");
+        assert_eq!(
+            coerced,
+            vec![JValue::Number(1.0), JValue::Number(2.0), JValue::string("b")]
+        );
+    }
+
+    #[test]
+    fn test_context_substitution_type_mismatch() {
+        // <s-:s> called with 0 args and a NUMBER context: the context type
+        // doesn't match the expected string type -> distinct T0411-class error.
+        let sig = Signature::parse("<s-:s>").expect("valid signature");
+        let args: Vec<JValue> = vec![];
+        let context = JValue::Number(42.0);
+        let result = sig.validate_and_coerce(&args, &context);
+        assert!(
+            matches!(result, Err(SignatureError::ContextTypeMismatch { .. })),
+            "expected ContextTypeMismatch, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_array_subtype_mismatch_within_repeat() {
+        // <a<n>+:o> called with an array containing a non-number element:
+        // the repeat's array-subtype check must still fire (T0412-class).
+        let sig = Signature::parse("<a<n>+:o>").expect("valid signature");
+        let bad_array = JValue::array(vec![JValue::string("x")]);
+        let args = vec![bad_array];
+        let result = sig.validate_and_coerce(&args, &JValue::Undefined);
+        assert!(
+            matches!(result, Err(SignatureError::ArrayTypeMismatch { .. })),
+            "expected ArrayTypeMismatch, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_repeat_with_leading_optional_does_not_spuriously_error() {
+        // <s?n+:a<n>> called with (1, 2, 3): the optional leading string slot
+        // matches zero characters (none of the 3 args is a string) and gets
+        // "phantom-assigned" args[0] per signature.js's own algorithm, while
+        // the repeat consumes args[1] and args[2] AND reads one position past
+        // the end of `args` (args[3], which doesn't exist). That out-of-bounds
+        // read must resolve to JValue::Undefined WITHOUT tripping the
+        // "explicit null/undefined for a non-nullable required type" error،
+        // since it was never actually supplied by the caller.
+        let sig = Signature::parse("<s?n+:a<n>>").expect("valid signature");
+        let args = vec![JValue::Number(1.0), JValue::Number(2.0), JValue::Number(3.0)];
+        let coerced = sig
+            .validate_and_coerce(&args, &JValue::Undefined)
+            .expect("must not error on out-of-bounds repeat padding");
+        // Only the first 2 entries matter to callers (lambda binding only
+        // uses as many entries as there are declared params), but the full
+        // vector must not be an error.
+        assert_eq!(coerced[0], JValue::Number(1.0));
+        assert_eq!(coerced[1], JValue::Number(2.0));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cargo test --lib signature:: -- --nocapture 2>&1 | tail -60
+```
+
+Expected: compile error (`validate_and_coerce` doesn't yet take a `context` parameter; `SignatureError::ContextTypeMismatch` doesn't exist).
+
+- [ ] **Step 3: Add the `ContextTypeMismatch` variant**
+
+In `src/signature.rs`, update the `SignatureError` enum (lines 8-24) by adding one variant after `ArrayTypeMismatch`:
+
+```rust
+    #[error("T0412: Argument {index} must be an array of {expected}")]
+    ArrayTypeMismatch { index: usize, expected: String },
+
+    #[error("T0411: Context value does not match function signature (expected {expected})")]
+    ContextTypeMismatch { index: usize, expected: String },
+
+    #[error("Undefined argument")]
+    UndefinedArgument,
+```
+
+- [ ] **Step 4: Rewrite `validate_arg_count`**
+
+Replace the existing `validate_arg_count` (lines 304-317) with:
+
+```rust
+    /// Validate argument count
+    pub fn validate_arg_count(&self, actual: usize) -> Result<(), SignatureError> {
+        let required = self.params.iter().filter(|p| !p.optional).count();
+        let unbounded = self.params.iter().any(|p| p.repeatable);
+        let max = self.params.len();
+
+        if actual < required || (!unbounded && actual > max) {
+            return Err(SignatureError::ArgumentCountMismatch {
+                expected: required,
+                actual,
+            });
+        }
+
+        Ok(())
+    }
+```
+
+- [ ] **Step 5: Rewrite `validate_and_coerce`**
+
+Replace the entire existing `validate_and_coerce` (lines 319-383) with:
+
+```rust
+    /// Validate and coerce arguments according to signature rules.
+    ///
+    /// `context` is the JSONata evaluation context (`$`) at the point of the
+    /// call, used for the '-' modifier's fallback-to-context behavior.
+    /// Pass `&JValue::Undefined` if there is no meaningful context (e.g. a
+    /// signature with no '-'-marked parameters never inspects it).
+    ///
+    /// Mirrors signature.js's regex-based validate(): build a one-char-per-
+    /// argument type-symbol string, match it against this signature's
+    /// compiled regex, then walk each parameter's captured group back to
+    /// positional arguments (a captured group may span multiple characters
+    /// when the parameter is repeatable with '+').
+    pub fn validate_and_coerce(
+        &self,
+        args: &[JValue],
+        context: &JValue,
+    ) -> Result<Vec<JValue>, SignatureError> {
+        self.validate_arg_count(args.len())?;
+
+        let supplied_sig: String = args.iter().map(|a| type_symbol(a)).collect();
+
+        let captures = match self.full_regex.captures(&supplied_sig) {
+            Some(c) => c,
+            None => return Err(self.arg_type_mismatch_error(&supplied_sig)),
+        };
+
+        let mut coerced_args = Vec::with_capacity(args.len());
+        let mut arg_index = 0usize;
+
+        for (i, param) in self.params.iter().enumerate() {
+            let matched = captures.get(i + 1).map(|m| m.as_str()).unwrap_or("");
+
+            if matched.is_empty() {
+                let arg = args.get(arg_index).cloned().unwrap_or(JValue::Undefined);
+
+                if param.context {
+                    let context_symbol = type_symbol(context).to_string();
+                    let context_regex_str = param.context_regex.as_deref().unwrap_or("");
+                    let context_re = Regex::new(&format!("^{}$", context_regex_str))
+                        .map_err(|e| SignatureError::InvalidSignature(e.to_string()))?;
+                    if context_re.is_match(&context_symbol) {
+                        coerced_args.push(context.clone());
+                    } else {
+                        return Err(SignatureError::ContextTypeMismatch {
+                            index: arg_index + 1,
+                            expected: Self::type_name(&param.param_type),
+                        });
+                    }
+                } else {
+                    // This position was genuinely supplied (not out-of-bounds
+                    // padding) only if arg_index is within the original args.
+                    let was_supplied = arg_index < args.len();
+                    if was_supplied
+                        && (arg.is_null() || arg.is_undefined())
+                        && !matches!(param.param_type, ParamType::Null | ParamType::Any)
+                    {
+                        return Err(SignatureError::UndefinedArgument);
+                    }
+                    coerced_args.push(arg);
+                    arg_index += 1;
+                }
+                continue;
+            }
+
+            for single in matched.chars() {
+                let was_supplied = arg_index < args.len();
+                let arg = args.get(arg_index).cloned().unwrap_or(JValue::Undefined);
+
+                if was_supplied
+                    && (arg.is_null() || arg.is_undefined())
+                    && !matches!(param.param_type, ParamType::Null | ParamType::Any)
+                {
+                    return Err(SignatureError::UndefinedArgument);
+                }
+
+                let resolved = if let ParamType::Array(elem_type) = &param.param_type {
+                    if single == 'm' {
+                        JValue::Undefined
+                    } else if let JValue::Array(arr) = &arg {
+                        if let Some(expected_elem) = elem_type {
+                            if !arr.is_empty() && !arr.iter().all(|v| expected_elem.matches(v)) {
+                                return Err(SignatureError::ArrayTypeMismatch {
+                                    index: arg_index + 1,
+                                    expected: Self::type_name(expected_elem),
+                                });
+                            }
+                        }
+                        arg.clone()
+                    } else {
+                        if let Some(expected_elem) = elem_type {
+                            if !expected_elem.matches(&arg) {
+                                return Err(SignatureError::ArrayTypeMismatch {
+                                    index: arg_index + 1,
+                                    expected: Self::type_name(expected_elem),
+                                });
+                            }
+                        }
+                        JValue::array(vec![arg.clone()])
+                    }
+                } else {
+                    arg.clone()
+                };
+
+                coerced_args.push(resolved);
+                arg_index += 1;
+            }
+        }
+
+        Ok(coerced_args)
+    }
+
+    /// Build an ArgumentTypeMismatch error identifying roughly which argument
+    /// broke validation, by matching a growing prefix of the joint pattern
+    /// (mirrors signature.js's throwValidationError). Exact index parity with
+    /// signature.js's backtracking behavior is not guaranteed in all cases —
+    /// this is a best-effort diagnostic, not something any test asserts on
+    /// precisely (the reference suite only checks error *codes*, not indices).
+    fn arg_type_mismatch_error(&self, supplied_sig: &str) -> SignatureError {
+        let mut good_to = 0usize;
+        let mut partial_pattern = String::from("^");
+        let mut last_param_type = ParamType::Any;
+
+        for param in &self.params {
+            partial_pattern.push_str(&param.regex);
+            last_param_type = param.param_type.clone();
+            match Regex::new(&partial_pattern) {
+                Ok(re) => match re.find(supplied_sig) {
+                    Some(m) if m.start() == 0 => good_to = m.end(),
+                    _ => break,
+                },
+                Err(_) => break,
+            }
+        }
+
+        SignatureError::ArgumentTypeMismatch {
+            index: good_to + 1,
+            expected: Self::type_name(&last_param_type),
+        }
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cargo test --lib signature:: -- --nocapture 2>&1 | tail -60
+```
+
+Expected: all tests in `signature::tests` pass, including all 5 new tests from Step 1 of this task and the 3 from Task 3.
+
+- [ ] **Step 7: Run the reference-suite cases directly to confirm 035-040 now pass**
+
+This will still fail at this point — Task 5 hasn't updated the `evaluator.rs` call sites to pass `validate_and_coerce`'s new required `context` argument, so the crate won't compile end-to-end yet. Confirm with:
+
+```bash
+cargo build --lib 2>&1 | tail -30
+```
+
+Expected: compile errors in `src/evaluator.rs` at the 4 `validate_and_coerce(...)` call sites (wrong number of arguments) — this is expected and fixed in Task 5. Do not run the Python test suite yet; it needs a successful `maturin develop` build, which needs Task 5.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/signature.rs
+git commit -m "$(cat <<'EOF'
+feat: rewrite signature matching to a regex-based engine
+
+Mirrors jsonata-js's signature.js algorithm: each parameter
+contributes a regex fragment, the whole signature compiles to one
+anchored regex, and actual arguments are matched by building a
+one-char-per-arg type-symbol string and running it through that
+regex. Matched groups split back into positional args, correctly
+handling '+' (one-or-more repeat, previously unsupported at all) and
+'-' (context-fallback, previously a silent no-op despite existing
+"<n-n:n>"-style signatures in the reference suite already testing
+paths where it didn't matter).
+
+validate_and_coerce now takes a `context: &JValue` parameter needed
+for '-'. Callers are updated in the next commit.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+(This commit will not compile standalone — `evaluator.rs`'s call sites still need Task 5. That's expected for an atomic logical commit; if your workflow requires every commit to build, squash Task 4 and Task 5 into one commit instead.)
+
+---
+
+## Task 5: Thread `context` through the evaluator call sites
+
+**Files:**
+- Modify: `src/evaluator.rs` at 4 call sites: `~6053` (`$join`'s primary validate), `~6062` (`$join`'s fallback validate), `~8147` (`invoke_lambda_with_env`), `~8367` (`invoke_lambda_body_for_tco`)
+- Test: `tests/python/test_signature_repeat.py` (new file)
+
+**Interfaces:**
+- Consumes: `Signature::validate_and_coerce(&self, args: &[JValue], context: &JValue)` from Task 4.
+- Produces: nothing new for later tasks — this is the last code-change task; Task 6 is verification only.
+
+- [ ] **Step 1: Write the failing Python test**
+
+Create `tests/python/test_signature_repeat.py`:
+
+```python
+"""Tests for the jsonata-js 2.2.1 signature '+' (repeat) and '-' (context) modifiers.
+
+These exercise src/signature.rs's regex-based matching engine directly through
+JSONata expressions, covering cases the reference suite's 6 new
+function-signatures cases (035-040) don't fully exercise on their own (see
+docs/superpowers/plans/2026-07-04-jsonata-2.2.1-phase1-signatures.md).
+"""
+
+import jsonatapy
+
+
+def test_repeat_param_basic():
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, 2, 3)', None
+    )
+    assert result == {"a": 1, "b": 2}
+
+
+def test_repeat_param_with_array_subtype():
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2)<a<n>+:o>{{"a": $arg1, "b": $arg2}}([1, 2], [3, 4], [5, 6])',
+        None,
+    )
+    assert result == {"a": [1, 2], "b": [3, 4]}
+
+
+def test_context_fallback_bare_call_uses_context():
+    # Bare (non-dot-chained) lambda call: this is the only shape that
+    # actually exercises signature.rs's own '-' context-substitution path
+    # (dot-chained calls have a separate, unrelated implicit-arg mechanism).
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2, $arg3)<n+s-:a<n>>{[$arg1, $arg2, $arg3]}(1, 2)', "b"
+    )
+    assert result == [1, 2, "b"]
+
+
+def test_context_fallback_not_used_when_arg_supplied():
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2, $arg3)<n+s-:a<n>>{[$arg1, $arg2, $arg3]}(1, 2, "a")', "b"
+    )
+    assert result == [1, 2, "a"]
+
+
+def test_repeat_param_rejects_wrong_type():
+    import pytest
+
+    with pytest.raises(ValueError, match="T0410"):
+        jsonatapy.evaluate(
+            'λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, "x")', None
+        )
+```
+
+- [ ] **Step 2: Run the test to verify it fails (build error expected)**
+
+```bash
+uv run pytest tests/python/test_signature_repeat.py -v 2>&1 | tail -20
+```
+
+Expected: import error or stale-extension failures — the Rust crate doesn't compile yet (Task 4 changed `validate_and_coerce`'s signature but the call sites weren't updated). This confirms the test file is wired up; the real "fails then passes" cycle happens once the crate builds, in Step 4 below.
+
+- [ ] **Step 3: Update the 4 call sites in `src/evaluator.rs`**
+
+**Call site 1 — `$join`'s primary signature, around line 6053:**
+
+Find:
+```rust
+                let coerced_args = match signature.validate_and_coerce(&evaluated_args) {
+```
+Replace with:
+```rust
+                let coerced_args = match signature.validate_and_coerce(&evaluated_args, data) {
+```
+
+**Call site 2 — `$join`'s fallback signature, around line 6062:**
+
+Find:
+```rust
+                        match sig_first_arg.validate_and_coerce(&evaluated_args[0..1]) {
+```
+Replace with:
+```rust
+                        match sig_first_arg.validate_and_coerce(&evaluated_args[0..1], data) {
+```
+
+(`data: &JValue` is already a parameter of the enclosing `evaluate_function_call` method — no new variable needed.)
+
+**Call site 3 — `invoke_lambda_with_env`, around line 8147:**
+
+Find:
+```rust
+            let coerced_values = match crate::signature::Signature::parse(sig_str) {
+                Ok(sig) => match sig.validate_and_coerce(values) {
+```
+Replace with:
+```rust
+            let coerced_values = match crate::signature::Signature::parse(sig_str) {
+                Ok(sig) => match sig.validate_and_coerce(values, data) {
+```
+
+(`data: &JValue` is already a parameter of `invoke_lambda_with_env` — no new variable needed.)
+
+Also update this function's error-mapping match arm (right after the block from call site 3) to handle the new `ContextTypeMismatch` variant — find the existing `ArrayTypeMismatch` arm (which produces a T0412 message) in this same match and add a new arm directly after it:
+
+```rust
+                            crate::signature::SignatureError::ArrayTypeMismatch {
+                                index,
+                                expected,
+                            } => {
+                                return Err(EvaluatorError::TypeError(format!(
+                                    "T0412: Argument {} of function must be an array of {}",
+                                    index, expected
+                                )));
+                            }
+                            crate::signature::SignatureError::ContextTypeMismatch {
+                                index,
+                                expected,
+                            } => {
+                                return Err(EvaluatorError::TypeError(format!(
+                                    "T0411: Context value at argument {} does not match function signature (expected {})",
+                                    index, expected
+                                )));
+                            }
+```
+
+**Call site 4 — `invoke_lambda_body_for_tco`, around line 8367:**
+
+Find:
+```rust
+            match crate::signature::Signature::parse(sig_str) {
+                Ok(sig) => match sig.validate_and_coerce(values) {
+```
+Replace with:
+```rust
+            match crate::signature::Signature::parse(sig_str) {
+                Ok(sig) => match sig.validate_and_coerce(values, data) {
+```
+
+(`data: &JValue` is already a parameter of `invoke_lambda_body_for_tco` — no new variable needed.)
+
+Also update this function's error-mapping match arm the same way — find its existing `ArrayTypeMismatch` arm and add a `ContextTypeMismatch` arm directly after it:
+
+```rust
+                        crate::signature::SignatureError::ArrayTypeMismatch { index, expected } => {
+                            return Err(EvaluatorError::TypeError(format!(
+                                "T0412: Argument {} of function must be an array of {}",
+                                index, expected
+                            )));
+                        }
+                        crate::signature::SignatureError::ContextTypeMismatch { index, expected } => {
+                            return Err(EvaluatorError::TypeError(format!(
+                                "T0411: Context value at argument {} does not match function signature (expected {})",
+                                index, expected
+                            )));
+                        }
+```
+
+- [ ] **Step 4: Build and run the tests to verify they pass**
+
+```bash
+cargo build --lib 2>&1 | tail -30
+```
+
+Expected: clean build (no errors — if there are unused-variable or type errors, check that `data` really is in scope by name at each edited call site; it should already be a parameter per the function signatures documented in the plan's Task 5 "Interfaces" section).
+
+```bash
+maturin develop --release
+uv run pytest tests/python/test_signature_repeat.py -v
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluator.rs tests/python/test_signature_repeat.py
+git commit -m "$(cat <<'EOF'
+fix: thread evaluation context through signature validation
+
+Wires the new context parameter (needed for '-' fallback support)
+through all 4 call sites of Signature::validate_and_coerce, and maps
+the new ContextTypeMismatch error to a T0411 message matching
+jsonata-js's own error code for this case.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Full verification and phase close-out
+
+**Files:** None modified — this task only runs checks and, if anything fails, sends you back to the relevant earlier task.
+
+**Interfaces:** None.
+
+- [ ] **Step 1: Full reference suite**
+
+```bash
+uv run pytest tests/python/test_reference_suite.py -q 2>&1 | tail -20
+```
+
+Expected: `1274 passed`. If any of case035-040 still fail, re-check Task 4's algorithm against that specific case's JSON fixture in `tests/jsonata-js/test/test-suite/groups/function-signatures/`. If a *previously-passing* case now fails, check `function-signatures/case003-006` specifically (they use `<n-n:n>` and must be unaffected — see the "Non-goals" section on the implicit-context mechanism being unrelated).
+
+- [ ] **Step 2: Full Python suite**
+
+```bash
+uv run pytest tests/python/ -v 2>&1 | tail -40
+```
+
+Expected: all pass, including the new `test_signature_repeat.py`.
+
+- [ ] **Step 3: Rust unit tests**
+
+```bash
+cargo test 2>&1 | tail -40
+```
+
+Expected: all pass (137+ existing tests, plus the new ones added in Tasks 2-4).
+
+- [ ] **Step 4: Lint and format**
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+uv run ruff check tests/python/test_signature_repeat.py
+```
+
+Expected: clean. If `cargo fmt --check` fails, run `cargo fmt` and amend/add a formatting commit.
+
+- [ ] **Step 5: Confirm the `$lookup` prototype-access non-goal is genuinely a non-issue**
+
+Upstream 2.2.1 hardens `$lookup` against reading JS-prototype-chain members (`hasOwnProperty` check) — not applicable to our `IndexMap`-backed objects, but worth a quick confirmation test rather than taking it on faith:
+
+```bash
+uv run python -c "
+import jsonatapy as j
+print(j.evaluate('\$lookup({\"toString\": 1}, \"toString\")', None))
+"
+```
+
+Expected: `1` (the actual object field value, not some inherited method reference — confirming there was never a prototype-pollution vector here to begin with).
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+git push -u origin feat/jsonata-2.2.1-signatures
+gh pr create --title "jsonata-js 2.2.1 Phase 1: signature engine rewrite for +/- repeat support" --body "$(cat <<'EOF'
+## Summary
+- Bumps the `tests/jsonata-js` reference submodule to v2.2.1.
+- Rewrites `src/signature.rs`'s parameter matcher from a hand-rolled
+  positional zip to a regex-based engine mirroring `signature.js`,
+  adding real support for `+` (one-or-more repeat, previously a hard
+  parse error) and `-` (context-fallback, previously a silent no-op).
+- Reference suite: 1268/1274 -> 1274/1274.
+
+## Test plan
+- [ ] `uv run pytest tests/python/test_reference_suite.py` -> 1274 passed
+- [ ] `uv run pytest tests/python/` -> all pass
+- [ ] `cargo test` -> all pass
+- [ ] `cargo clippy -- -D warnings` -> clean
+- [ ] `cargo fmt --check` -> clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report the PR URL back once created.
+
+---
+
+## What's next
+
+Phase 2 (the guardrails feature — `timeout`/`stack`/`sequence` limit options, new errors D1011/D1012/D1015, on both the Rust and Python public APIs) gets its own separate implementation plan, written after this phase merges — see `docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md` for its design.

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3806,7 +3806,7 @@ impl Evaluator {
                             }
                         } // end else (tuple path)
                     }
-                    _ => Ok(JValue::Null),
+                    _ => Ok(JValue::Undefined),
                 };
             }
         }
@@ -5896,6 +5896,7 @@ impl Evaluator {
                 let string = match &evaluated_args[0] {
                     JValue::String(s) => s.clone(),
                     JValue::Null => return Ok(JValue::Null),
+                    JValue::Undefined => return Ok(JValue::Undefined),
                     _ => {
                         return Err(EvaluatorError::TypeError(
                             "pad() first argument must be a string".to_string(),
@@ -6723,7 +6724,7 @@ impl Evaluator {
                             }
                             arrays.push(arr.to_vec());
                         }
-                        JValue::Null => {
+                        JValue::Null | JValue::Undefined => {
                             // Null/undefined means result is empty
                             return Ok(JValue::array(vec![]));
                         }
@@ -8393,7 +8394,10 @@ impl Evaluator {
                                 index, expected
                             )));
                         }
-                        crate::signature::SignatureError::ContextTypeMismatch { index, expected } => {
+                        crate::signature::SignatureError::ContextTypeMismatch {
+                            index,
+                            expected,
+                        } => {
                             return Err(EvaluatorError::TypeError(format!(
                                 "T0411: Context value at argument {} does not match function signature (expected {})",
                                 index, expected
@@ -10195,7 +10199,7 @@ impl Evaluator {
         // Check left operand is a number or null
         let start_f64 = match left {
             JValue::Number(n) => Some(*n),
-            JValue::Null => None,
+            JValue::Null | JValue::Undefined => None,
             _ => {
                 return Err(EvaluatorError::EvaluationError(
                     "T2003: Left operand of range operator must be a number".to_string(),
@@ -10215,7 +10219,7 @@ impl Evaluator {
         // Check right operand is a number or null
         let end_f64 = match right {
             JValue::Number(n) => Some(*n),
-            JValue::Null => None,
+            JValue::Null | JValue::Undefined => None,
             _ => {
                 return Err(EvaluatorError::EvaluationError(
                     "T2004: Right operand of range operator must be a number".to_string(),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -6050,7 +6050,7 @@ impl Evaluator {
                     EvaluatorError::EvaluationError(format!("Invalid signature: {}", e))
                 })?;
 
-                let coerced_args = match signature.validate_and_coerce(&evaluated_args) {
+                let coerced_args = match signature.validate_and_coerce(&evaluated_args, data) {
                     Ok(args) => args,
                     Err(crate::signature::SignatureError::UndefinedArgument) => {
                         // This can happen if the separator is undefined
@@ -6059,7 +6059,7 @@ impl Evaluator {
                             EvaluatorError::EvaluationError(format!("Invalid signature: {}", e))
                         })?;
 
-                        match sig_first_arg.validate_and_coerce(&evaluated_args[0..1]) {
+                        match sig_first_arg.validate_and_coerce(&evaluated_args[0..1], data) {
                             Ok(args) => args,
                             Err(crate::signature::SignatureError::ArrayTypeMismatch {
                                 index,
@@ -8144,7 +8144,7 @@ impl Evaluator {
         if let Some(sig_str) = signature {
             // Validate and coerce arguments with signature
             let coerced_values = match crate::signature::Signature::parse(sig_str) {
-                Ok(sig) => match sig.validate_and_coerce(values) {
+                Ok(sig) => match sig.validate_and_coerce(values, data) {
                     Ok(coerced) => coerced,
                     Err(e) => {
                         self.context.pop_scope();
@@ -8166,6 +8166,15 @@ impl Evaluator {
                             } => {
                                 return Err(EvaluatorError::TypeError(format!(
                                     "T0412: Argument {} of function must be an array of {}",
+                                    index, expected
+                                )));
+                            }
+                            crate::signature::SignatureError::ContextTypeMismatch {
+                                index,
+                                expected,
+                            } => {
+                                return Err(EvaluatorError::TypeError(format!(
+                                    "T0411: Context value at argument {} does not match function signature (expected {})",
                                     index, expected
                                 )));
                             }
@@ -8364,7 +8373,7 @@ impl Evaluator {
         // Validate signature if present
         let coerced_values = if let Some(sig_str) = &lambda.signature {
             match crate::signature::Signature::parse(sig_str) {
-                Ok(sig) => match sig.validate_and_coerce(values) {
+                Ok(sig) => match sig.validate_and_coerce(values, data) {
                     Ok(coerced) => coerced,
                     Err(e) => match e {
                         crate::signature::SignatureError::UndefinedArgument => {
@@ -8381,6 +8390,12 @@ impl Evaluator {
                         crate::signature::SignatureError::ArrayTypeMismatch { index, expected } => {
                             return Err(EvaluatorError::TypeError(format!(
                                 "T0412: Argument {} of function must be an array of {}",
+                                index, expected
+                            )));
+                        }
+                        crate::signature::SignatureError::ContextTypeMismatch { index, expected } => {
+                            return Err(EvaluatorError::TypeError(format!(
+                                "T0411: Context value at argument {} does not match function signature (expected {})",
                                 index, expected
                             )));
                         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2202,6 +2202,10 @@ mod tests {
         // without error. This was rejected before jsonata-js 2.2.1 compatibility work
         // ("Unexpected token in signature: Plus").
         let result = parse("λ($arg1, $arg2)<n+n:o>{{\"a\": $arg1, \"b\": $arg2}}(1, 2, 3)");
-        assert!(result.is_ok(), "expected parse to succeed, got {:?}", result);
+        assert!(
+            result.is_ok(),
+            "expected parse to succeed, got {:?}",
+            result
+        );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -762,6 +762,10 @@ impl Parser {
                     signature.push('-');
                     self.advance()?;
                 }
+                Token::Plus => {
+                    signature.push('+');
+                    self.advance()?;
+                }
                 Token::Colon => {
                     signature.push(':');
                     self.advance()?;
@@ -2190,5 +2194,14 @@ mod tests {
             }
             _ => panic!("Expected Function node"),
         }
+    }
+
+    #[test]
+    fn test_signature_with_repeat_modifier_parses() {
+        // A lambda literal with a '+' (one-or-more) signature modifier must parse
+        // without error. This was rejected before jsonata-js 2.2.1 compatibility work
+        // ("Unexpected token in signature: Plus").
+        let result = parse("λ($arg1, $arg2)<n+n:o>{{\"a\": $arg1, \"b\": $arg2}}(1, 2, 3)");
+        assert!(result.is_ok(), "expected parse to succeed, got {:?}", result);
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -463,7 +463,7 @@ impl Signature {
     ) -> Result<Vec<JValue>, SignatureError> {
         self.validate_arg_count(args.len())?;
 
-        let supplied_sig: String = args.iter().map(|a| type_symbol(a)).collect();
+        let supplied_sig: String = args.iter().map(type_symbol).collect();
 
         let captures = match self.full_regex.captures(&supplied_sig) {
             Some(c) => c,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -2,6 +2,7 @@
 // Mirrors signature.js from the reference implementation
 
 use crate::value::JValue;
+use regex::Regex;
 use thiserror::Error;
 
 /// Signature validation errors
@@ -18,6 +19,9 @@ pub enum SignatureError {
 
     #[error("T0412: Argument {index} must be an array of {expected}")]
     ArrayTypeMismatch { index: usize, expected: String },
+
+    #[error("T0411: Context value does not match function signature (expected {expected})")]
+    ContextTypeMismatch { index: usize, expected: String },
 
     #[error("Undefined argument")]
     UndefinedArgument,
@@ -82,11 +86,100 @@ impl ParamType {
     }
 }
 
+/// Map a ParamType back to its single-character signature symbol.
+/// Used to rebuild a union type's regex character class from its parsed
+/// component types.
+fn type_char(t: &ParamType) -> char {
+    match t {
+        ParamType::String => 's',
+        ParamType::Number => 'n',
+        ParamType::Boolean => 'b',
+        ParamType::Null => 'l',
+        ParamType::Object => 'o',
+        ParamType::Array(_) => 'a',
+        ParamType::Function(_) => 'f',
+        ParamType::Any => 'x',
+        // Unreachable in practice: signature.js does not nest unions inside
+        // unions, and our parser never constructs one this way either.
+        ParamType::Union(_) => 'x',
+    }
+}
+
+/// Get the single-character type symbol for a value, mirroring signature.js's
+/// getSymbol(): used to build the "supplied signature" string that gets
+/// matched against a Signature's compiled regex.
+fn type_symbol(value: &JValue) -> char {
+    match value {
+        JValue::Null => 'l',
+        JValue::Bool(_) => 'b',
+        JValue::Number(_) => 'n',
+        JValue::String(_) => 's',
+        JValue::Array(_) => 'a',
+        JValue::Object(_) => 'o',
+        JValue::Undefined => 'm',
+        JValue::Lambda { .. } => 'f',
+        JValue::Builtin { .. } => 'f',
+        JValue::Regex { .. } => 'o',
+    }
+}
+
 /// Function parameter definition
 #[derive(Debug, Clone)]
 pub struct Parameter {
     pub param_type: ParamType,
     pub optional: bool,
+    /// Regex fragment for this parameter, e.g. "[nm]", "[nm]+", "[sm]?".
+    /// Combined across all params to build a Signature's full_regex.
+    regex: String,
+    /// True if this parameter was declared with the '+' (one-or-more) modifier.
+    repeatable: bool,
+    /// True if this parameter was declared with the '-' modifier: when the
+    /// caller omits this argument, substitute the evaluation context value
+    /// instead (if its type is compatible).
+    context: bool,
+    /// Regex fragment (without the '-'-induced trailing '?') used to test
+    /// whether the context value's type is compatible, when `context` is true.
+    context_regex: Option<String>,
+}
+
+impl Parameter {
+    /// Construct a Parameter directly (not via signature-string parsing).
+    /// Used by tests and by Signature::new. Produces a non-repeatable,
+    /// non-context parameter with the standard base regex for its type.
+    #[allow(dead_code)]
+    pub fn new(param_type: ParamType, optional: bool) -> Self {
+        let mut regex = Self::base_regex(&param_type);
+        if optional {
+            regex.push('?');
+        }
+        Parameter {
+            param_type,
+            optional,
+            regex,
+            repeatable: false,
+            context: false,
+            context_regex: None,
+        }
+    }
+
+    /// The base (unquantified) regex character class for a parameter type,
+    /// mirroring signature.js's per-symbol regex assignment.
+    fn base_regex(param_type: &ParamType) -> String {
+        match param_type {
+            ParamType::Array(_) => "[asnblfom]".to_string(),
+            ParamType::Function(_) => "f".to_string(),
+            ParamType::Any => "[asnblfom]".to_string(),
+            ParamType::String => "[sm]".to_string(),
+            ParamType::Number => "[nm]".to_string(),
+            ParamType::Boolean => "[bm]".to_string(),
+            ParamType::Null => "[lm]".to_string(),
+            ParamType::Object => "[om]".to_string(),
+            ParamType::Union(types) => {
+                let chars: String = types.iter().map(type_char).collect();
+                format!("[{}m]", chars)
+            }
+        }
+    }
 }
 
 /// Function signature
@@ -95,16 +188,31 @@ pub struct Signature {
     pub params: Vec<Parameter>,
     #[allow(dead_code)]
     pub return_type: Option<ParamType>,
+    /// The compiled regex matching this signature's full parameter list
+    /// against a "supplied signature" type-symbol string, e.g. "^([nm]+)([nm])$".
+    full_regex: Regex,
 }
 
 impl Signature {
     /// Create a new signature
     #[allow(dead_code)]
     pub fn new(params: Vec<Parameter>, return_type: Option<ParamType>) -> Self {
+        let full_regex = Self::compile_full_regex(&params);
         Signature {
             params,
             return_type,
+            full_regex,
         }
+    }
+
+    /// Build the anchored whole-signature regex from each parameter's fragment.
+    fn compile_full_regex(params: &[Parameter]) -> Regex {
+        let pattern: String = std::iter::once("^".to_string())
+            .chain(params.iter().map(|p| format!("({})", p.regex)))
+            .chain(std::iter::once("$".to_string()))
+            .collect();
+        Regex::new(&pattern)
+            .unwrap_or_else(|e| panic!("generated signature regex `{}` is invalid: {}", pattern, e))
     }
 
     /// Parse a signature string like "<n-n:n>" or "<s?:b>"
@@ -143,9 +251,12 @@ impl Signature {
             Self::parse_params(param_str)?
         };
 
+        let full_regex = Self::compile_full_regex(&params);
+
         Ok(Signature {
             params,
             return_type,
+            full_regex,
         })
     }
 
@@ -164,31 +275,47 @@ impl Signature {
         None
     }
 
-    /// Parse parameter types from string like "n-n" or "a<s>s?"
+    /// Parse parameter types from string like "n-n" or "a<s>s?" or "n+n"
     fn parse_params(param_str: &str) -> Result<Vec<Parameter>, SignatureError> {
         let mut params = Vec::new();
         let mut chars = param_str.chars().peekable();
 
         while chars.peek().is_some() {
-            // Check for separator
-            if chars.peek() == Some(&'-') {
-                chars.next();
-                continue;
-            }
-
             let param_type = Self::parse_type_chars(&mut chars)?;
+            let mut regex = Parameter::base_regex(&param_type);
+            let mut optional = false;
+            let mut repeatable = false;
+            let mut context = false;
+            let mut context_regex = None;
 
-            // Check for optional marker
-            let optional = if chars.peek() == Some(&'?') {
-                chars.next();
-                true
-            } else {
-                false
-            };
+            match chars.peek() {
+                Some('?') => {
+                    chars.next();
+                    regex.push('?');
+                    optional = true;
+                }
+                Some('+') => {
+                    chars.next();
+                    regex.push('+');
+                    repeatable = true;
+                }
+                Some('-') => {
+                    chars.next();
+                    context = true;
+                    context_regex = Some(regex.clone());
+                    regex.push('?');
+                    optional = true;
+                }
+                _ => {}
+            }
 
             params.push(Parameter {
                 param_type,
                 optional,
+                regex,
+                repeatable,
+                context,
+                context_regex,
             });
         }
 
@@ -304,9 +431,10 @@ impl Signature {
     /// Validate argument count
     pub fn validate_arg_count(&self, actual: usize) -> Result<(), SignatureError> {
         let required = self.params.iter().filter(|p| !p.optional).count();
+        let unbounded = self.params.iter().any(|p| p.repeatable);
         let max = self.params.len();
 
-        if actual < required || actual > max {
+        if actual < required || (!unbounded && actual > max) {
             return Err(SignatureError::ArgumentCountMismatch {
                 expected: required,
                 actual,
@@ -316,70 +444,144 @@ impl Signature {
         Ok(())
     }
 
-    /// Validate and coerce arguments according to signature rules
+    /// Validate and coerce arguments according to signature rules.
     ///
-    /// Like the JavaScript implementation, this:
-    /// - Wraps non-array values in arrays when expecting array type
-    /// - Checks array element types when specified
-    /// - Returns the validated (and possibly coerced) arguments
-    pub fn validate_and_coerce(&self, args: &[JValue]) -> Result<Vec<JValue>, SignatureError> {
-        // Check argument count first
+    /// `context` is the JSONata evaluation context (`$`) at the point of the
+    /// call, used for the '-' modifier's fallback-to-context behavior.
+    /// Pass `&JValue::Undefined` if there is no meaningful context (e.g. a
+    /// signature with no '-'-marked parameters never inspects it).
+    ///
+    /// Mirrors signature.js's regex-based validate(): build a one-char-per-
+    /// argument type-symbol string, match it against this signature's
+    /// compiled regex, then walk each parameter's captured group back to
+    /// positional arguments (a captured group may span multiple characters
+    /// when the parameter is repeatable with '+').
+    pub fn validate_and_coerce(
+        &self,
+        args: &[JValue],
+        context: &JValue,
+    ) -> Result<Vec<JValue>, SignatureError> {
         self.validate_arg_count(args.len())?;
 
+        let supplied_sig: String = args.iter().map(|a| type_symbol(a)).collect();
+
+        let captures = match self.full_regex.captures(&supplied_sig) {
+            Some(c) => c,
+            None => return Err(self.arg_type_mismatch_error(&supplied_sig)),
+        };
+
         let mut coerced_args = Vec::with_capacity(args.len());
+        let mut arg_index = 0usize;
 
-        // Check and coerce each argument type
-        for (i, (param, arg)) in self.params.iter().zip(args.iter()).enumerate() {
-            // Special case: if argument is null or undefined, return UndefinedArgument
-            // This allows the caller to decide whether to return undefined or error
-            if (arg.is_null() || arg.is_undefined())
-                && !matches!(param.param_type, ParamType::Null | ParamType::Any)
-            {
-                return Err(SignatureError::UndefinedArgument);
-            }
+        for (i, param) in self.params.iter().enumerate() {
+            let matched = captures.get(i + 1).map(|m| m.as_str()).unwrap_or("");
 
-            // Handle array coercion: any value can be coerced to an array
-            if let ParamType::Array(elem_type) = &param.param_type {
-                let arr = if let JValue::Array(arr) = arg {
-                    // Already an array - check element types if specified
-                    if let Some(expected_elem) = elem_type {
-                        if !arr.is_empty() && !arr.iter().all(|v| expected_elem.matches(v)) {
-                            return Err(SignatureError::ArrayTypeMismatch {
-                                index: i + 1,
-                                expected: Self::type_name(expected_elem),
-                            });
-                        }
+            if matched.is_empty() {
+                let arg = args.get(arg_index).cloned().unwrap_or(JValue::Undefined);
+
+                if param.context {
+                    let context_symbol = type_symbol(context).to_string();
+                    let context_regex_str = param.context_regex.as_deref().unwrap_or("");
+                    let context_re = Regex::new(&format!("^{}$", context_regex_str))
+                        .map_err(|e| SignatureError::InvalidSignature(e.to_string()))?;
+                    if context_re.is_match(&context_symbol) {
+                        coerced_args.push(context.clone());
+                    } else {
+                        return Err(SignatureError::ContextTypeMismatch {
+                            index: arg_index + 1,
+                            expected: Self::type_name(&param.param_type),
+                        });
                     }
-                    arg.clone()
                 } else {
-                    // Non-array value - coerce by wrapping in array
-                    // But first check if the element type matches
-                    if let Some(expected_elem) = elem_type {
-                        if !expected_elem.matches(arg) {
-                            return Err(SignatureError::ArrayTypeMismatch {
-                                index: i + 1,
-                                expected: Self::type_name(expected_elem),
-                            });
-                        }
+                    // This position was genuinely supplied (not out-of-bounds
+                    // padding) only if arg_index is within the original args.
+                    let was_supplied = arg_index < args.len();
+                    if was_supplied
+                        && (arg.is_null() || arg.is_undefined())
+                        && !matches!(param.param_type, ParamType::Null | ParamType::Any)
+                    {
+                        return Err(SignatureError::UndefinedArgument);
                     }
-                    // Wrap the value in an array
-                    JValue::array(vec![arg.clone()])
-                };
-                coerced_args.push(arr);
+                    coerced_args.push(arg);
+                    arg_index += 1;
+                }
                 continue;
             }
 
-            // Standard type checking for non-array types
-            if !param.param_type.matches(arg) {
-                return Err(SignatureError::ArgumentTypeMismatch {
-                    index: i + 1,
-                    expected: Self::type_name(&param.param_type),
-                });
+            for single in matched.chars() {
+                let was_supplied = arg_index < args.len();
+                let arg = args.get(arg_index).cloned().unwrap_or(JValue::Undefined);
+
+                if was_supplied
+                    && (arg.is_null() || arg.is_undefined())
+                    && !matches!(param.param_type, ParamType::Null | ParamType::Any)
+                {
+                    return Err(SignatureError::UndefinedArgument);
+                }
+
+                let resolved = if let ParamType::Array(elem_type) = &param.param_type {
+                    if single == 'm' {
+                        JValue::Undefined
+                    } else if let JValue::Array(arr) = &arg {
+                        if let Some(expected_elem) = elem_type {
+                            if !arr.is_empty() && !arr.iter().all(|v| expected_elem.matches(v)) {
+                                return Err(SignatureError::ArrayTypeMismatch {
+                                    index: arg_index + 1,
+                                    expected: Self::type_name(expected_elem),
+                                });
+                            }
+                        }
+                        arg.clone()
+                    } else {
+                        if let Some(expected_elem) = elem_type {
+                            if !expected_elem.matches(&arg) {
+                                return Err(SignatureError::ArrayTypeMismatch {
+                                    index: arg_index + 1,
+                                    expected: Self::type_name(expected_elem),
+                                });
+                            }
+                        }
+                        JValue::array(vec![arg.clone()])
+                    }
+                } else {
+                    arg.clone()
+                };
+
+                coerced_args.push(resolved);
+                arg_index += 1;
             }
-            coerced_args.push(arg.clone());
         }
 
         Ok(coerced_args)
+    }
+
+    /// Build an ArgumentTypeMismatch error identifying roughly which argument
+    /// broke validation, by matching a growing prefix of the joint pattern
+    /// (mirrors signature.js's throwValidationError). Exact index parity with
+    /// signature.js's backtracking behavior is not guaranteed in all cases —
+    /// this is a best-effort diagnostic, not something any test asserts on
+    /// precisely (the reference suite only checks error *codes*, not indices).
+    fn arg_type_mismatch_error(&self, supplied_sig: &str) -> SignatureError {
+        let mut good_to = 0usize;
+        let mut partial_pattern = String::from("^");
+        let mut last_param_type = ParamType::Any;
+
+        for param in &self.params {
+            partial_pattern.push_str(&param.regex);
+            last_param_type = param.param_type.clone();
+            match Regex::new(&partial_pattern) {
+                Ok(re) => match re.find(supplied_sig) {
+                    Some(m) if m.start() == 0 => good_to = m.end(),
+                    _ => break,
+                },
+                Err(_) => break,
+            }
+        }
+
+        SignatureError::ArgumentTypeMismatch {
+            index: good_to + 1,
+            expected: Self::type_name(&last_param_type),
+        }
     }
 
     /// Get a human-readable name for a parameter type
@@ -411,14 +613,8 @@ mod tests {
     fn test_signature_validation() {
         let sig = Signature::new(
             vec![
-                Parameter {
-                    param_type: ParamType::String,
-                    optional: false,
-                },
-                Parameter {
-                    param_type: ParamType::Number,
-                    optional: true,
-                },
+                Parameter::new(ParamType::String, false),
+                Parameter::new(ParamType::Number, true),
             ],
             Some(ParamType::String),
         );
@@ -434,5 +630,139 @@ mod tests {
 
         // Invalid: too many args
         assert!(sig.validate_arg_count(3).is_err());
+    }
+
+    #[test]
+    fn test_parse_signature_with_repeat_modifier() {
+        // "<n+n:o>" must parse into exactly 2 params: a repeatable number,
+        // then a required number.
+        let sig = Signature::parse("<n+n:o>").expect("valid signature");
+        assert_eq!(sig.params.len(), 2);
+        assert_eq!(sig.params[0].param_type, ParamType::Number);
+        assert!(!sig.params[0].optional);
+        assert_eq!(sig.params[1].param_type, ParamType::Number);
+        assert!(!sig.params[1].optional);
+    }
+
+    #[test]
+    fn test_repeat_param_allows_more_args_than_declared_slots() {
+        // "<n+n>" (2 type-slots, one repeatable) must accept 3 args, whereas
+        // "<nn>" (2 required, non-repeatable slots) must reject 3 args.
+        let repeating = Signature::parse("<n+n:o>").expect("valid signature");
+        assert!(repeating.validate_arg_count(3).is_ok());
+
+        let non_repeating = Signature::parse("<nn:o>").expect("valid signature");
+        assert!(non_repeating.validate_arg_count(3).is_err());
+    }
+
+    #[test]
+    fn test_repeat_param_coerces_all_matched_args() {
+        // <n+n:o> called with (1, 2, 3): the repeat consumes 2 numbers, the
+        // final required slot consumes the 3rd. All 3 must appear in order.
+        let sig = Signature::parse("<n+n:o>").expect("valid signature");
+        let args = vec![
+            JValue::Number(1.0),
+            JValue::Number(2.0),
+            JValue::Number(3.0),
+        ];
+        let coerced = sig
+            .validate_and_coerce(&args, &JValue::Undefined)
+            .expect("should validate");
+        assert_eq!(coerced, args);
+    }
+
+    #[test]
+    fn test_repeat_param_rejects_wrong_type_within_repeat() {
+        // <n+> with (1, 2, "x"): the 3rd arg breaks the all-numbers repeat,
+        // and there's nothing else in the signature to absorb a string, so
+        // the whole match fails -> T0410-class error (ArgumentTypeMismatch).
+        let sig = Signature::parse("<n+:o>").expect("valid signature");
+        let args = vec![
+            JValue::Number(1.0),
+            JValue::Number(2.0),
+            JValue::string("x"),
+        ];
+        let result = sig.validate_and_coerce(&args, &JValue::Undefined);
+        assert!(
+            matches!(result, Err(SignatureError::ArgumentTypeMismatch { .. })),
+            "expected ArgumentTypeMismatch, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_context_substitution_success() {
+        // <n+s-:a<n>> called with (1, 2) and a string context: the omitted
+        // 3rd (context-fallback) argument should be filled from the context.
+        let sig = Signature::parse("<n+s-:a<n>>").expect("valid signature");
+        let args = vec![JValue::Number(1.0), JValue::Number(2.0)];
+        let context = JValue::string("b");
+        let coerced = sig
+            .validate_and_coerce(&args, &context)
+            .expect("should validate using context fallback");
+        assert_eq!(
+            coerced,
+            vec![
+                JValue::Number(1.0),
+                JValue::Number(2.0),
+                JValue::string("b")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_context_substitution_type_mismatch() {
+        // <s-:s> called with 0 args and a NUMBER context: the context type
+        // doesn't match the expected string type -> distinct T0411-class error.
+        let sig = Signature::parse("<s-:s>").expect("valid signature");
+        let args: Vec<JValue> = vec![];
+        let context = JValue::Number(42.0);
+        let result = sig.validate_and_coerce(&args, &context);
+        assert!(
+            matches!(result, Err(SignatureError::ContextTypeMismatch { .. })),
+            "expected ContextTypeMismatch, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_array_subtype_mismatch_within_repeat() {
+        // <a<n>+:o> called with an array containing a non-number element:
+        // the repeat's array-subtype check must still fire (T0412-class).
+        let sig = Signature::parse("<a<n>+:o>").expect("valid signature");
+        let bad_array = JValue::array(vec![JValue::string("x")]);
+        let args = vec![bad_array];
+        let result = sig.validate_and_coerce(&args, &JValue::Undefined);
+        assert!(
+            matches!(result, Err(SignatureError::ArrayTypeMismatch { .. })),
+            "expected ArrayTypeMismatch, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_repeat_with_leading_optional_does_not_spuriously_error() {
+        // <s?n+:a<n>> called with (1, 2, 3): the optional leading string slot
+        // matches zero characters (none of the 3 args is a string) and gets
+        // "phantom-assigned" args[0] per signature.js's own algorithm, while
+        // the repeat consumes args[1] and args[2] AND reads one position past
+        // the end of `args` (args[3], which doesn't exist). That out-of-bounds
+        // read must resolve to JValue::Undefined WITHOUT tripping the
+        // "explicit null/undefined for a non-nullable required type" error,
+        // since it was never actually supplied by the caller.
+        let sig = Signature::parse("<s?n+:a<n>>").expect("valid signature");
+        let args = vec![
+            JValue::Number(1.0),
+            JValue::Number(2.0),
+            JValue::Number(3.0),
+        ];
+        let coerced = sig
+            .validate_and_coerce(&args, &JValue::Undefined)
+            .expect("must not error on out-of-bounds repeat padding");
+        // Only the first 2 entries matter to callers (lambda binding only
+        // uses as many entries as there are declared params), but the full
+        // vector must not be an error.
+        assert_eq!(coerced[0], JValue::Number(1.0));
+        assert_eq!(coerced[1], JValue::Number(2.0));
     }
 }

--- a/tests/python/test_signature_repeat.py
+++ b/tests/python/test_signature_repeat.py
@@ -1,0 +1,50 @@
+"""Tests for the jsonata-js 2.2.1 signature '+' (repeat) and '-' (context) modifiers.
+
+These exercise src/signature.rs's regex-based matching engine directly through
+JSONata expressions, covering cases the reference suite's 6 new
+function-signatures cases (035-040) don't fully exercise on their own (see
+docs/superpowers/plans/2026-07-04-jsonata-2.2.1-phase1-signatures.md).
+"""
+
+import jsonatapy
+
+
+def test_repeat_param_basic():
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, 2, 3)', None
+    )
+    assert result == {"a": 1, "b": 2}
+
+
+def test_repeat_param_with_array_subtype():
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2)<a<n>+:o>{{"a": $arg1, "b": $arg2}}([1, 2], [3, 4], [5, 6])',
+        None,
+    )
+    assert result == {"a": [1, 2], "b": [3, 4]}
+
+
+def test_context_fallback_bare_call_uses_context():
+    # Bare (non-dot-chained) lambda call: this is the only shape that
+    # actually exercises signature.rs's own '-' context-substitution path
+    # (dot-chained calls have a separate, unrelated implicit-arg mechanism).
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2, $arg3)<n+s-:a<n>>{[$arg1, $arg2, $arg3]}(1, 2)', "b"
+    )
+    assert result == [1, 2, "b"]
+
+
+def test_context_fallback_not_used_when_arg_supplied():
+    result = jsonatapy.evaluate(
+        'λ($arg1, $arg2, $arg3)<n+s-:a<n>>{[$arg1, $arg2, $arg3]}(1, 2, "a")', "b"
+    )
+    assert result == [1, 2, "a"]
+
+
+def test_repeat_param_rejects_wrong_type():
+    import pytest
+
+    with pytest.raises(ValueError, match="T0410"):
+        jsonatapy.evaluate(
+            'λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, "x")', None
+        )

--- a/tests/python/test_signature_repeat.py
+++ b/tests/python/test_signature_repeat.py
@@ -10,9 +10,7 @@ import jsonatapy
 
 
 def test_repeat_param_basic():
-    result = jsonatapy.evaluate(
-        'λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, 2, 3)', None
-    )
+    result = jsonatapy.evaluate('λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, 2, 3)', None)
     assert result == {"a": 1, "b": 2}
 
 
@@ -29,7 +27,7 @@ def test_context_fallback_bare_call_uses_context():
     # actually exercises signature.rs's own '-' context-substitution path
     # (dot-chained calls have a separate, unrelated implicit-arg mechanism).
     result = jsonatapy.evaluate(
-        'λ($arg1, $arg2, $arg3)<n+s-:a<n>>{[$arg1, $arg2, $arg3]}(1, 2)', "b"
+        "λ($arg1, $arg2, $arg3)<n+s-:a<n>>{[$arg1, $arg2, $arg3]}(1, 2)", "b"
     )
     assert result == [1, 2, "b"]
 
@@ -45,6 +43,4 @@ def test_repeat_param_rejects_wrong_type():
     import pytest
 
     with pytest.raises(ValueError, match="T0410"):
-        jsonatapy.evaluate(
-            'λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, "x")', None
-        )
+        jsonatapy.evaluate('λ($arg1, $arg2)<n+n:o>{{"a": $arg1, "b": $arg2}}(1, "x")', None)


### PR DESCRIPTION
## Summary
- Bumps the `tests/jsonata-js` reference submodule from v2.1.0 to v2.2.1.
- Rewrites `src/signature.rs`'s function-signature matcher from a hand-rolled positional zip to a regex-based engine mirroring jsonata-js's own `signature.js` algorithm, adding real support for `+` (one-or-more repeat, previously a hard parse error) and correctly implementing `-` (context-fallback, previously a silent no-op despite looking functional).
- Threads a new `context: &JValue` parameter through `Signature::validate_and_coerce`'s 4 call sites, adds `SignatureError::ContextTypeMismatch` → T0411.
- Fixes a pre-existing bug this work surfaced (not part of the upstream 2.2.1 diff): a field-access fast path and 3 builtins (`range()`, `$zip`, `$pad`) treated `Null` and `Undefined` inconsistently, only observable now that the new signature engine actually distinguishes them.
- Reference suite: 1268/1274 → **1274/1274**.

See `docs/superpowers/plans/2026-07-04-jsonata-2.2.1-phase1-signatures.md` (committed on this branch) for the full design rationale, and `docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md` on `main` for the two-phase project design (Phase 2, the guardrails feature, is separate follow-up work).

## Follow-ups identified during review (non-blocking, not part of this PR)
- Residual `JValue::Null` vs `Undefined` inconsistency at other sites in `evaluator.rs` beyond the 3 fixed here (understood, documented risk — not exercised by the current test suite).
- `type_symbol(JValue::Regex)` maps to `'o'` where `signature.js` treats a regex as function-like (`'f'`) — latent, untested divergence.
- Per-call regex (re)compilation cost in the new signature engine — a benchmark, not a known problem, would tell us if this is worth optimizing.

## Test plan
- [x] `uv run pytest tests/python/test_reference_suite.py` → 1274 passed
- [x] `uv run pytest tests/python/` → 1361 passed, 4 skipped
- [x] `cargo test` → 146 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean
- [x] `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)