### PR TITLE
fix: resolve benchmark results path in PR-comment step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -227,7 +227,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const resultsFile = '${{ steps.run_benchmark.outputs.results_file }}';
+            const path = require('path');
+            // steps.run_benchmark.outputs.results_file is relative to the
+            // benchmarks/ directory (that step runs after `cd benchmarks`).
+            // This step does not cd, so resolve it from the workspace root.
+            const resultsFile = path.join('benchmarks', '${{ steps.run_benchmark.outputs.results_file }}');
             const results = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
 
             // Calculate summary statistics


### PR DESCRIPTION
## Summary
- The `benchmark.yml` workflow's "Run Benchmarks" job has failed on every `pull_request`-triggered run for months (confirmed across unrelated dependabot PRs going back to April) — it only ever "worked" on `push` to `main`, which skips the affected step entirely.
- Root cause: the `run_benchmark` step sets its `results_file` output while the shell is `cd`'d into `benchmarks/`, so the value is relative to that directory (e.g. `results/benchmark_results_*.json`). The "Compare with baseline" step also `cd`s into `benchmarks` first, so it already resolves this correctly. The "Comment on PR" step does not `cd`, so it read the same output value directly from the workspace root and failed with `ENOENT`.
- Fix: resolve the path relative to `benchmarks/` in the one step that doesn't already `cd` there, rather than changing the output's meaning (which the already-working "Compare with baseline" step depends on).

Found while investigating an unrelated PR (#36) that surfaced this as a "Benchmarks action failed" report — confirmed via `gh run list --workflow=benchmark.yml --event=pull_request` that this branch's changes aren't the cause; this workflow file was untouched by that branch.

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- [x] Embedded JS syntax-checked with `node --check` (template expression substituted with a representative value)
- [ ] Confirm the "Run Benchmarks" job passes on this PR itself (this is exactly the workflow being fixed, so this PR is its own test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)