### PR TITLE
Implement % (parent-reference) and @/# (focus/index binding) operators

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ See [official JSONata docs](https://docs.jsonata.org/) for the full language ref
 
 ## Performance
 
-`jsonata-core` passes **1613/1682** JSONata reference tests (69 xfailed pending known
-gaps in the `%` parent operator and `@` tuple-stream binding) and is the fastest JSONata
-implementation available in either Rust or Python.
+`jsonata-core` passes **1678/1682** JSONata reference tests (4 xfailed pending known
+Phase 5 stragglers in `array-constructor`, `function-distinct`, and `flattening`) and
+is the fastest JSONata implementation available in either Rust or Python.
 
 ### Pure Rust (Criterion benchmarks, no Python overhead)
 
@@ -161,8 +161,8 @@ See [Performance docs](docs/performance.md) for full benchmark results and metho
 
 ## Features
 
-- **1613/1682 JSONata reference tests passing** — 69 xfailed pending the `%` parent
-  operator and `@` tuple-stream binding
+- **1678/1682 JSONata reference tests passing** — 4 xfailed pending Phase 5 stragglers
+  (`array-constructor`, `function-distinct`, `flattening`)
 - **Pure Rust core** — no JavaScript runtime, no Node.js dependency
 - **Optional Python bindings** — PyO3/maturin, zero-copy where possible
 - **Cross-platform** — Linux, macOS (Intel & ARM), Windows; Python 3.10–3.13

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,8 @@ let result = Evaluator::new().evaluate(&ast, &data)?;
 
 ## Performance highlights
 
-- **1613/1682** JSONata reference tests passing (69 xfailed pending the `%` parent
-  operator and `@` tuple-stream binding)
+- **1678/1682** JSONata reference tests passing (4 xfailed pending Phase 5 stragglers
+  in `array-constructor`, `function-distinct`, and `flattening`)
 - **up to 18x faster** than the JavaScript reference implementation for pure expression workloads
 - **~40x faster** than jsonata-rs (the next pure-Rust JSONata implementation)
 - **~10–65x faster** than jsonata-python across all categories

--- a/docs/superpowers/plans/2026-07-06-parent-and-focus-binding-operators.md
+++ b/docs/superpowers/plans/2026-07-06-parent-and-focus-binding-operators.md
@@ -1,0 +1,1541 @@
+# `%` Parent-Reference and `@` Focus-Binding Operators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement JSONata's `%` (parent-reference) and `@$var` (focus-binding) operators in the Rust parser/evaluator, fixing the existing `#$var` (index-binding) tuple-propagation gap as part of the same unified mechanism, so all 65 currently-xfailed cases in the `parent-operator` and `joins` reference-suite groups pass.
+
+**Architecture:** Port jsonata-js's two-pass design: (1) parser produces trivial/unresolved nodes for `%`/`@` (mirroring its one-line prefix/infix rules), (2) a new post-parse `ast_transform` pass (mirroring `processAST`/`seekParent`/`resolveAncestry`) walks the tree once, converting `#`'s existing wrapping node and the new `%`/`@` markers into step-level flags (`focus`/`index_var`/`ancestor_label`/`is_tuple`) on `PathStep`. At runtime, any step with `is_tuple` set dispatches to a new, self-contained tuple-aware step evaluator (mirroring jsonata-js's `evaluateTupleStep`, separate from the existing plain step evaluator) that reuses the existing general-purpose `evaluate_path_step` for the actual per-row work and binds tuple keys into a real scope frame before evaluating (fixing the existing `#` propagation gap).
+
+**Tech Stack:** Rust (parser.rs/ast.rs/evaluator.rs), `thiserror` for error variants, existing `IndexMap`-backed `JValue::Object` tuple-wrapper convention.
+
+## Global Constraints
+
+- Full completion bar: all 28 `parent-operator` + 37 `joins` xfail entries must pass for real (not via the test harness's lenient "any error accepted" fallback) — see Task 8's error-code work.
+- `#$var`'s existing passing tests must continue to pass unchanged after the `IndexBind`→step-flag migration.
+- No VM/bytecode-compiler support needed — `%`/`@`/`#` fall back to the tree-walker only, matching existing project convention (named-variable lookups already force tree-walker fallback).
+- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` must stay clean after every task.
+- Design source of truth: `docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md`. Reference implementation: `tests/jsonata-js/src/parser.js` (~L616-847 prefix/infix rules, ~L937-1235 `processAST`/`seekParent`/`pushAncestry`/`resolveAncestry`) and `tests/jsonata-js/src/jsonata.js` (~L83-85 `case 'parent'`, ~L229-380 `createFrameFromTuple`/`evaluateTupleStep`).
+- Branch: `feature/parent-and-focus-binding-operators` (already created, pushed, spec committed).
+
+---
+
+### Task 1: Lexer/parser additions for `%` and `@`
+
+**Files:**
+- Modify: `src/ast.rs` (add `BinaryOp::FocusBind`)
+- Modify: `src/parser.rs:97` (add `Token::At` to the `Token` enum, after `Hash`)
+- Modify: `src/parser.rs:614` (lexer char-dispatch: add `@` arm, after the existing `Some('#') => ...` arm at line ~608-611)
+- Modify: `src/parser.rs:972-981` (`parse_primary`'s `Token::Star`/`Token::StarStar` arms: add a `Token::Percent` arm producing `AstNode::Parent`)
+- Modify: `src/parser.rs` infix dispatch loop (same `match` that handles `Token::Hash` at line 1471-1491): add a `Token::At` arm
+- Test: `src/parser.rs` `#[cfg(test)] mod tests` (existing module at the bottom of the file)
+
+**Interfaces:**
+- Produces: `AstNode::Parent` (new unit-like variant, no payload yet — payload is added in Task 2), `BinaryOp::FocusBind` (new variant), both consumed by Task 3's `ast_transform` pass.
+- Consumes: existing `Token`, `AstNode::Binary`, `ParserError` types (all already defined).
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Add to the `#[cfg(test)] mod tests` block at the bottom of `src/parser.rs`:
+
+```rust
+#[test]
+fn test_parent_operator_parses_as_prefix() {
+    let ast = parse("%.OrderID").unwrap();
+    // %.OrderID should parse as a path with two steps: Parent, then Name("OrderID")
+    match ast {
+        AstNode::Path { steps } => {
+            assert_eq!(steps.len(), 2);
+            assert!(matches!(steps[0].node, AstNode::Parent));
+            assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "OrderID"));
+        }
+        other => panic!("expected Path, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_percent_still_parses_as_modulo_infix() {
+    // Regression: % must still work as binary modulo when NOT in prefix position
+    let ast = parse("10 % 3").unwrap();
+    assert!(matches!(
+        ast,
+        AstNode::Binary {
+            op: BinaryOp::Modulo,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_focus_bind_parses_as_binary_marker() {
+    let ast = parse("Order@$o").unwrap();
+    match ast {
+        AstNode::Binary {
+            op: BinaryOp::FocusBind,
+            lhs,
+            rhs,
+        } => {
+            assert!(matches!(*lhs, AstNode::Name(ref n) if n == "Order"));
+            assert!(matches!(*rhs, AstNode::Variable(ref n) if n == "o"));
+        }
+        other => panic!("expected Binary{{FocusBind}}, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_focus_bind_requires_variable_rhs() {
+    // S0214: @'s RHS must be a bare variable reference
+    let err = parse("Order@foo").unwrap_err();
+    assert!(err.to_string().starts_with("S0214"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib test_parent_operator_parses_as_prefix test_percent_still_parses_as_modulo_infix test_focus_bind_parses_as_binary_marker test_focus_bind_requires_variable_rhs`
+Expected: compile error (`AstNode::Parent`/`BinaryOp::FocusBind` don't exist, `Token::At` doesn't exist) — this is the expected "fails to compile" state for a new-variant TDD step; proceed to Step 3.
+
+- [ ] **Step 3: Add `AstNode::Parent` and `BinaryOp::FocusBind`**
+
+In `src/ast.rs`, add to the `AstNode` enum (right after the `Descendant` variant, ~line 138):
+
+```rust
+    /// Parent-reference operator (%) in path expressions
+    /// Resolved to a specific ancestor slot by the post-parse ast_transform pass;
+    /// unit variant at parse time, matching jsonata-js's bare `{type: 'parent'}`.
+    Parent,
+```
+
+Add to the `BinaryOp` enum (right after `ColonEqual`, ~line 220):
+
+```rust
+    // Focus binding (raw parse-time marker for @$var; resolved into a
+    // PathStep.focus flag by ast_transform, matching jsonata-js's own
+    // parser.js:834-847, which also produces a generic binary node here)
+    FocusBind,
+```
+
+- [ ] **Step 4: Add `Token::At` and lex `@`**
+
+In `src/parser.rs`, add to the `Token` enum right after `Hash` (line 97):
+
+```rust
+    At, // @ focus binding operator
+```
+
+In the lexer's char-dispatch `match`, add right after the existing `Some('#') => { self.advance(); return Ok(Token::Hash); }` arm (~line 608-611):
+
+```rust
+                Some('@') => {
+                    self.advance();
+                    return Ok(Token::At);
+                }
+```
+
+- [ ] **Step 5: Add the `%` prefix rule in `parse_primary`**
+
+In `src/parser.rs`, add right after the `Token::StarStar` arm (line 977-981):
+
+```rust
+            Token::Percent => {
+                // Parent operator in primary position. Bare at parse time --
+                // ast_transform assigns the actual ancestor slot (label/level).
+                self.advance()?;
+                Ok(AstNode::Parent)
+            }
+```
+
+- [ ] **Step 6: Add the `@` infix rule**
+
+In `src/parser.rs`, add right after the existing `Token::Hash => { ... }` arm (line 1471-1491) in the infix dispatch loop, inside the same `match &self.current_token { ... }`:
+
+```rust
+                Token::At => {
+                    // Focus binding operator: @$var
+                    // Produces a generic Binary(FocusBind) marker -- ast_transform
+                    // resolves this into a PathStep.focus flag, matching
+                    // jsonata-js's parser.js:834-847 (which does the same S0214
+                    // check inline, deferring all other semantics to processAST).
+                    self.advance()?; // skip '@'
+
+                    let var_name = match &self.current_token {
+                        Token::Variable(name) => name.clone(),
+                        _ => {
+                            return Err(ParserError::Coded {
+                                code: "S0214",
+                                message: "Expected a variable reference after @".to_string(),
+                            });
+                        }
+                    };
+                    self.advance()?; // skip variable
+
+                    lhs = AstNode::Binary {
+                        op: BinaryOp::FocusBind,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(AstNode::Variable(var_name)),
+                    };
+                }
+```
+
+- [ ] **Step 7: Add `ParserError::Coded` variant**
+
+In `src/parser.rs`, add to the `ParserError` enum (after `Expected`, line 36-37):
+
+```rust
+    /// A JSONata-spec-coded parse error (S0214-S0217 for the %/@ operators).
+    /// Code is at the start of the message (matching the DateTimeError::Coded
+    /// convention from the datetime picture-string engine) so
+    /// test_reference_suite.py's extract_error_code() finds it.
+    #[error("{code}: {message}")]
+    Coded {
+        code: &'static str,
+        message: String,
+    },
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cargo test --lib test_parent_operator_parses_as_prefix test_percent_still_parses_as_modulo_infix test_focus_bind_parses_as_binary_marker test_focus_bind_requires_variable_rhs`
+Expected: 4 passed
+
+- [ ] **Step 9: Run the full existing test suite to confirm no regressions**
+
+Run: `cargo test`
+Expected: all existing tests still pass (no new failures) — `Token::Percent`'s dual prefix/infix meaning and the new `Token::At` arm are purely additive.
+
+- [ ] **Step 10: `cargo fmt` and `cargo clippy`**
+
+Run: `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: clean
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/ast.rs src/parser.rs
+git commit -m "feat(parser): add % (parent) prefix and @ (focus-bind) infix parsing
+
+Both produce bare/unresolved AST markers (AstNode::Parent, Binary{FocusBind})
+at parse time -- matching jsonata-js's own trivial one-line prefix/infix
+rules. All real semantics (ancestor-slot resolution, step-flag assignment)
+land in the ast_transform pass (next task), not here."
+```
+
+---
+
+### Task 2: `PathStep` new fields for unified tuple/ancestor flags
+
+**Files:**
+- Modify: `src/ast.rs:20-26` (`PathStep` struct)
+- Modify: `src/ast.rs:241-254` (`PathStep::new`/`with_stages` constructors)
+- Test: `src/ast.rs` `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Produces: `PathStep.focus: Option<String>`, `PathStep.index_var: Option<String>`, `PathStep.ancestor_label: Option<String>`, `PathStep.is_tuple: bool` — consumed by Task 3 (ast_transform sets them) and Tasks 5-6 (evaluator reads them).
+- Consumes: nothing new; `PathStep::new`/`with_stages` are the only two call sites that construct `PathStep` via struct literal anywhere in the crate (verified: `grep -n "PathStep {" src/*.rs` returns only these two, plus the struct definition itself) — every other of the 17+ call sites uses `PathStep::new(...)`, so adding fields with defaults here is non-breaking everywhere else.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/ast.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn test_path_step_new_defaults_new_fields_to_none() {
+    let step = PathStep::new(AstNode::Name("foo".to_string()));
+    assert_eq!(step.focus, None);
+    assert_eq!(step.index_var, None);
+    assert_eq!(step.ancestor_label, None);
+    assert!(!step.is_tuple);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib test_path_step_new_defaults_new_fields_to_none`
+Expected: compile error (fields don't exist yet)
+
+- [ ] **Step 3: Add the fields and update constructors**
+
+In `src/ast.rs`, replace the `PathStep` struct (lines 20-26):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PathStep {
+    /// The main step node (field name, wildcard, etc.)
+    pub node: AstNode,
+    /// Stages to apply during this step (e.g., predicates)
+    pub stages: Vec<Stage>,
+    /// Set by `@$var` (focus binding): binds the step's per-element value to
+    /// this variable name (without the `$` prefix) during tuple-stream
+    /// evaluation. Mirrors jsonata-js's `step.focus`.
+    pub focus: Option<String>,
+    /// Set by `#$var` (index binding): binds the step's per-element index to
+    /// this variable name (without the `$` prefix). Mirrors jsonata-js's
+    /// `step.index`. Replaces the retired `AstNode::IndexBind` wrapping node.
+    pub index_var: Option<String>,
+    /// Set by ast_transform when a later `%` reference needs this step's
+    /// *input* value preserved. The label is synthetic (e.g. "!0", "!1", ...)
+    /// and used as a tuple-dict key at runtime. Mirrors jsonata-js's
+    /// `step.ancestor.label`.
+    pub ancestor_label: Option<String>,
+    /// True when this step must participate in tuple-stream evaluation
+    /// (because of its own `focus`/`index_var`/`ancestor_label`, or because
+    /// an earlier step in the same path already entered tuple-stream mode).
+    /// Mirrors jsonata-js's `step.tuple`.
+    pub is_tuple: bool,
+}
+```
+
+Replace the constructors (lines 241-254):
+
+```rust
+impl PathStep {
+    /// Create a path step from a node without stages
+    pub fn new(node: AstNode) -> Self {
+        PathStep {
+            node,
+            stages: Vec::new(),
+            focus: None,
+            index_var: None,
+            ancestor_label: None,
+            is_tuple: false,
+        }
+    }
+
+    /// Create a path step with stages
+    pub fn with_stages(node: AstNode, stages: Vec<Stage>) -> Self {
+        PathStep {
+            node,
+            stages,
+            focus: None,
+            index_var: None,
+            ancestor_label: None,
+            is_tuple: false,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib test_path_step_new_defaults_new_fields_to_none`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite to confirm no regressions**
+
+Run: `cargo test`
+Expected: all existing tests still pass (purely additive fields with safe defaults)
+
+- [ ] **Step 6: `cargo fmt` and `cargo clippy`, then commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+git add src/ast.rs
+git commit -m "feat(ast): add focus/index_var/ancestor_label/is_tuple fields to PathStep
+
+Additive-only change (both PathStep constructors default the new fields),
+laying the groundwork for the ast_transform pass and unified tuple-runtime
+work in the next tasks. AstNode::IndexBind is not yet retired -- that
+happens once ast_transform can rewrite it away (Task 4)."
+```
+
+---
+
+### Task 3: `ast_transform` — the ancestor-resolution compile pass
+
+This is the core novel piece: a faithful, value-returning (not mutate-in-place) port of jsonata-js's `seekParent`/`pushAncestry`/`resolveAncestry`.
+
+**Files:**
+- Create: `src/ast_transform.rs`
+- Modify: `src/lib.rs` (add `pub mod ast_transform;`)
+- Test: `src/ast_transform.rs` `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: `AstNode` (specifically the new `AstNode::Parent`, `BinaryOp::FocusBind`, and the existing `AstNode::IndexBind` from Task 1/pre-existing code), `PathStep`'s new fields from Task 2.
+- Produces: `pub fn resolve_ancestry(ast: AstNode) -> Result<AstNode, AstTransformError>` — the single entry point Task 4 wires into `parser::parse()`. `AstTransformError` is a new error enum (S0213/S0215/S0216/S0217 — S0214 was already handled inline in Task 1's parser rule).
+
+This task covers **only plain paths** (a `%`/`%.%` chain resolving back through `Name`/`Wildcard`/`Block`/nested `Path` steps, and `@`/`#` becoming step flags). Predicate and sort-term ancestor resolution (`Account.Order.Product[%.OrderID='order104']`, `SKU^(%.Price)`) is Task 4's scope, once the basic per-path mechanics are proven correct in isolation.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `src/ast_transform.rs`:
+
+```rust
+// Post-parse AST transformation pass.
+// Mirrors parser.js's processAST/seekParent/pushAncestry/resolveAncestry
+// (tests/jsonata-js/src/parser.js ~L937-1235), adapted to Rust's ownership
+// model: instead of mutating tree nodes in place, this consumes the raw
+// tree and rebuilds an enriched one with ancestor/tuple metadata resolved.
+
+use crate::ast::{AstNode, BinaryOp, PathStep};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AstTransformError {
+    #[error("{code}: {message}")]
+    Coded {
+        code: &'static str,
+        message: String,
+    },
+}
+
+fn coded(code: &'static str, message: impl Into<String>) -> AstTransformError {
+    AstTransformError::Coded {
+        code,
+        message: message.into(),
+    }
+}
+
+/// Monotonic counters for synthetic ancestor labels ("!0", "!1", ...),
+/// mirroring jsonata-js's module-level `ancestorLabel`/`ancestorIndex`
+/// counters. Threaded explicitly through the pass rather than using global
+/// mutable state, since Rust doesn't have JS's implicit module-scope `var`.
+struct LabelGen {
+    next_label: usize,
+}
+
+impl LabelGen {
+    fn new() -> Self {
+        LabelGen { next_label: 0 }
+    }
+
+    fn fresh_label(&mut self) -> String {
+        let label = format!("!{}", self.next_label);
+        self.next_label += 1;
+        label
+    }
+}
+
+/// Entry point: resolve all ancestor references in a freshly-parsed AST.
+pub fn resolve_ancestry(ast: AstNode) -> Result<AstNode, AstTransformError> {
+    let mut labels = LabelGen::new();
+    transform_node(ast, &mut labels)
+}
+
+/// Recursively rebuild `node`, resolving any `%`/`@`/`#` found within.
+/// Mirrors jsonata-js's processAST's generic per-node-type dispatch.
+fn transform_node(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
+    match node {
+        AstNode::Path { steps } => {
+            let transformed_steps = transform_path_steps(steps, labels)?;
+            Ok(AstNode::Path {
+                steps: transformed_steps,
+            })
+        }
+        AstNode::Block(exprs) => {
+            let transformed: Result<Vec<AstNode>, AstTransformError> = exprs
+                .into_iter()
+                .map(|e| transform_node(e, labels))
+                .collect();
+            Ok(AstNode::Block(transformed?))
+        }
+        // Parent/FocusBind/IndexBind found OUTSIDE a path context (e.g. a
+        // bare top-level `%`) can't derive an ancestor -- S0217.
+        AstNode::Parent => Err(coded(
+            "S0217",
+            "The parent operator % cannot be used at this point in the expression",
+        )),
+        // Recurse into every other node's children unchanged (no ancestor
+        // resolution needed for nodes that aren't paths/blocks/parent refs).
+        // Binary/Unary/Function/etc. are handled generically here; Task 4
+        // extends this with predicate/sort-term-specific recursion once
+        // basic path resolution (this task) is proven correct.
+        other => transform_children(other, labels),
+    }
+}
+
+/// Recurse into a node's child expressions without any path-specific
+/// ancestor logic (used for node types that can't themselves be paths).
+fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
+    match node {
+        AstNode::Binary { op, lhs, rhs } => Ok(AstNode::Binary {
+            op,
+            lhs: Box::new(transform_node(*lhs, labels)?),
+            rhs: Box::new(transform_node(*rhs, labels)?),
+        }),
+        AstNode::Unary { op, operand } => Ok(AstNode::Unary {
+            op,
+            operand: Box::new(transform_node(*operand, labels)?),
+        }),
+        AstNode::Array(elements) => {
+            let transformed: Result<Vec<AstNode>, AstTransformError> = elements
+                .into_iter()
+                .map(|e| transform_node(e, labels))
+                .collect();
+            Ok(AstNode::Array(transformed?))
+        }
+        // Leaf nodes and everything else pass through unchanged.
+        other => Ok(other),
+    }
+}
+
+/// Resolve a path's steps: migrate `#`/`@` markers into step-level flags,
+/// then walk backward from the last step resolving any `%` references
+/// (mirrors resolveAncestry, parser.js ~L1002-1030).
+fn transform_path_steps(
+    steps: Vec<PathStep>,
+    labels: &mut LabelGen,
+) -> Result<Vec<PathStep>, AstTransformError> {
+    // Task 3 scope: migrate #/@ into step flags and resolve a *single*
+    // trailing `%` reference with no intervening predicates/sort terms.
+    // Multi-level `%.%` chains and predicate/sort-term ancestor resolution
+    // are Task 4.
+    let mut resolved: Vec<PathStep> = Vec::with_capacity(steps.len());
+    for step in steps {
+        resolved.push(migrate_binding_markers(step, labels)?);
+    }
+    Ok(resolved)
+}
+
+/// Convert a step's raw-parse-time binding marker (if any) into the
+/// unified PathStep flags, recursing into the step's own node first (a
+/// step's node can itself be a Block/nested Path containing `%`/`@`/`#`).
+fn migrate_binding_markers(
+    mut step: PathStep,
+    labels: &mut LabelGen,
+) -> Result<PathStep, AstTransformError> {
+    match step.node {
+        AstNode::Binary {
+            op: BinaryOp::FocusBind,
+            lhs,
+            rhs,
+        } => {
+            let var_name = match *rhs {
+                AstNode::Variable(name) => name,
+                _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
+            };
+            step.node = transform_node(*lhs, labels)?;
+            step.focus = Some(var_name);
+            step.is_tuple = true;
+        }
+        AstNode::IndexBind { input, variable } => {
+            step.node = transform_node(*input, labels)?;
+            step.index_var = Some(variable);
+            step.is_tuple = true;
+        }
+        other => {
+            step.node = transform_node(other, labels)?;
+        }
+    }
+    Ok(step)
+}
+```
+
+- [ ] **Step 2: Write the failing unit tests**
+
+Add `#[cfg(test)] mod tests` to the bottom of `src/ast_transform.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Stage;
+
+    #[test]
+    fn test_focus_bind_becomes_step_flag() {
+        // Order@$o  -->  Path{steps: [Name("Order") with focus=Some("o"), is_tuple=true]}
+        let ast = AstNode::Path {
+            steps: vec![PathStep::new(AstNode::Binary {
+                op: BinaryOp::FocusBind,
+                lhs: Box::new(AstNode::Name("Order".to_string())),
+                rhs: Box::new(AstNode::Variable("o".to_string())),
+            })],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 1);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Order"));
+                assert_eq!(steps[0].focus, Some("o".to_string()));
+                assert!(steps[0].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_index_bind_becomes_step_flag() {
+        // arr#$i  -->  Path{steps: [Name("arr") with index_var=Some("i"), is_tuple=true]}
+        let ast = AstNode::Path {
+            steps: vec![PathStep::new(AstNode::IndexBind {
+                input: Box::new(AstNode::Name("arr".to_string())),
+                variable: "i".to_string(),
+            })],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 1);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "arr"));
+                assert_eq!(steps[0].index_var, Some("i".to_string()));
+                assert!(steps[0].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_bare_parent_at_top_level_is_s0217() {
+        let err = resolve_ancestry(AstNode::Parent).unwrap_err();
+        assert!(err.to_string().starts_with("S0217"));
+    }
+
+    #[test]
+    fn test_path_step_with_stages_preserved() {
+        // Ensure stages (predicates) survive the transform unchanged when
+        // there's no binding marker involved.
+        let ast = AstNode::Path {
+            steps: vec![PathStep::with_stages(
+                AstNode::Name("Order".to_string()),
+                vec![Stage::Filter(Box::new(AstNode::Boolean(true)))],
+            )],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps[0].stages.len(), 1);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register the new module**
+
+In `src/lib.rs`, find the existing `pub mod parser;` (or similar module declarations near the top) and add:
+
+```rust
+pub mod ast_transform;
+```
+
+- [ ] **Step 4: Run tests to verify they fail, then pass**
+
+Run: `cargo test --lib ast_transform::`
+Expected (before Step 1's code is saved): compile error. After saving `src/ast_transform.rs` as written above: 4 passed. (This module is written test-and-implementation together above since the pass is genuinely new code with no prior partial version to red/green against line-by-line — but verify by temporarily commenting out `migrate_binding_markers`'s body and confirming the tests fail first, then restoring it, if you want a stricter red/green cycle.)
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cargo test`
+Expected: all passed — `ast_transform` isn't wired into `parser::parse()` yet (Task 4), so nothing else is affected.
+
+- [ ] **Step 6: `cargo fmt` and `cargo clippy`, then commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+git add src/ast_transform.rs src/lib.rs
+git commit -m "feat: add ast_transform pass resolving @/# binding markers to step flags
+
+Ports jsonata-js's processAST-style post-parse pass, adapted to Rust's
+ownership model (consumes + rebuilds rather than mutates in place).
+This task covers single-step @/# migration and top-level bare-% detection
+(S0217) only -- multi-level %.% chains and predicate/sort-term ancestor
+resolution land in the next task, once this foundation is verified.
+
+Not yet wired into parser::parse() (next task) -- purely additive so far."
+```
+
+---
+
+### Task 4: Full `%`/`%.%` ancestor resolution + wire into `parser::parse()`
+
+Extends Task 3's `ast_transform` with the actual `seekParent`/`pushAncestry` backward-walk (chained `%.%`, resolution through `Block`s, predicates, and sort terms), and connects the whole pass to the real parsing entry point.
+
+**Files:**
+- Modify: `src/ast_transform.rs` (extend `transform_path_steps`, add `seek_parent`)
+- Modify: `src/parser.rs:1653-1656` (`pub fn parse`)
+- Modify: `src/ast.rs` (retire `AstNode::IndexBind` — see Step 5)
+- Test: `src/ast_transform.rs` `#[cfg(test)] mod tests`, plus new integration tests in `tests/parent_and_focus_binding_suite.rs` (created in Task 8) once the evaluator side exists
+
+**Interfaces:**
+- Produces: `AstNode::Parent(String)` (now carrying its resolved ancestor label directly, replacing the bare unit variant from Task 1 — see Step 1's rationale), full backward-walk ancestor resolution.
+- Consumes: Task 3's `transform_path_steps`/`migrate_binding_markers`, Task 2's `PathStep` fields.
+
+- [ ] **Step 1: Change `AstNode::Parent` to carry its resolved label**
+
+In `src/ast.rs`, change the `Parent` variant (added in Task 1) from a unit variant to:
+
+```rust
+    /// Parent-reference operator (%), resolved. Carries the synthetic
+    /// ancestor label ("!0", "!1", ...) assigned by ast_transform -- looked
+    /// up at runtime via the same tuple/scope mechanism as $-variables.
+    Parent(String),
+```
+
+Rationale: jsonata-js assigns the slot (`{label, level, index}`) the moment `processAST`'s generic dispatch first sees *any* `%` node (before `seekParent`'s backward walk even starts) — the walk only *decrements* `level` and matches it against the right ancestor step. Since our `AstNode::Parent` from Task 1 is produced directly by the parser (not by `ast_transform`'s generic dispatch), we resolve its label eagerly, right when `ast_transform` first encounters it, then thread the *count* of unresolved `%`-levels alongside it during the backward walk (see Step 3) rather than mutating the node's own field after the fact.
+
+- [ ] **Step 2: Update Task 1/3's `AstNode::Parent` construction sites**
+
+In `src/parser.rs`'s `%` prefix rule (Task 1, Step 5), the parser doesn't have a label counter — that's `ast_transform`'s job. Change the prefix rule to produce a placeholder the transform pass recognizes and replaces:
+
+```rust
+            Token::Percent => {
+                // Parent operator in primary position. Label is resolved by
+                // ast_transform -- this empty string is never observed by
+                // the evaluator (ast_transform's transform_node fills every
+                // AstNode::Parent("") with a real label or errors S0217).
+                self.advance()?;
+                Ok(AstNode::Parent(String::new()))
+            }
+```
+
+Update `src/ast_transform.rs`'s `transform_node`'s `AstNode::Parent => Err(coded("S0217", ...))` arm (Task 3, Step 1) — a bare `Parent` reached via the generic `transform_node` dispatch (i.e. NOT found during a path's backward walk in Step 3 below) still means "no enclosing path to derive an ancestor from", so it stays an `S0217` error regardless of the (currently-empty) label payload:
+
+```rust
+        AstNode::Parent(_) => Err(coded(
+            "S0217",
+            "The parent operator % cannot be used at this point in the expression",
+        )),
+```
+
+Update the two Task 1 parser tests (`test_parent_operator_parses_as_prefix`) and Task 3 unit tests that pattern-match `AstNode::Parent` as a unit variant — change `matches!(steps[0].node, AstNode::Parent)` to `matches!(steps[0].node, AstNode::Parent(_))`.
+
+- [ ] **Step 3: Write the failing `%.%` chain test**
+
+Add to `src/ast_transform.rs`'s tests:
+
+```rust
+    #[test]
+    fn test_single_level_parent_resolves_to_previous_step() {
+        // Account.Order.% (no further field after %) -- % refers to Order's
+        // input, i.e. Account's output. Mirrors seekParent's single-level case.
+        let ast = AstNode::Path {
+            steps: vec![
+                PathStep::new(AstNode::Name("Account".to_string())),
+                PathStep::new(AstNode::Name("Order".to_string())),
+                PathStep::new(AstNode::Parent(String::new())),
+            ],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 3);
+                // The "Order" step (index 1) is the one % refers to -- it
+                // must be stamped with an ancestor_label and is_tuple.
+                assert!(steps[1].ancestor_label.is_some());
+                assert!(steps[1].is_tuple);
+                // The % step itself resolves to a Parent(label) matching it.
+                match &steps[2].node {
+                    AstNode::Parent(label) => {
+                        assert_eq!(Some(label.clone()), steps[1].ancestor_label);
+                    }
+                    other => panic!("expected Parent(label), got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_chained_parent_resolves_two_levels_back() {
+        // Account.Order.Product.%.%  -- first % refers to Product's input
+        // (Order's output); second % refers to Order's input (Account's
+        // output). Mirrors the parent002.jsonata test shape.
+        let ast = AstNode::Path {
+            steps: vec![
+                PathStep::new(AstNode::Name("Account".to_string())),
+                PathStep::new(AstNode::Name("Order".to_string())),
+                PathStep::new(AstNode::Name("Product".to_string())),
+                PathStep::new(AstNode::Parent(String::new())),
+                PathStep::new(AstNode::Parent(String::new())),
+            ],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                let order_label = steps[1].ancestor_label.clone();
+                let account_label = steps[0].ancestor_label.clone();
+                assert!(order_label.is_some());
+                assert!(account_label.is_some());
+                assert_ne!(order_label, account_label);
+                match &steps[3].node {
+                    AstNode::Parent(label) => assert_eq!(Some(label.clone()), order_label),
+                    other => panic!("expected Parent(label), got {:?}", other),
+                }
+                match &steps[4].node {
+                    AstNode::Parent(label) => assert_eq!(Some(label.clone()), account_label),
+                    other => panic!("expected Parent(label), got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cargo test --lib test_single_level_parent_resolves_to_previous_step test_chained_parent_resolves_two_levels_back`
+Expected: FAIL (current `transform_path_steps` doesn't resolve `%` at all yet, it only migrates `@`/`#`)
+
+- [ ] **Step 5: Implement `seek_parent` and extend `transform_path_steps`**
+
+Replace `transform_path_steps` in `src/ast_transform.rs`:
+
+```rust
+/// A `%` reference still walking backward looking for its ancestor step,
+/// mirroring jsonata-js's `slot` object threaded through `seekParent`.
+/// Rust-idiomatic value-returning adaptation: instead of mutating a shared
+/// `slot` object in place (as the JS does), `seek_parent` returns the
+/// remaining level count for the caller to check `> 0` and keep walking.
+struct PendingAncestor {
+    label: String,
+    /// How many steps further back this reference still needs to walk.
+    /// A fresh `%` starts at level 1 (its own immediately-preceding step);
+    /// `%.%` increments this to 2 before the walk begins.
+    level: usize,
+}
+
+fn transform_path_steps(
+    steps: Vec<PathStep>,
+    labels: &mut LabelGen,
+) -> Result<Vec<PathStep>, AstTransformError> {
+    // Pass 1: migrate #/@ into step flags, recursing into nested content.
+    let mut resolved: Vec<PathStep> = Vec::with_capacity(steps.len());
+    for step in steps {
+        resolved.push(migrate_binding_markers(step, labels)?);
+    }
+
+    // Pass 2: walk backward from the end resolving any %/%.% chains.
+    // Mirrors resolveAncestry (parser.js ~L1002-1030): collect every
+    // pending ancestor reference in the last step, then walk earlier steps
+    // decrementing level until it reaches 0 (found the target step) or we
+    // run off the front of the path (S0217).
+    let last_index = resolved.len() - 1;
+    let mut pending: Vec<PendingAncestor> = Vec::new();
+    if let AstNode::Parent(label) = &resolved[last_index].node {
+        pending.push(PendingAncestor {
+            label: label.clone(),
+            level: 1,
+        });
+    }
+
+    for pending_ref in pending {
+        let mut level = pending_ref.level;
+        let mut index = last_index;
+        loop {
+            if index == 0 {
+                return Err(coded(
+                    "S0217",
+                    "The parent operator % cannot be resolved -- not enough enclosing path steps",
+                ));
+            }
+            index -= 1;
+            level = seek_parent(&mut resolved[index], &pending_ref.label, level)?;
+            if level == 0 {
+                break;
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
+/// Try to resolve one level of a pending ancestor reference against `step`.
+/// Returns the remaining level count (0 means resolved at this step).
+/// Mirrors jsonata-js's seekParent (parser.js ~L941-986), restricted for
+/// this task to Name/Wildcard steps -- Block/predicate/sort-term recursion
+/// is intentionally out of scope here (only plain path chains are handled
+/// by this task; predicates/sort terms are wired in Task 6).
+fn seek_parent(
+    step: &mut PathStep,
+    label: &str,
+    level: usize,
+) -> Result<usize, AstTransformError> {
+    match &step.node {
+        AstNode::Name(_) | AstNode::Wildcard => {
+            let remaining = level - 1;
+            if remaining == 0 {
+                // Reuse an existing label if this step already captures an
+                // ancestor value for a different %, matching jsonata-js's
+                // "reuse the existing label" branch (parser.js ~L949-953).
+                if step.ancestor_label.is_none() {
+                    step.ancestor_label = Some(label.to_string());
+                }
+                step.is_tuple = true;
+            }
+            Ok(remaining)
+        }
+        _ => Err(coded(
+            "S0217",
+            "The parent operator % cannot derive an ancestor from this kind of path step",
+        )),
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib test_single_level_parent_resolves_to_previous_step test_chained_parent_resolves_two_levels_back`
+Expected: 2 passed
+
+- [ ] **Step 7: Retire `AstNode::IndexBind`**
+
+Now that `migrate_binding_markers` (Task 3) consumes `AstNode::IndexBind` and rewrites it away before the tree reaches the evaluator, remove the variant. In `src/ast.rs`, delete the `IndexBind { input, variable }` variant (lines 162-170). Do NOT change `src/parser.rs`'s existing `#$var` infix rule (line 1471-1491) — it still constructs `AstNode::IndexBind` at raw-parse time; `ast_transform` always runs immediately afterward and consumes it (wired in Step 8 below), so the variant only needs to exist transiently between parse and transform.
+
+Search for other `AstNode::IndexBind` references that will now fail to compile:
+
+```bash
+grep -rn "AstNode::IndexBind" src/*.rs
+```
+
+Each hit in `src/evaluator.rs` (the investigation found dispatch arms at ~3306-3334 and possibly others) is now unreachable once `ast_transform` runs unconditionally (Step 8) — delete those match arms. If deletion produces a non-exhaustive-match compile error elsewhere, that confirms another live site; delete it too. Do not leave a `_ => unreachable!()` catch-all for `IndexBind` specifically — remove the arm entirely so the compiler proves it's gone.
+
+- [ ] **Step 8: Wire `ast_transform` into `parser::parse()`**
+
+In `src/parser.rs`, replace the free-standing `pub fn parse` (lines 1653-1656):
+
+```rust
+/// Parse a JSONata expression string into an AST
+///
+/// This is the main entry point for parsing. Runs the post-parse
+/// ast_transform pass (ancestor-slot resolution, @/#/% unification)
+/// unconditionally, matching jsonata-js's processAST always running
+/// immediately after the raw Pratt parse.
+pub fn parse(expression: &str) -> Result<AstNode, ParserError> {
+    let mut parser = Parser::new(expression.to_string())?;
+    let raw_ast = parser.parse()?;
+    crate::ast_transform::resolve_ancestry(raw_ast)
+        .map_err(|e| ParserError::Coded {
+            code: match &e {
+                crate::ast_transform::AstTransformError::Coded { code, .. } => code,
+            },
+            message: e.to_string(),
+        })
+}
+```
+
+- [ ] **Step 9: Run the full test suite**
+
+Run: `cargo test`
+Expected: this is the first task where a compile/runtime regression is possible, since `ast_transform` now runs on *every* parsed expression, and `IndexBind` is fully retired. Investigate and fix any failure by reading the actual failing test's expression and comparing against `transform_node`'s coverage (Step 1 of Task 3 lists which node types recurse — if a real expression uses a node type not yet covered by `transform_children`, add an arm for it, following the same pattern as the existing `Binary`/`Unary`/`Array` arms).
+
+- [ ] **Step 10: `cargo fmt` and `cargo clippy`, then commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+git add src/ast.rs src/ast_transform.rs src/parser.rs
+git commit -m "feat: resolve %/%.% ancestor chains, retire IndexBind, wire ast_transform in
+
+parser::parse() now always runs ast_transform after the raw Pratt parse,
+matching jsonata-js's processAST always running immediately after parsing.
+AstNode::IndexBind is fully retired -- ast_transform rewrites #\$var into
+the same step-level index_var flag that @\$var and % use, so the evaluator
+now only ever sees the unified PathStep representation.
+
+Note: %/@/# do not yet affect evaluation (Tasks 5-7) -- parsing and AST
+shape are correct, but the evaluator hasn't been taught to read the new
+flags yet. Expressions using % or @ will parse successfully but evaluate
+incorrectly (% resolves to an unbound scope lookup, @ has no effect on
+tuple-stream output) until those tasks land."
+```
+
+---
+
+### Task 5: Runtime — unified tuple-aware step evaluator
+
+Adds the new tuple-aware step evaluator (mirroring jsonata-js's `evaluateTupleStep`), reusing the existing general-purpose `evaluate_path_step` (src/evaluator.rs:4579) for per-row work, and fixes the `#` propagation gap by binding every tuple key into a real scope frame unconditionally.
+
+**Files:**
+- Modify: `src/evaluator.rs:3645-4578` (`evaluate_path`'s main step loop — extend the `is_tuple_array`/`needs_tuple_context_binding` dispatch at ~lines 4016-4113)
+- Modify: `src/evaluator.rs:2861-2897` (`AstNode::Variable` lookup arm — add `!`-prefixed ancestor-label lookup alongside the existing `$name` tuple-binding lookup)
+- Modify: `src/evaluator.rs:83-` (`evaluate_internal_impl`'s big `match node { ... }` — add `AstNode::Parent(label)` arm)
+- Test: `tests/parent_and_focus_binding_suite.rs` (new; see Task 8) is the end-to-end verification; this task also gets direct unit-level coverage below.
+
+**Interfaces:**
+- Consumes: `PathStep.focus`/`index_var`/`ancestor_label`/`is_tuple` (Task 2/4), `AstNode::Parent(String)` (Task 4).
+- Produces: a new `fn evaluate_tuple_path_step(&mut self, step: &PathStep, tuple_bindings: &[JValue], original_data: &JValue) -> Result<Vec<JValue>, EvaluatorError>` — takes the *previous* row of tuple-wrapper `JValue::Object`s (or plain values, for the first tuple step in a path) and returns the next row.
+
+- [ ] **Step 1: Write the failing evaluator test**
+
+Add to `src/evaluator.rs`'s existing `#[cfg(test)] mod tests` (or the closest evaluator test module — check for one near the bottom of the file with `grep -n "mod tests" src/evaluator.rs`; if the evaluator's tests live in `tests/integration_test.rs` instead, add there):
+
+```rust
+#[test]
+fn test_focus_bind_makes_variable_available_in_next_step() {
+    let data: JValue = serde_json::json!({
+        "Account": {
+            "Order": [
+                {"OrderID": "o1", "Product": [{"SKU": "a"}, {"SKU": "b"}]}
+            ]
+        }
+    })
+    .into();
+    let ast = crate::parser::parse("Account.Order@$o.Product.{ 'sku': SKU, 'order': $o.OrderID }").unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data).unwrap();
+    assert_eq!(
+        result,
+        serde_json::json!([
+            {"sku": "a", "order": "o1"},
+            {"sku": "b", "order": "o1"}
+        ])
+        .into()
+    );
+}
+
+#[test]
+fn test_parent_reference_resolves_to_enclosing_step_value() {
+    let data: JValue = serde_json::json!({
+        "Account": {
+            "Order": [
+                {"OrderID": "o1", "Product": [{"Name": "Hat"}]}
+            ]
+        }
+    })
+    .into();
+    let ast = crate::parser::parse("Account.Order.Product.{ 'name': Name, 'order': %.OrderID }").unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data).unwrap();
+    assert_eq!(
+        result,
+        serde_json::json!([{"name": "Hat", "order": "o1"}]).into()
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test test_focus_bind_makes_variable_available_in_next_step test_parent_reference_resolves_to_enclosing_step_value`
+Expected: FAIL (`$o`/`%` don't resolve correctly yet — `%` currently hits a missing-match-arm compile error since `AstNode::Parent(String)` has no evaluator arm; `@` parses but doesn't affect tuple output since evaluator doesn't read `step.focus`/`is_tuple` yet)
+
+- [ ] **Step 3: Add the `AstNode::Parent` runtime lookup**
+
+In `src/evaluator.rs`, add an arm to `evaluate_internal_impl`'s big match (alongside the existing `AstNode::Variable(name) => { ... }` arm at line 2861):
+
+```rust
+            AstNode::Parent(label) => {
+                // Resolves via the same real scope frame that tuple steps
+                // bind into (Step 4 below) -- no special-casing needed
+                // beyond an ordinary scope lookup, matching jsonata-js's
+                // `case 'parent': result = environment.lookup(expr.slot.label);`
+                self.context
+                    .lookup(label)
+                    .cloned()
+                    .map_or(Ok(JValue::Undefined), Ok)
+            }
+```
+
+- [ ] **Step 4: Add `evaluate_tuple_path_step` and wire it into `evaluate_path`'s loop**
+
+In `src/evaluator.rs`, locate the existing tuple-special-case block inside `evaluate_path`'s step loop (the `is_tuple_array`/`needs_tuple_context_binding` logic at ~lines 4016-4113 -- **read the current file first**, since Task 4 may have shifted line numbers slightly). Replace the narrow `needs_tuple_context_binding` gate (currently `matches!(&step.node, AstNode::Object(_) | AstNode::FunctionApplication(_) | AstNode::Variable(_))`) and its inline 3-arm handling with a call to a new function that handles every step type generically:
+
+```rust
+    /// Evaluate one path step against a tuple stream, mirroring jsonata-js's
+    /// evaluateTupleStep (jsonata.js ~L315-380). Reuses the existing
+    /// general-purpose evaluate_path_step for the actual per-row value
+    /// computation, then wraps each result according to the step's
+    /// focus/index_var/ancestor_label flags. Every tuple key (old bindings
+    /// carried forward, plus any new focus/index_var/ancestor_label this
+    /// step adds) is bound into a real scope frame (self.context) before
+    /// evaluating -- this is the fix for the #-propagation gap: previously
+    /// only 3 node types got this promotion, now every step does.
+    fn evaluate_tuple_path_step(
+        &mut self,
+        step: &PathStep,
+        tuple_bindings: &[JValue],
+        original_data: &JValue,
+    ) -> Result<Vec<JValue>, EvaluatorError> {
+        let mut result = Vec::new();
+
+        for tuple in tuple_bindings {
+            let tuple_obj = match tuple {
+                JValue::Object(obj) => obj.clone(),
+                other => {
+                    // First tuple step in a path: wrap the plain value as {'@': value}.
+                    let mut wrapper = IndexMap::new();
+                    wrapper.insert("@".to_string(), other.clone());
+                    wrapper.insert("__tuple__".to_string(), JValue::Bool(true));
+                    std::rc::Rc::new(wrapper)
+                }
+            };
+
+            // Bind every existing tuple key into a real scope frame before
+            // evaluating this step -- unconditional, matching
+            // createFrameFromTuple's "for every key in tuple, frame.bind(...)".
+            let mut bound_names = Vec::new();
+            for (key, value) in tuple_obj.iter() {
+                if let Some(name) = key.strip_prefix('$') {
+                    self.context.bind(name.to_string(), value.clone());
+                    bound_names.push(name.to_string());
+                } else if key.starts_with('!') {
+                    self.context.bind(key.clone(), value.clone());
+                    bound_names.push(key.clone());
+                }
+            }
+
+            let actual_data = tuple_obj.get("@").cloned().unwrap_or(JValue::Undefined);
+            let step_result = self.evaluate_path_step(&step.node, &actual_data, original_data);
+
+            for name in &bound_names {
+                self.context.unbind(name);
+            }
+            let step_result = step_result?;
+
+            let row_values: Vec<JValue> = match &step_result {
+                JValue::Array(arr) if !matches!(step.node, AstNode::Object(_)) => {
+                    arr.iter().cloned().collect()
+                }
+                other => vec![other.clone()],
+            };
+
+            for value in row_values {
+                if value.is_undefined() {
+                    continue;
+                }
+                let mut new_tuple = (*tuple_obj).clone();
+                if let Some(focus_var) = &step.focus {
+                    new_tuple.insert(format!("${}", focus_var), value);
+                    // focus binding keeps '@' as the step's INPUT, matching
+                    // jsonata-js: `tuple[expr.focus] = res[bb]; tuple['@'] = tupleBindings[ee]['@'];`
+                } else {
+                    new_tuple.insert("@".to_string(), value);
+                }
+                if let Some(ancestor_label) = &step.ancestor_label {
+                    new_tuple.insert(ancestor_label.clone(), actual_data.clone());
+                }
+                new_tuple.insert("__tuple__".to_string(), JValue::Bool(true));
+                result.push(JValue::object(new_tuple));
+            }
+        }
+
+        Ok(result)
+    }
+```
+
+Then, in `evaluate_path`'s main loop, change the trigger condition from the narrow 3-node-type check to a general one, and replace the call:
+
+```rust
+            let enters_tuple_mode = is_tuple_array || step.is_tuple;
+
+            if enters_tuple_mode {
+                if let JValue::Array(arr) = &current {
+                    let tuple_row = self.evaluate_tuple_path_step(step, arr, data)?;
+                    current = JValue::array(tuple_row);
+                    continue;
+                } else {
+                    // First tuple step, current isn't an array yet (single value input).
+                    let tuple_row = self.evaluate_tuple_path_step(step, std::slice::from_ref(&current), data)?;
+                    current = JValue::array(tuple_row);
+                    continue;
+                }
+            }
+```
+
+Remove the old narrow `needs_tuple_context_binding` block entirely (the one being replaced) — do not leave both in place.
+
+- [ ] **Step 5: Add `!`-prefixed ancestor-label lookup fallback**
+
+In `src/evaluator.rs`'s `AstNode::Variable(name)` arm (~lines 2861-2897), the existing tuple-binding fallback (`format!("${}", name)`) only covers `$name` keys. Ancestor labels (`!0`, `!1`, ...) are looked up directly via `AstNode::Parent`'s own arm (Step 3 above), which calls `self.context.lookup(label)` — since Step 4's `evaluate_tuple_path_step` now binds `!`-prefixed keys into `self.context` directly (not just into the tuple dict), no additional fallback is needed in the `Variable` arm itself. Skip this step if Step 4 is implemented as written; it exists here as a checkpoint to re-verify that assumption once Step 6's tests run.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test test_focus_bind_makes_variable_available_in_next_step test_parent_reference_resolves_to_enclosing_step_value`
+Expected: 2 passed. If not, the most likely gap is the fast-path/single-step shortcuts elsewhere in `evaluate_path` (e.g. the single-field fast path at ~line 3657-3684) bypassing the new tuple dispatch — check whether `step.is_tuple` needs to be checked there too before taking the fast path.
+
+- [ ] **Step 7: Run the full test suite**
+
+Run: `cargo test`
+Expected: no regressions. Existing `#$var` tests are the highest-risk area here (they now go through the new `evaluate_tuple_path_step` instead of the old narrow 3-arm handling) — if any fail, compare their expression against jsonata-js's actual output (`node -e "..."` against the submodule, or the reference-suite JSON) rather than assuming the old Rust behavior was correct.
+
+- [ ] **Step 8: `cargo fmt` and `cargo clippy`, then commit**
+
+```bash
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+git add src/evaluator.rs
+git commit -m "feat(evaluator): unified tuple-aware step evaluation for %/@/#
+
+Adds evaluate_tuple_path_step (mirrors jsonata-js's evaluateTupleStep),
+reusing the existing evaluate_path_step for per-row work. Every tuple
+step now binds ALL its keys (\$name AND !label) into a real scope frame
+unconditionally, fixing the previous partial-promotion gap that only
+covered Object/FunctionApplication/Variable next-steps. % now resolves
+via ordinary scope lookup of its ancestor label."
+```
+
+---
+
+### Task 6: Predicate and sort-term ancestor resolution
+
+Extends `ast_transform` to resolve `%` inside filter predicates (`Product[%.OrderID='order104']`) and sort terms (`SKU^(%.Price)`), matching jsonata-js's `pushAncestry` handling in `processAST`'s `case '['` and `case '^'` branches (parser.js ~L1097-1130, ~L1147-1170 -- re-read these exact ranges from the submodule before starting, since this task's plan text summarizes rather than quotes them verbatim).
+
+**Files:**
+- Modify: `src/ast_transform.rs` (extend `migrate_binding_markers`/`transform_node` to recurse into `Stage::Filter` predicates and `AstNode::Sort` terms, propagating unresolved ancestor references up to the enclosing path via a `seeking_parent: Vec<PendingAncestor>` return value)
+- Test: `src/ast_transform.rs` unit tests
+
+**Interfaces:**
+- Consumes: Task 4's `PendingAncestor`, `seek_parent`.
+- Produces: predicate/sort-term-aware ancestor resolution — no new public interface, this is entirely internal to `ast_transform`.
+
+- [ ] **Step 1: Read the reference implementation precisely**
+
+Before writing any code, read `tests/jsonata-js/src/parser.js` lines 1097-1130 (`case '['`) and 1147-1170 (`case '^'`) directly, plus `pushAncestry` (~L988-1000) and `resolveAncestry` (~L1002-1030) again with these two call sites in mind. Confirm exactly how a predicate's own `seekingParent` list gets merged into the *step* it's attached to (not the whole path) versus how sort terms attach theirs to the `sort` step. Write down the exact mechanism in a comment at the top of the code you add in Step 3, so a future reader doesn't have to re-derive it.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `src/ast_transform.rs`'s tests (exact expected shape depends on Step 1's findings — this is deliberately left to be filled in against the real algorithm rather than guessed, per this task's own Step 1):
+
+```rust
+    #[test]
+    fn test_parent_inside_predicate_resolves_against_enclosing_step() {
+        // Account.Order.Product[%.OrderID='order104'] -- % inside the
+        // predicate must resolve against "Order" (the step the predicate
+        // is attached to's enclosing context), not "Product" itself.
+        // Fill in the exact AstNode shape once Step 1's reading confirms
+        // how our parser currently represents Product[predicate] --
+        // check whether the predicate lives in PathStep.stages (a
+        // Stage::Filter) on the "Product" step, per the existing
+        // Stage enum in src/ast.rs.
+        todo!("write once Step 1 confirms the exact predicate AST shape and jsonata-js's exact pushAncestry mechanism");
+    }
+```
+
+(This `todo!()` is intentionally the ONE placeholder in this entire plan — it exists because this task's own Step 1 requires reading source not yet re-read at plan-writing time, and guessing the exact mechanism here risks writing a subtly-wrong test that passes for the wrong reason. Replace it before considering Step 2 done; do not proceed to Step 3 with it still in place.)
+
+- [ ] **Step 3: Implement predicate/sort-term ancestor propagation**
+
+Based on Step 1's findings, extend `transform_node`'s handling so that:
+- A `Stage::Filter` predicate is transformed with its own fresh recursive call; any `PendingAncestor` it produces (a `%` inside it that couldn't be resolved within the predicate's own tiny scope) gets attached to the *step* the predicate/stage belongs to, then resolved by that step's normal backward walk (extending `transform_path_steps`'s pending-ancestor collection at the "last step" to also pull from `Stage::Filter`/sort-term predicates on *any* step, not just the path's last step).
+- `AstNode::Sort { input, terms }`'s each term gets the same treatment.
+
+Write the actual code here once Step 1 and Step 2 are complete — this step's content depends on their findings and is not pre-specified further.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib ast_transform::`
+Expected: all pass, including the test written in Step 2.
+
+- [ ] **Step 5: Run the full test suite, `cargo fmt`/`clippy`, commit**
+
+```bash
+cargo test
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+git add src/ast_transform.rs
+git commit -m "feat: resolve % inside predicates and sort terms
+
+Extends ancestor resolution to filter predicates and sort terms, matching
+jsonata-js's pushAncestry handling in processAST's case '[' / case '^'."
+```
+
+---
+
+### Task 7: Close the tuple-wrapper output leak
+
+Adds the unwrap-at-boundary fix identified in the design's Section 3.
+
+**Files:**
+- Modify: `src/evaluator.rs` (top of `pub fn evaluate`, ~line 2709)
+- Modify: `src/lib.rs` (`json_to_python`, ~line 436, or wherever the Python-boundary serializer lives — confirm exact location via `grep -n "fn json_to_python" src/lib.rs`)
+- Test: new unit test in `src/evaluator.rs`
+
+**Interfaces:**
+- Consumes: the `__tuple__`/`@` convention already established.
+- Produces: no new public interface — this is a correctness fix at existing boundaries.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn test_bare_index_bind_result_does_not_leak_tuple_wrapper() {
+    let data: JValue = serde_json::json!({"items": [1, 2, 3]}).into();
+    let ast = crate::parser::parse("items#$i").unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data).unwrap();
+    // Each element should be the plain value, not {"@":1,"$i":0,"__tuple__":true}
+    match result {
+        JValue::Array(arr) => {
+            for item in arr.iter() {
+                assert!(
+                    !matches!(item, JValue::Object(obj) if obj.get("__tuple__").is_some()),
+                    "tuple wrapper leaked into output: {:?}",
+                    item
+                );
+            }
+        }
+        other => panic!("expected array, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test test_bare_index_bind_result_does_not_leak_tuple_wrapper`
+Expected: FAIL (this is the exact latent bug the investigation found for `#` — confirm it actually reproduces before fixing)
+
+- [ ] **Step 3: Add the unwrap helper and call it at both boundaries**
+
+In `src/evaluator.rs`, add near `evaluate`:
+
+```rust
+/// Strip a lingering tuple wrapper from a value about to leave the
+/// evaluator (either a single tuple object, or an array of them),
+/// recursively -- this is the single choke point that was missing
+/// (call sites previously unwrapped locally and inconsistently).
+fn unwrap_tuple_output(value: JValue) -> JValue {
+    match value {
+        JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)) => obj
+            .get("@")
+            .cloned()
+            .map(unwrap_tuple_output)
+            .unwrap_or(JValue::Undefined),
+        JValue::Array(arr) => {
+            JValue::array(arr.iter().cloned().map(unwrap_tuple_output).collect())
+        }
+        other => other,
+    }
+}
+```
+
+In `pub fn evaluate`, wrap the final return value:
+
+```rust
+    pub fn evaluate(&mut self, node: &AstNode, data: &JValue) -> Result<JValue, EvaluatorError> {
+        // ... existing body ...
+        result.map(unwrap_tuple_output)
+    }
+```
+
+(Read the current exact body/return shape of `evaluate` at line 2709 first — the exact edit depends on whether it currently returns directly or via an intermediate `let result = ...; result` binding.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test test_bare_index_bind_result_does_not_leak_tuple_wrapper`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite, `cargo fmt`/`clippy`, commit**
+
+```bash
+cargo test
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings
+git add src/evaluator.rs
+git commit -m "fix(evaluator): unwrap lingering tuple wrapper before returning to caller
+
+Closes a latent bug (pre-existing for #, newly reachable for @/%): a bare
+tuple-producing expression at the top level previously leaked
+{\"@\":...,\"__tuple__\":true} wrapper objects into user-visible output."
+```
+
+---
+
+### Task 8: Test suite integration and xfail removal
+
+**Files:**
+- Create: `tests/parent_and_focus_binding_suite.rs` (sibling to `tests/datetime_picture_suite.rs`)
+- Modify: `tests/python/test_reference_suite.py` (remove the 65 `parent-operator`/`joins` xfail entries and the two `_XFAIL_PHASE_BY_GROUP` keys)
+- Modify: `README.md`, `docs/index.md` (pass-count claims)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-7.
+- Produces: the final green reference-suite state.
+
+- [ ] **Step 1: Create the cargo integration test harness**
+
+Copy the structure of `tests/datetime_picture_suite.rs` (its `run_case`/`error_message`/`run_group_file` helpers are generic enough to reuse verbatim — they dispatch on `result`/`undefinedResult`/`code` keys in a test spec, not on anything datetime-specific). Create `tests/parent_and_focus_binding_suite.rs`:
+
+```rust
+// Fast-iteration mirror of the parent-operator/joins reference-suite cases
+// for the %/@ operators, mirroring tests/datetime_picture_suite.rs's
+// structure (see that file for the run_case/run_group_file helpers this
+// duplicates -- kept as a separate file since this isn't datetime-related).
+
+use jsonata_core::{
+    evaluator::{Evaluator, EvaluatorError},
+    parser::parse,
+    value::JValue,
+};
+use serde_json::Value as JsonValue;
+use std::fs;
+use std::path::Path;
+
+fn error_message(e: &EvaluatorError) -> &str {
+    match e {
+        EvaluatorError::TypeError(m) => m,
+        EvaluatorError::ReferenceError(m) => m,
+        EvaluatorError::EvaluationError(m) => m,
+    }
+}
+
+fn resolve_expr(case: &JsonValue, group_dir: &Path) -> Option<String> {
+    if let Some(expr) = case.get("expr").and_then(|e| e.as_str()) {
+        return Some(expr.to_string());
+    }
+    let expr_file = case.get("expr-file").and_then(|e| e.as_str())?;
+    fs::read_to_string(group_dir.join(expr_file)).ok()
+}
+
+fn resolve_data(case: &JsonValue, dataset_dir: &Path) -> JsonValue {
+    if let Some(data) = case.get("data") {
+        return data.clone();
+    }
+    if let Some(dataset) = case.get("dataset").and_then(|d| d.as_str()) {
+        let path = dataset_dir.join(format!("{dataset}.json"));
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(parsed) = serde_json::from_str(&content) {
+                return parsed;
+            }
+        }
+    }
+    JsonValue::Null
+}
+
+fn run_case(case: &JsonValue, group_dir: &Path, dataset_dir: &Path) -> Result<(), String> {
+    let expr = resolve_expr(case, group_dir).ok_or("missing expr/expr-file")?;
+    let data: JValue = resolve_data(case, dataset_dir).into();
+
+    let ast = parse(&expr).map_err(|e| format!("parse error: {e}"))?;
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data);
+
+    if let Some(code) = case.get("code").and_then(|c| c.as_str()) {
+        return match &result {
+            Err(e) => {
+                let msg = error_message(e);
+                if msg.starts_with(code) {
+                    Ok(())
+                } else {
+                    Err(format!("expected code {code}, got error: {msg}"))
+                }
+            }
+            Ok(v) => Err(format!("expected error {code}, got result {v:?}")),
+        };
+    }
+
+    if case.get("undefinedResult").and_then(|b| b.as_bool()) == Some(true) {
+        return match result {
+            Ok(JValue::Undefined) | Ok(JValue::Null) => Ok(()),
+            Ok(other) => Err(format!("expected undefined, got {other:?}")),
+            Err(e) => Err(format!("expected undefined, got error: {e}")),
+        };
+    }
+
+    if let Some(expected) = case.get("result") {
+        return match result {
+            Ok(v) => {
+                let actual = serde_json::to_value(&v)
+                    .map_err(|e| format!("failed to serialize result: {e}"))?;
+                if &actual == expected {
+                    Ok(())
+                } else {
+                    Err(format!("expected {expected}, got {actual}"))
+                }
+            }
+            Err(e) => Err(format!("expected result {expected}, got error: {e}")),
+        };
+    }
+
+    Err("test spec has no expected outcome (result, undefinedResult, or code)".to_string())
+}
+
+fn run_group_file(path: &Path, group_dir: &Path, dataset_dir: &Path) -> (usize, Vec<String>) {
+    let content = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading {path:?}: {e}"));
+    let json: JsonValue =
+        serde_json::from_str(&content).unwrap_or_else(|e| panic!("parsing {path:?}: {e}"));
+    let cases: Vec<&JsonValue> = match &json {
+        JsonValue::Array(arr) => arr.iter().collect(),
+        obj => vec![obj],
+    };
+
+    let mut failures = Vec::new();
+    for (i, case) in cases.iter().enumerate() {
+        if let Err(msg) = run_case(case, group_dir, dataset_dir) {
+            let desc = case
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("");
+            failures.push(format!(
+                "{}[{i}] ({desc}): {msg}",
+                path.file_stem().unwrap().to_string_lossy()
+            ));
+        }
+    }
+    (cases.len(), failures)
+}
+
+fn groups_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/jsonata-js/test/test-suite/groups")
+}
+
+fn dataset_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/jsonata-js/test/test-suite/datasets")
+}
+
+#[test]
+fn parent_operator() {
+    let group_dir = groups_root().join("parent-operator");
+    let (total, failures) = run_group_file(&group_dir.join("parent.json"), &group_dir, &dataset_dir());
+    assert!(
+        failures.is_empty(),
+        "{}/{} failed:\n{}",
+        failures.len(),
+        total,
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn joins() {
+    let group_dir = groups_root().join("joins");
+    let mut all_failures = Vec::new();
+    let mut all_total = 0;
+    for entry in fs::read_dir(&group_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            let (total, failures) = run_group_file(&path, &group_dir, &dataset_dir());
+            all_total += total;
+            all_failures.extend(failures);
+        }
+    }
+    assert!(
+        all_failures.is_empty(),
+        "{}/{} failed:\n{}",
+        all_failures.len(),
+        all_total,
+        all_failures.join("\n")
+    );
+}
+```
+
+- [ ] **Step 2: Run and iterate**
+
+Run: `cargo test --test parent_and_focus_binding_suite`
+Expected: some failures initially. For each failure, read the failing expression, compare against jsonata-js's actual behavior (running it through the submodule's reference implementation if the expected JSON result is ambiguous), and fix the root cause in Tasks 1-7's code rather than special-casing the test. Repeat until both `parent_operator` and `joins` pass.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+cargo test
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+maturin develop --release
+uv run pytest tests/python/test_reference_suite.py -q
+```
+Expected: cargo all green; pytest shows 65 fewer xfails than before this task started (confirm exact before/after counts via `grep -c '"parent-operator/\|"joins/'` against `tests/python/test_reference_suite.py`, same pattern used in Phases 1-2).
+
+- [ ] **Step 4: Remove the xfail entries**
+
+```bash
+sed -i '/"parent-operator\/.*",\?$/d; /"joins\/.*",\?$/d' tests/python/test_reference_suite.py
+```
+
+Then manually remove the two now-empty `_XFAIL_PHASE_BY_GROUP` entries (`"parent-operator": ...` and `"joins": ...`) and update the module docstring's pass/xfail counts (same pattern as Phases 1-2's commits).
+
+- [ ] **Step 5: Update README.md / docs/index.md**
+
+Update the pass-count claims (search for the current numbers via `grep -n "1613\|69 xfail" README.md docs/index.md`) to reflect the new total, and remove `%`/`@`/`joins` from the "pending" gap list, leaving only Phase 5's stragglers.
+
+- [ ] **Step 6: Final full-suite verification and commit**
+
+```bash
+uv run pytest tests/python/ -q
+git add tests/parent_and_focus_binding_suite.rs tests/python/test_reference_suite.py README.md docs/index.md
+git commit -m "test: add %/@ integration suite, remove parent-operator/joins xfails
+
+65 xfail entries removed (28 parent-operator + 37 joins). Updates
+README.md/docs/index.md pass-count claims. Only Phase 5's 4 untriaged
+stragglers (array-constructor, function-distinct, flattening) remain."
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Section 1 (AST/parser) → Tasks 1-2, 4 (IndexBind retirement). Section 2 (ancestor-resolution pass) → Tasks 3-4, 6. Section 3 (runtime unification) → Task 5, 7. Section 4 (error handling) → Tasks 1 (S0214), 3-4 (S0215-S0217 wiring, refined in Task 6). Section 5 (testing) → Task 8, plus unit tests embedded in every task.
+- **Placeholder scan:** one intentional `todo!()` in Task 6 Step 2, explicitly justified (depends on a source re-read that hasn't happened yet) and explicitly required to be resolved before Step 3 — flagged rather than hidden, per the skill's guidance that "no placeholders" means no *vague* content, not that every fact must be pre-known before a large legacy-codebase integration begins.
+- **Type consistency:** `AstNode::Parent` changes shape between Task 1 (unit variant) and Task 4 (carries `String`) — Task 4 Step 2 explicitly calls out updating Task 1's tests for this. `PathStep.ancestor_label`/`focus`/`index_var` names are consistent from Task 2 through Task 7. `evaluate_tuple_path_step`'s signature (Task 5) is used consistently in Task 5 alone (no other task calls it directly).

--- a/docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md
+++ b/docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md
@@ -1,0 +1,189 @@
+# `%` (parent reference) and `@` (focus binding) operators
+
+## Context
+
+This is the deferred Phase 3+4 of
+[`docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md`](2026-07-05-reference-suite-coverage-gap-design.md).
+That spec's original estimate treated `%` (28 cases, `parent-operator` group) and `@`
+(37 cases, `joins` group) as bounded bug fixes ("some expression shapes don't parse",
+"a wrapper object leaks into output"). A pre-implementation investigation (recorded in
+memory as `project_parent_and_at_operators.md`) found instead that **both are completely
+unimplemented at the lexer/AST level**: `@` causes an immediate lexer error, `%` only ever
+tokenizes as binary modulo, and there is no post-parse AST transformation pass of any kind
+in this parser (unlike jsonata-js's `processAST`). That finding is why this was split out
+into its own combined effort rather than bundled into Phases 0-2 (which shipped as the
+`2.1.6` release prep).
+
+Phases 0-2 (reference-suite loader fix, datetime picture-string engine,
+`$formatInteger`/`$parseInteger`) are merged to `main`. The `2.1.6` release itself is on
+hold at the user's request until this effort (and Phase 5's remaining stragglers) also
+land — see Release Line below.
+
+**Reference implementation:** `tests/jsonata-js/src/parser.js` (prefix/infix rules ~L616-847;
+the post-parse pass `processAST`/`seekParent`/`pushAncestry`/`resolveAncestry` ~L937-1235)
+and `tests/jsonata-js/src/jsonata.js` (`evaluate`'s `case 'parent'` ~L83-85;
+`evaluateTupleStep`/`createFrameFromTuple` ~L229-380). All line numbers confirmed by direct
+reading during this design's brainstorming session, not secondhand summary.
+
+## Scope
+
+In scope:
+- `%` (parent-reference operator), including chained `%.%` (two-or-more levels up),
+  working inside plain paths, object-constructor group-by clauses, array constructors,
+  predicates/filters, and sort terms.
+- `@$var` (focus/positional binding), including chained joins (`Account.Order@$o.Product`)
+  and the `S0214`/`S0215`/`S0216` parse-time error cases in `joins/errors.json`.
+- Fixing the existing `#$var` (index-binding) tuple-propagation gap as part of the same
+  runtime mechanism unification (decided in this design; see "Decisions" below) — `#`'s
+  current passing tests must continue to pass unchanged.
+- The single unwrap-at-output-boundary fix that closes the "tuple wrapper leaks into
+  user-visible output" bug class (latent today for `#`, would otherwise be newly reachable
+  for `@`/`%`).
+
+Out of scope:
+- Phase 5 (`array-constructor`, `function-distinct`, `flattening` stragglers) — separate,
+  untriaged, tracked in the parent spec.
+- Any VM/bytecode-compiler support for `%`/`@`/`#` — these fall back to the tree-walker
+  only, matching how Phases 1-2 handled uncompilable constructs (e.g. named-variable
+  lookups already force tree-walker fallback; see `MEMORY.md`'s Phase 2 compiler notes).
+
+## Decisions (from brainstorming Q&A)
+
+1. **Fix the `#` propagation gap as part of this work**, rather than building `%`/`@` on
+   top of a known-buggy mechanism and leaving `#` as-is. The investigation found tuple
+   bindings currently propagate through the `data` value itself rather than the real
+   variable-scope stack (`self.context`), and only get promoted into `self.context` for
+   three specific next-step node types (`Object`/`FunctionApplication`/`Variable`).
+2. **Keep the existing `JValue::Object` tuple-wrapper convention** (`__tuple__`/`@`/`$name`
+   reserved keys), rather than replacing it with a dedicated non-`JValue` Rust-native
+   context structure. This directly mirrors jsonata-js's own design — it also represents
+   tuple bindings as a plain object flowing through the pipeline (`{'@': item, ...}`) *and*
+   builds a real scope frame from that same object (`createFrameFromTuple`) before
+   evaluating each step. Chosen over a bigger refactor (threading a new parameter through
+   dozens of evaluator functions) because it's both lower-risk and more faithful to the
+   reference implementation.
+3. **Aim for full completion of all 69 currently-xfailed cases** (28 `parent-operator` +
+   37 `joins` + 4 Phase-5 stragglers are explicitly *not* included in that 69 — Phase 5
+   stays separate scope) as the bar for this effort, not partial/best-effort coverage.
+
+## Design
+
+### 1. AST & parser changes
+
+- New leaf node `AstNode::Parent(AncestorSlot)` for `%`, where `AncestorSlot` holds a
+  synthetic label (`!0`, `!1`, ...) assigned during the post-parse pass (Section 2) — the
+  node itself is inert at parse time, matching jsonata-js's trivial one-line prefix rule.
+- **Step-level flags, not wrapping nodes.** `#$i`, `@$v`, and `%`'s ancestor-capture are
+  all represented in jsonata-js as flags on the path step itself (`step.index`,
+  `step.focus`, `step.ancestor`, all alongside `step.tuple = true`) — not as nodes that
+  wrap what they bind. This port adds `focus: Option<String>`, `index_var: Option<String>`,
+  `ancestor_label: Option<String>`, and `is_tuple: bool` fields directly on `PathStep`, and
+  **retires `AstNode::IndexBind`** in favor of setting `index_var` on the step it applies
+  to. This is the most invasive part of the design (it touches `#`'s existing, currently
+  passing representation) but is necessary: if `#` keeps a special wrapping node while
+  `@`/`%` use step-level flags, the three can't share one unified tuple mechanism, and
+  Decision 1's propagation fix can't land as a single change.
+- Parser additions: `%` gets a one-line prefix rule (same shape as the existing
+  `Token::Star => AstNode::Wildcard` arm in `parse_primary`); `@` gets a one-line infix
+  rule validating its RHS is a bare variable reference (else `S0214`). Both produce
+  bare/unresolved nodes at this stage — all the real semantic work happens in Section 2,
+  matching jsonata-js's own two-pass split.
+
+### 2. Compile-time ancestor-resolution pass
+
+A new pass (new module, e.g. `src/ast_transform.rs`) runs on the freshly-parsed tree
+before it reaches the evaluator. It is a faithful port of jsonata-js's
+`seekParent`/`pushAncestry`/`resolveAncestry`, adapted to Rust's ownership model: instead
+of mutating tree nodes in place (as the JS does), it **consumes the raw tree and rebuilds
+an enriched one** with Section 1's new fields filled in — same algorithm, immutable
+reconstruction instead of mutate-in-place, the natural Rust adaptation rather than a
+design compromise.
+
+For each path, walking backward from the last step: when a `%` (`AstNode::Parent`) is
+found, locate the step `level` positions back (chained `%.%` increments `level`) and stamp
+*that* step with a synthetic `ancestor_label` and `is_tuple = true` — walking through
+parenthesized `AstNode::Block`s (into their last expression, per the
+`parent000`-`parent006` test shapes, which deliberately wrap different path segments in
+parens to stress exactly this), through predicates and sort terms (mirroring
+`pushAncestry`'s predicate/sort-term entry points), and reusing an existing label when the
+same step already got one from an earlier `%` reference in the same expression (so
+`%.OrderID` and `%.%.\`Account Name\`` sharing an ancestor step share one label, not two).
+
+Errors surface here: `S0217` ("can't derive ancestor") when `%` walks off the front of a
+path into something that isn't a name/wildcard/block/path. Note the
+`Account.Order.().%` test case (`"undefinedResult": true`, not an error) needs
+verification during implementation of exactly where jsonata-js draws this line — `()` is a
+syntactically valid empty step, so the ancestor slot likely still resolves at compile time,
+just evaluates to undefined at runtime because the slot's bound value was never populated
+by an empty step. Confirm against the reference implementation rather than assuming.
+
+### 3. Runtime tuple-binding unification
+
+After Section 1's `IndexBind` migration, a step becomes tuple-producing whenever
+`PathStep.is_tuple` is set — by `@`, `#`, *or* a downstream `%` (Section 2) — so a plain
+`Account.Order.Product` step with no visible binding syntax can still enter the tuple path
+purely because something later needs its ancestor value, exactly matching jsonata-js.
+
+The wrapper stays the existing `JValue::Object` with `__tuple__`/`@`/`$name` keys
+(Decision 2), gaining one more reserved-key convention for ancestor labels (`!0`, `!1`,
+...). The fix (Decision 1): every tuple step unconditionally builds a real scope frame
+from the current tuple dict before evaluating that step's sub-expression — mirroring
+`createFrameFromTuple`, called unconditionally in jsonata-js — replacing the current
+partial promotion that only covers three next-step node types. `%` then resolves via
+ordinary scope lookup of its synthetic label; no special-casing needed at the lookup site
+beyond what `$name` resolution already does.
+
+The "leaks into output" bug closes as a side effect of touching every tuple-step call
+site: add a single unwrap-at-boundary check (top of `Evaluator::evaluate()` and/or the
+`json_to_python` boundary in `src/lib.rs`) that strips a lingering `__tuple__` wrapper
+before it reaches the caller.
+
+### 4. Error handling
+
+Four parse/compile-time error codes must match jsonata-js exactly (`joins/errors.json`
+asserts on them directly):
+
+| Code | Condition |
+|---|---|
+| S0214 | `@`'s RHS isn't a bare variable reference |
+| S0215 | `@` applied to a step that already has predicates/stages defined |
+| S0216 | `@` applied after a sort (`^(...)`) clause |
+| S0217 | `%` can't derive an ancestor |
+
+These map onto a coded error variant the same way Phase 1's `D3130`-`D3136` datetime codes
+did — message starts with the code, so `test_reference_suite.py`'s `extract_error_code`
+picks it up via its `^([TDUS]\d{4}):` prefix match.
+
+### 5. Testing plan
+
+Following the Phase 1/2 pattern: a new cargo integration test file (e.g.
+`tests/parent_and_focus_binding_suite.rs`, sibling to `tests/datetime_picture_suite.rs`)
+runs every case in `parent-operator/parent.json` and every file under `joins/` through the
+full parser+evaluator pipeline, for fast (`cargo test`, seconds) iteration ahead of the
+slower `maturin develop` + `pytest` cycle. Given the "full completion" bar (Decision 3),
+also add targeted Rust unit tests for the ancestor-resolution pass itself (e.g. asserting
+exact label/level bookkeeping for a `%.%` chain through a nested block) — that pass is
+intricate enough to want coverage below the end-to-end/black-box level.
+
+## Definition of done
+
+- All 28 `parent-operator` + 37 `joins` xfail entries removed from
+  `tests/python/test_reference_suite.py` and passing for real.
+- `#$var` (index binding) continues to pass all its existing tests unchanged.
+- No wrapper-leak regressions: a bare tuple-producing expression (any of `%`/`@`/`#`) at
+  the top level of an expression does not leak `__tuple__`/`@`/`$name`/`!N` keys into
+  Python-visible output.
+- `cargo test` (including the new integration suite + new unit tests), `cargo fmt --check`,
+  `cargo clippy --all-targets --all-features -- -D warnings` all clean.
+- `uv run pytest tests/python/test_reference_suite.py` shows only the 4 Phase-5-straggler
+  xfails remaining (69 → 4), full suite has no new failures elsewhere.
+- README.md / docs/index.md pass-count claims updated to match.
+
+## Release line
+
+Per the user's decision earlier in this session, the `2.1.6` release (Phases 0-2, already
+merged and CI-green) is held until this effort and Phase 5 both land, then ships together
+in one release rather than as separate point releases. If Phase 5 turns out to be
+significantly delayed relative to this effort once both are scoped, revisit whether to
+split them into `2.1.6`/`2.1.7` instead — not decided now, since Phase 5 hasn't been
+triaged yet.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -137,6 +137,11 @@ pub enum AstNode {
     /// Descendant operator (**) in path expressions
     Descendant,
 
+    /// Parent-reference operator (%) in path expressions
+    /// Resolved to a specific ancestor slot by the post-parse ast_transform pass;
+    /// unit variant at parse time, matching jsonata-js's bare `{type: 'parent'}`.
+    Parent,
+
     /// Array filter/predicate [condition]
     /// Can be an index (number) or a predicate (boolean expression)
     Predicate(Box<AstNode>),
@@ -217,6 +222,11 @@ pub enum BinaryOp {
 
     // Variable binding
     ColonEqual, // :=
+
+    // Focus binding (raw parse-time marker for @$var; resolved into a
+    // PathStep.focus flag by ast_transform, matching jsonata-js's own
+    // parser.js:834-847, which also produces a generic binary node here)
+    FocusBind,
 
     // Coalescing
     Coalesce, // ??

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -23,6 +23,24 @@ pub struct PathStep {
     pub node: AstNode,
     /// Stages to apply during this step (e.g., predicates)
     pub stages: Vec<Stage>,
+    /// Set by `@$var` (focus binding): binds the step's per-element value to
+    /// this variable name (without the `$` prefix) during tuple-stream
+    /// evaluation. Mirrors jsonata-js's `step.focus`.
+    pub focus: Option<String>,
+    /// Set by `#$var` (index binding): binds the step's per-element index to
+    /// this variable name (without the `$` prefix). Mirrors jsonata-js's
+    /// `step.index`. Replaces the retired `AstNode::IndexBind` wrapping node.
+    pub index_var: Option<String>,
+    /// Set by ast_transform when a later `%` reference needs this step's
+    /// *input* value preserved. The label is synthetic (e.g. "!0", "!1", ...)
+    /// and used as a tuple-dict key at runtime. Mirrors jsonata-js's
+    /// `step.ancestor.label`.
+    pub ancestor_label: Option<String>,
+    /// True when this step must participate in tuple-stream evaluation
+    /// (because of its own `focus`/`index_var`/`ancestor_label`, or because
+    /// an earlier step in the same path already entered tuple-stream mode).
+    /// Mirrors jsonata-js's `step.tuple`.
+    pub is_tuple: bool,
 }
 
 /// AST Node types
@@ -254,12 +272,23 @@ impl PathStep {
         PathStep {
             node,
             stages: Vec::new(),
+            focus: None,
+            index_var: None,
+            ancestor_label: None,
+            is_tuple: false,
         }
     }
 
     /// Create a path step with stages
     pub fn with_stages(node: AstNode, stages: Vec<Stage>) -> Self {
-        PathStep { node, stages }
+        PathStep {
+            node,
+            stages,
+            focus: None,
+            index_var: None,
+            ancestor_label: None,
+            is_tuple: false,
+        }
     }
 }
 
@@ -322,5 +351,14 @@ mod tests {
             rhs: Box::new(AstNode::number(2.0)),
         };
         assert!(matches!(node, AstNode::Binary { .. }));
+    }
+
+    #[test]
+    fn test_path_step_new_defaults_new_fields_to_none() {
+        let step = PathStep::new(AstNode::Name("foo".to_string()));
+        assert_eq!(step.focus, None);
+        assert_eq!(step.index_var, None);
+        assert_eq!(step.ancestor_label, None);
+        assert!(!step.is_tuple);
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,6 +11,12 @@ use serde::{Deserialize, Serialize};
 pub enum Stage {
     /// Filter/predicate stage [expr]
     Filter(Box<AstNode>),
+    /// Positional index stage `#$var` that lands on a step already carrying an
+    /// index/stages (jsonata-js's `{type: 'index', value}` stage). Binds the
+    /// variable to each surviving tuple's position in the CURRENT (post-earlier-
+    /// stages) result, so e.g. `books@$b#$ib[$l.isbn=$b.isbn]#$ib2` gives `$ib`
+    /// the pre-filter book position and `$ib2` the post-filter position.
+    Index(String),
 }
 
 /// A step in a path expression with optional stages

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -155,10 +155,13 @@ pub enum AstNode {
     /// Descendant operator (**) in path expressions
     Descendant,
 
-    /// Parent-reference operator (%) in path expressions
-    /// Resolved to a specific ancestor slot by the post-parse ast_transform pass;
-    /// unit variant at parse time, matching jsonata-js's bare `{type: 'parent'}`.
-    Parent,
+    /// Parent-reference operator (%) in path expressions, resolved.
+    /// Carries the synthetic ancestor label ("!0", "!1", ...) assigned by
+    /// ast_transform -- looked up at runtime via the same tuple/scope
+    /// mechanism as $-variables. The parser produces `Parent(String::new())`
+    /// (an empty placeholder never observed by the evaluator); ast_transform
+    /// fills every occurrence with a real label or raises S0217.
+    Parent(String),
 
     /// Array filter/predicate [condition]
     /// Can be an index (number) or a predicate (boolean expression)
@@ -180,16 +183,6 @@ pub enum AstNode {
         input: Box<AstNode>,
         /// Sort terms - list of (expression, ascending) tuples
         terms: Vec<(AstNode, bool)>,
-    },
-
-    /// Index binding operator #$var
-    /// Binds the current array index to the specified variable during path traversal
-    /// For example: arr#$i.field binds the index to $i for each element
-    IndexBind {
-        /// The input expression being indexed
-        input: Box<AstNode>,
-        /// The variable name to bind the index to (without the $ prefix)
-        variable: String,
     },
 
     /// Transform operator |location|update[,delete]|
@@ -245,6 +238,14 @@ pub enum BinaryOp {
     // PathStep.focus flag by ast_transform, matching jsonata-js's own
     // parser.js:834-847, which also produces a generic binary node here)
     FocusBind,
+
+    // Index binding (raw parse-time marker for #$var; resolved into a
+    // PathStep.index_var flag by ast_transform). Reuses the same generic
+    // Binary-node representation as FocusBind (rather than a dedicated
+    // `AstNode::IndexBind` struct variant) so the retired `IndexBind`
+    // variant has zero remaining construction sites once removed from
+    // ast.rs -- see Task 4's ast_transform.rs migrate_binding_markers.
+    IndexBind,
 
     // Coalescing
     Coalesce, // ??

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -345,6 +345,26 @@ fn splice_marker_steps(
     let Transformed { node, pending } = transformed;
     let steps = match node {
         AstNode::Path { mut steps } => {
+            // Our parser encodes `$[[1..4]]` (and any `expr[pred]`) as a separate
+            // trailing `Predicate` step rather than a step carrying the predicate
+            // as a `stage` (as jsonata-js does). For an index marker, mirror
+            // jsonata's `#` case (parser.js ~L1206-1223: when the target step
+            // already has stages, PUSH an index stage) by folding those trailing
+            // predicate pseudo-steps into the preceding real step's stages, then
+            // stamping the index on that step. This makes `$[[1..4]]#$pos[$pos>=2]`
+            // apply the `[[1..4]]` filter, then number the survivors, then filter
+            // by `$pos` -- rather than crashing on a `Predicate` step node in
+            // create_tuple_stream.
+            if matches!(marker, BindingMarker::Index(_)) {
+                while steps.len() >= 2
+                    && matches!(steps.last().map(|s| &s.node), Some(AstNode::Predicate(_)))
+                {
+                    let pred = steps.pop().unwrap();
+                    if let AstNode::Predicate(inner) = pred.node {
+                        steps.last_mut().unwrap().stages.push(Stage::Filter(inner));
+                    }
+                }
+            }
             if let Some(last) = steps.last_mut() {
                 check_focus_bind_target(&marker, &last.stages, &last.node)?;
                 apply_marker_to_step(last, marker);

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -888,6 +888,51 @@ fn walk_backward(
             return Ok(level);
         }
         index -= 1;
+        // Skip filter-predicate pseudo-steps: our parser encodes `@$v[pred]`
+        // and standalone `foo[pred]` chained after a marker as a separate
+        // `Predicate` step, whereas jsonata-js carries the predicate as a
+        // `stage` on the owning step (so it never appears as a distinct step in
+        // resolveAncestry). A predicate is a filter, never an ancestor target,
+        // so the backward ancestry walk steps over it -- without this, a `%`
+        // after `books@$B[$L.isbn=$B.isbn]` hits the predicate step and wrongly
+        // reports S0217.
+        //
+        // Then skip over a run of contiguous focus-bound (`@$var`) steps,
+        // treating them as a SINGLE ancestor hop -- mirrors jsonata-js
+        // resolveAncestry (parser.js ~L1023-1025): `while(index >= 0 &&
+        // step.focus && path.steps[index].focus) { step = path.steps[index--] }`.
+        // Because our extra `Predicate` steps sit between the focus steps (which
+        // in jsonata are adjacent, the predicates being stages), the
+        // focus-contiguity test must look through those predicate steps to the
+        // previous REAL navigation step. So in
+        // `library.loans@$L.books@$B[...].customers@$C[...].{ $keys(%.%) }` all
+        // three focus steps collapse into one hop and `%.%` reaches the root.
+        loop {
+            while index > 0 && matches!(steps[index].node, AstNode::Predicate(_)) {
+                index -= 1;
+            }
+            // Locate the previous non-predicate step (if any) to test contiguity.
+            let mut prev = None;
+            if index > 0 {
+                let mut j = index - 1;
+                loop {
+                    if !matches!(steps[j].node, AstNode::Predicate(_)) {
+                        prev = Some(j);
+                        break;
+                    }
+                    if j == 0 {
+                        break;
+                    }
+                    j -= 1;
+                }
+            }
+            match prev {
+                Some(p) if steps[index].focus.is_some() && steps[p].focus.is_some() => {
+                    index = p;
+                }
+                _ => break,
+            }
+        }
         level = seek_parent_step(&mut steps[index], label, level, state)?;
     }
     Ok(0)

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -4,7 +4,7 @@
 // model: instead of mutating tree nodes in place, this consumes the raw
 // tree and rebuilds an enriched one with ancestor/tuple metadata resolved.
 
-use crate::ast::{AstNode, BinaryOp, PathStep};
+use crate::ast::{AstNode, BinaryOp, PathStep, Stage};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -134,6 +134,21 @@ fn substitute_labels(node: AstNode, state: &AncestryState) -> AstNode {
                 .into_iter()
                 .map(|s| PathStep {
                     node: substitute_labels(s.node, state),
+                    // Stages (predicates) can contain `%` references whose
+                    // labels were aliased during resolution (e.g. a second
+                    // predicate reusing a step an earlier one already tagged),
+                    // so they must be substituted too -- otherwise the
+                    // pre-alias label survives and evaluates against the wrong
+                    // tuple key.
+                    stages: s
+                        .stages
+                        .into_iter()
+                        .map(|st| match st {
+                            Stage::Filter(e) => {
+                                Stage::Filter(Box::new(substitute_labels(*e, state)))
+                            }
+                        })
+                        .collect(),
                     ..s
                 })
                 .collect(),
@@ -620,25 +635,55 @@ fn transform_children(
             })
         }
         AstNode::Sort { input, terms } => {
-            // Structural transform + generic pending bubbling only.
-            // Deliberately NOT integrating Sort as a resolvable step against
-            // EARLIER steps of its own `input` path (jsonata-js's '^' case
-            // pushes a synthetic sortStep onto input's own steps list and
-            // re-runs resolveAncestry on the combined path) -- that
-            // sort-term-specific ancestor resolution is Task 6 scope. Here,
-            // a `%` inside a sort term simply bubbles up as this Sort node's
-            // own pending, same as any other composite node's children.
+            // Mirrors jsonata-js's `case '^'` (parser.js ~L1151-1170): the
+            // sort is modeled as a synthetic `sort` step APPENDED to the
+            // input path, each term's own seeking `%` slots are bubbled onto
+            // it, then resolveAncestry walks them backward. Because the sort
+            // step sits after every input step, resolveAncestry starts at the
+            // step BEFORE it -- i.e. the LAST real input step -- so a level-1
+            // term slot resolves against the last input step (no predicate-
+            // style "resolve against the step itself" special case is needed;
+            // it's a plain uniform backward walk over the input steps).
             let input_t = transform_node(*input, state)?;
+            let was_path = matches!(input_t.node, AstNode::Path { .. });
+            // jsonata wraps a non-path input into a single-step path so the
+            // sort step has something to walk back through. We do the same for
+            // the walk, then unwrap again if nothing tagged the wrapped step.
+            let mut steps = match input_t.node {
+                AstNode::Path { steps } => steps,
+                other => vec![PathStep::new(other)],
+            };
             let mut pending = input_t.pending;
             let mut transformed_terms = Vec::with_capacity(terms.len());
             for (expr, asc) in terms {
                 let t = transform_node(expr, state)?;
-                pending.extend(t.pending);
+                for slot in t.pending {
+                    let remaining = walk_backward(&mut steps, &slot.label, slot.level, state)?;
+                    if remaining > 0 {
+                        pending.push(PendingAncestor {
+                            label: slot.label,
+                            level: remaining,
+                        });
+                    }
+                }
                 transformed_terms.push((t.node, asc));
             }
+            let input_node = if was_path {
+                AstNode::Path { steps }
+            } else {
+                // Single-node input: keep it wrapped only if a sort term
+                // actually tagged it (so the ancestor label survives on a
+                // PathStep); otherwise restore the bare node unchanged.
+                let s = steps.pop().expect("single wrapped step");
+                if s.is_tuple || s.ancestor_label.is_some() {
+                    AstNode::Path { steps: vec![s] }
+                } else {
+                    s.node
+                }
+            };
             Ok(Transformed {
                 node: AstNode::Sort {
-                    input: Box::new(input_t.node),
+                    input: Box::new(input_node),
                     terms: transformed_terms,
                 },
                 pending,
@@ -723,12 +768,33 @@ fn transform_path_steps(
     // ancestor resolution should walk backward from.
     let mut resolved: Vec<PathStep> = Vec::with_capacity(steps.len());
     let mut own_pending: Vec<Vec<PendingAncestor>> = Vec::with_capacity(steps.len());
+    // `pred_pending[i]` holds the seeking `%` slots bubbled up from step i's
+    // own filter predicate(s) (`Stage::Filter`), transformed here so a `%`
+    // inside `Product[%.OrderID=...]` is resolved (was previously left
+    // untouched, since stages weren't recursed into). Transformed AFTER the
+    // step's node so the step's OWN `%`-ness (if any) claims a label first,
+    // matching jsonata-js's slot-creation order.
+    let mut pred_pending: Vec<Vec<PendingAncestor>> = Vec::with_capacity(steps.len());
     for step in steps {
         let (spliced, pending) = migrate_binding_markers(step, state)?;
         let last_idx = spliced.len().saturating_sub(1);
         let mut pending_opt = Some(pending);
-        for (i, s) in spliced.into_iter().enumerate() {
+        for (i, mut s) in spliced.into_iter().enumerate() {
+            let mut pp: Vec<PendingAncestor> = Vec::new();
+            let stages = std::mem::take(&mut s.stages);
+            let mut new_stages = Vec::with_capacity(stages.len());
+            for stage in stages {
+                match stage {
+                    Stage::Filter(expr) => {
+                        let t = transform_node(*expr, state)?;
+                        pp.extend(t.pending);
+                        new_stages.push(Stage::Filter(Box::new(t.node)));
+                    }
+                }
+            }
+            s.stages = new_stages;
             resolved.push(s);
+            pred_pending.push(pp);
             if i == last_idx {
                 own_pending.push(pending_opt.take().unwrap_or_default());
             } else {
@@ -737,12 +803,23 @@ fn transform_path_steps(
         }
     }
 
-    // Pass 2: for each step (in ascending/encounter order) with its own
-    // pending, walk backward through the steps BEFORE it, resolving each
-    // pending reference. Any reference that runs off the front of this path
-    // (never finding a target) bubbles up as this whole Path's own pending.
+    // Pass 2: for each step (in ascending/encounter order), resolve first its
+    // predicate slots (mirroring jsonata-js pushing predicate slots onto the
+    // step's seekingParent BEFORE the step's own slot), then its own pending.
+    // Any reference that runs off the front of this path (never finding a
+    // target) bubbles up as this whole Path's own pending.
     let mut path_pending: Vec<PendingAncestor> = Vec::new();
     for i in 0..resolved.len() {
+        for pending in std::mem::take(&mut pred_pending[i]) {
+            let remaining =
+                resolve_predicate_slot(&mut resolved, i, &pending.label, pending.level, state)?;
+            if remaining > 0 {
+                path_pending.push(PendingAncestor {
+                    label: pending.label,
+                    level: remaining,
+                });
+            }
+        }
         let pending_here = std::mem::take(&mut own_pending[i]);
         for pending in pending_here {
             let remaining =
@@ -757,6 +834,40 @@ fn transform_path_steps(
     }
 
     Ok((resolved, path_pending))
+}
+
+/// Resolve one seeking `%` slot that bubbled up out of a filter predicate
+/// attached to step `i`. Mirrors jsonata-js's `case '['` slot handling
+/// (parser.js ~L1119-1128):
+/// - a `level == 1` slot resolves against the attached step ITSELF first
+///   (`seekParent(step, slot)`): a `name`/`wildcard` step gets tagged; a `%`
+///   (parent) step instead bumps the level and the walk continues backward;
+/// - a `level > 1` slot is decremented (the attached step is skipped, never
+///   tagged) and resolved by walking backward through the steps BEFORE it.
+///
+/// Either way, whatever level remains unresolved is walked backward through
+/// `resolved[..i]`; the leftover (if the reference runs off the path front)
+/// is returned to bubble up as the enclosing path's own pending.
+fn resolve_predicate_slot(
+    resolved: &mut [PathStep],
+    i: usize,
+    label: &str,
+    level: usize,
+    state: &mut AncestryState,
+) -> Result<usize, AstTransformError> {
+    // Split so the attached step (`rest[0]`) and the steps before it
+    // (`prefix`) can be borrowed mutably at the same time.
+    let (prefix, rest) = resolved.split_at_mut(i);
+    let remaining = if level == 1 {
+        seek_parent_step(&mut rest[0], label, 1, state)?
+    } else {
+        level - 1
+    };
+    if remaining == 0 {
+        Ok(0)
+    } else {
+        walk_backward(prefix, label, remaining, state)
+    }
 }
 
 /// Walk backward through `steps` (from its last element) trying to resolve
@@ -919,7 +1030,252 @@ fn migrate_binding_markers(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::Stage;
+
+    // --- Task 6: `%` inside filter predicates and sort terms ---
+    //
+    // Mechanism ported from jsonata-js processAST (parser.js). Ground truth
+    // for every tag target below was dumped from jsonata-js's own `.ast()`
+    // (via `node -e 'jsonata(expr).ast()'` in tests/jsonata-js).
+    //
+    // PREDICATE (`case '['`, parser.js ~L1097-1130): each slot the predicate
+    // is still seeking is examined -- a level-1 slot resolves against the
+    // STEP the predicate is attached to (`seekParent(step, slot)`, which tags
+    // that step, or bumps the level if the step is itself a `%`); a level>N>1
+    // slot is decremented and then resolved by walking backward through the
+    // steps BEFORE the attached step. In our flat-path model this is: for a
+    // predicate slot on step i, level==1 -> seek_parent_step(resolved[i]);
+    // level>1 -> walk_backward(resolved[..i], level-1).
+    //
+    // SORT (`case '^'`, parser.js ~L1151-1170): jsonata appends a synthetic
+    // `sort` step to the input path, bubbles every term's own seeking slots
+    // onto it, then runs resolveAncestry -- which walks backward starting at
+    // the step BEFORE the sort step, i.e. the LAST real input step. So a
+    // level-1 sort-term slot resolves against the last input step (no
+    // predicate-style "attach to the step itself" special case is needed;
+    // it's a uniform backward walk over the input steps).
+
+    // Helper: locate the ancestor_label a resolved path assigns to a given
+    // step index, panicking with context if the shape is wrong.
+    fn resolve_path(expr: &str) -> Vec<PathStep> {
+        let ast = crate::parser::Parser::new(expr.to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        match resolve_ancestry(ast).unwrap() {
+            AstNode::Path { steps } => steps,
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parent_inside_predicate_resolves_against_enclosing_step() {
+        // Account.Order.Product[%.OrderID='order104'].SKU
+        // Ground truth (jsonata-js .ast()): the `%` inside the predicate
+        // tags the Product step (steps[2]) -- i.e. `%` resolves to Product's
+        // own input (Order), and Product itself carries the ancestor label.
+        let steps = resolve_path("Account.Order.Product[%.OrderID='order104'].SKU");
+        assert_eq!(steps.len(), 4);
+        assert!(matches!(steps[2].node, AstNode::Name(ref n) if n == "Product"));
+        let product_label = steps[2].ancestor_label.clone();
+        assert!(product_label.is_some(), "Product must be tagged");
+        assert!(steps[2].is_tuple);
+        assert!(
+            steps[1].ancestor_label.is_none(),
+            "Order must NOT be tagged"
+        );
+        // The `%` inside the predicate must carry Product's label.
+        match &steps[2].stages[0] {
+            Stage::Filter(expr) => match expr.as_ref() {
+                AstNode::Binary { lhs, .. } => match lhs.as_ref() {
+                    AstNode::Path { steps: inner } => match &inner[0].node {
+                        AstNode::Parent(label) => {
+                            assert_eq!(Some(label.clone()), product_label)
+                        }
+                        other => panic!("expected Parent, got {:?}", other),
+                    },
+                    other => panic!("expected inner Path, got {:?}", other),
+                },
+                other => panic!("expected Binary, got {:?}", other),
+            },
+        }
+    }
+
+    #[test]
+    fn test_parent_chain_inside_predicate_resolves_two_levels() {
+        // Account.Order.Product[%.%.`Account Name`='Firefly'].SKU
+        // Ground truth: first `%` tags Product (steps[2]), second `%` tags
+        // Order (steps[1]).
+        let steps = resolve_path("Account.Order.Product[%.%.`Account Name`='Firefly'].SKU");
+        assert_eq!(steps.len(), 4);
+        let product_label = steps[2].ancestor_label.clone();
+        let order_label = steps[1].ancestor_label.clone();
+        assert!(product_label.is_some(), "Product must be tagged");
+        assert!(order_label.is_some(), "Order must be tagged");
+        assert_ne!(product_label, order_label);
+        match &steps[2].stages[0] {
+            Stage::Filter(expr) => match expr.as_ref() {
+                AstNode::Binary { lhs, .. } => match lhs.as_ref() {
+                    AstNode::Path { steps: inner } => {
+                        // inner = [Parent, Parent, Name("Account Name")]
+                        match &inner[0].node {
+                            AstNode::Parent(l) => assert_eq!(Some(l.clone()), product_label),
+                            other => panic!("expected Parent, got {:?}", other),
+                        }
+                        match &inner[1].node {
+                            AstNode::Parent(l) => assert_eq!(Some(l.clone()), order_label),
+                            other => panic!("expected Parent, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected inner Path, got {:?}", other),
+                },
+                other => panic!("expected Binary, got {:?}", other),
+            },
+        }
+    }
+
+    #[test]
+    fn test_parent_predicate_on_parent_step_itself() {
+        // Account.Order.Product.Price.%[%.OrderID='order103'].SKU
+        // Ground truth: the trailing `.%` step's own reference tags Price
+        // (steps[3]); the predicate's `%` (attached to a `%` step, so bumped
+        // one level) tags Product (steps[2]).
+        let steps = resolve_path("Account.Order.Product.Price.%[%.OrderID='order103'].SKU");
+        // [Account, Order, Product, Price, %(stages), SKU]
+        assert_eq!(steps.len(), 6);
+        assert!(matches!(steps[4].node, AstNode::Parent(_)));
+        let price_label = steps[3].ancestor_label.clone();
+        let product_label = steps[2].ancestor_label.clone();
+        assert!(
+            price_label.is_some(),
+            "Price must be tagged (by the % step)"
+        );
+        assert!(
+            product_label.is_some(),
+            "Product must be tagged (by the predicate %)"
+        );
+        assert_ne!(price_label, product_label);
+    }
+
+    #[test]
+    fn test_two_predicates_share_and_differ_labels() {
+        // Account.Order.Product[%.OrderID='order104'][%.%.`Account Name`='Firefly'].SKU
+        // Ground truth: first predicate's `%` -> Product; second predicate's
+        // first `%` -> Product (REUSE same label); second `%` -> Order.
+        let steps = resolve_path(
+            "Account.Order.Product[%.OrderID='order104'][%.%.`Account Name`='Firefly'].SKU",
+        );
+        assert_eq!(steps.len(), 4);
+        assert_eq!(steps[2].stages.len(), 2);
+        let product_label = steps[2].ancestor_label.clone();
+        let order_label = steps[1].ancestor_label.clone();
+        assert!(product_label.is_some());
+        assert!(order_label.is_some());
+        assert_ne!(product_label, order_label);
+        // first predicate: %  -> Product
+        match &steps[2].stages[0] {
+            Stage::Filter(expr) => match expr.as_ref() {
+                AstNode::Binary { lhs, .. } => match lhs.as_ref() {
+                    AstNode::Path { steps: inner } => match &inner[0].node {
+                        AstNode::Parent(l) => assert_eq!(Some(l.clone()), product_label),
+                        other => panic!("{:?}", other),
+                    },
+                    other => panic!("{:?}", other),
+                },
+                other => panic!("{:?}", other),
+            },
+        }
+        // second predicate: %.% -> Product (reuse), Order
+        match &steps[2].stages[1] {
+            Stage::Filter(expr) => match expr.as_ref() {
+                AstNode::Binary { lhs, .. } => match lhs.as_ref() {
+                    AstNode::Path { steps: inner } => {
+                        match &inner[0].node {
+                            AstNode::Parent(l) => assert_eq!(Some(l.clone()), product_label),
+                            other => panic!("{:?}", other),
+                        }
+                        match &inner[1].node {
+                            AstNode::Parent(l) => assert_eq!(Some(l.clone()), order_label),
+                            other => panic!("{:?}", other),
+                        }
+                    }
+                    other => panic!("{:?}", other),
+                },
+                other => panic!("{:?}", other),
+            },
+        }
+    }
+
+    #[test]
+    fn test_parent_inside_sort_term_resolves_to_last_input_step() {
+        // Account.Order.Product.SKU^(%.Price)
+        // Ground truth: the sort term's `%` tags SKU (the last input step).
+        let ast = crate::parser::Parser::new("Account.Order.Product.SKU^(%.Price)".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        match resolve_ancestry(ast).unwrap() {
+            AstNode::Sort { input, terms } => {
+                let steps = match input.as_ref() {
+                    AstNode::Path { steps } => steps,
+                    other => panic!("expected Path input, got {:?}", other),
+                };
+                assert_eq!(steps.len(), 4);
+                assert!(matches!(steps[3].node, AstNode::Name(ref n) if n == "SKU"));
+                let sku_label = steps[3].ancestor_label.clone();
+                assert!(sku_label.is_some(), "SKU must be tagged");
+                // term = (Path[Parent, Name("Price")], asc)
+                match &terms[0].0 {
+                    AstNode::Path { steps: inner } => match &inner[0].node {
+                        AstNode::Parent(l) => assert_eq!(Some(l.clone()), sku_label),
+                        other => panic!("{:?}", other),
+                    },
+                    other => panic!("{:?}", other),
+                }
+            }
+            other => panic!("expected Sort, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_two_sort_terms_share_and_differ_labels() {
+        // Account.Order.Product.SKU^(%.Price, >%.%.OrderID)
+        // Ground truth: term1 `%` -> SKU; term2 `%.%` -> SKU (reuse), Product.
+        let ast = crate::parser::Parser::new(
+            "Account.Order.Product.SKU^(%.Price, >%.%.OrderID)".to_string(),
+        )
+        .unwrap()
+        .parse()
+        .unwrap();
+        match resolve_ancestry(ast).unwrap() {
+            AstNode::Sort { input, terms } => {
+                let steps = match input.as_ref() {
+                    AstNode::Path { steps } => steps,
+                    other => panic!("{:?}", other),
+                };
+                let sku_label = steps[3].ancestor_label.clone();
+                let product_label = steps[2].ancestor_label.clone();
+                assert!(sku_label.is_some());
+                assert!(product_label.is_some());
+                assert_ne!(sku_label, product_label);
+                assert_eq!(terms.len(), 2);
+                // term2 = %.%.OrderID
+                match &terms[1].0 {
+                    AstNode::Path { steps: inner } => {
+                        match &inner[0].node {
+                            AstNode::Parent(l) => assert_eq!(Some(l.clone()), sku_label),
+                            other => panic!("{:?}", other),
+                        }
+                        match &inner[1].node {
+                            AstNode::Parent(l) => assert_eq!(Some(l.clone()), product_label),
+                            other => panic!("{:?}", other),
+                        }
+                    }
+                    other => panic!("{:?}", other),
+                }
+            }
+            other => panic!("expected Sort, got {:?}", other),
+        }
+    }
 
     #[test]
     fn test_focus_bind_becomes_step_flag() {

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -147,6 +147,7 @@ fn substitute_labels(node: AstNode, state: &AncestryState) -> AstNode {
                             Stage::Filter(e) => {
                                 Stage::Filter(Box::new(substitute_labels(*e, state)))
                             }
+                            Stage::Index(v) => Stage::Index(v),
                         })
                         .collect(),
                     ..s
@@ -367,7 +368,16 @@ fn splice_marker_steps(
             }
             if let Some(last) = steps.last_mut() {
                 check_focus_bind_target(&marker, &last.stages, &last.node)?;
-                apply_marker_to_step(last, marker);
+                // A SECOND index binding on the same step (e.g. `books#$ib[...]#$ib2`)
+                // must not overwrite the first: append it as an ordered index
+                // stage so it numbers the post-filter positions (jsonata's `#`
+                // case pushing an index stage when the step already has one).
+                if let (BindingMarker::Index(var), true) = (&marker, last.index_var.is_some()) {
+                    last.stages.push(Stage::Index(var.clone()));
+                    last.is_tuple = true;
+                } else {
+                    apply_marker_to_step(last, marker);
+                }
             }
             steps
         }
@@ -810,6 +820,9 @@ fn transform_path_steps(
                         pp.extend(t.pending);
                         new_stages.push(Stage::Filter(Box::new(t.node)));
                     }
+                    // Index stages carry only a variable name -- nothing to
+                    // resolve/transform.
+                    Stage::Index(v) => new_stages.push(Stage::Index(v)),
                 }
             }
             s.stages = new_stages;
@@ -1159,6 +1172,7 @@ mod tests {
         );
         // The `%` inside the predicate must carry Product's label.
         match &steps[2].stages[0] {
+            Stage::Index(_) => unreachable!("no index stage in this test"),
             Stage::Filter(expr) => match expr.as_ref() {
                 AstNode::Binary { lhs, .. } => match lhs.as_ref() {
                     AstNode::Path { steps: inner } => match &inner[0].node {
@@ -1187,6 +1201,7 @@ mod tests {
         assert!(order_label.is_some(), "Order must be tagged");
         assert_ne!(product_label, order_label);
         match &steps[2].stages[0] {
+            Stage::Index(_) => unreachable!("no index stage in this test"),
             Stage::Filter(expr) => match expr.as_ref() {
                 AstNode::Binary { lhs, .. } => match lhs.as_ref() {
                     AstNode::Path { steps: inner } => {
@@ -1247,6 +1262,7 @@ mod tests {
         assert_ne!(product_label, order_label);
         // first predicate: %  -> Product
         match &steps[2].stages[0] {
+            Stage::Index(_) => unreachable!("no index stage in this test"),
             Stage::Filter(expr) => match expr.as_ref() {
                 AstNode::Binary { lhs, .. } => match lhs.as_ref() {
                     AstNode::Path { steps: inner } => match &inner[0].node {
@@ -1260,6 +1276,7 @@ mod tests {
         }
         // second predicate: %.% -> Product (reuse), Order
         match &steps[2].stages[1] {
+            Stage::Index(_) => unreachable!("no index stage in this test"),
             Stage::Filter(expr) => match expr.as_ref() {
                 AstNode::Binary { lhs, .. } => match lhs.as_ref() {
                     AstNode::Path { steps: inner } => {

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -1,0 +1,237 @@
+// Post-parse AST transformation pass.
+// Mirrors parser.js's processAST/seekParent/pushAncestry/resolveAncestry
+// (tests/jsonata-js/src/parser.js ~L937-1235), adapted to Rust's ownership
+// model: instead of mutating tree nodes in place, this consumes the raw
+// tree and rebuilds an enriched one with ancestor/tuple metadata resolved.
+
+use crate::ast::{AstNode, BinaryOp, PathStep};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AstTransformError {
+    #[error("{code}: {message}")]
+    Coded { code: &'static str, message: String },
+}
+
+fn coded(code: &'static str, message: impl Into<String>) -> AstTransformError {
+    AstTransformError::Coded {
+        code,
+        message: message.into(),
+    }
+}
+
+/// Monotonic counters for synthetic ancestor labels ("!0", "!1", ...),
+/// mirroring jsonata-js's module-level `ancestorLabel`/`ancestorIndex`
+/// counters. Threaded explicitly through the pass rather than using global
+/// mutable state, since Rust doesn't have JS's implicit module-scope `var`.
+///
+/// Not yet consumed: this task's scope stops at single-step `@`/`#`
+/// migration and top-level bare-`%` detection, neither of which needs a
+/// fresh label. `fresh_label` is wired up by Task 4's `%`/`%.%` chain
+/// resolution (`pushAncestry`/`resolveAncestry`), which is the reason this
+/// struct is threaded through `transform_node` already.
+#[allow(dead_code)]
+struct LabelGen {
+    next_label: usize,
+}
+
+impl LabelGen {
+    fn new() -> Self {
+        LabelGen { next_label: 0 }
+    }
+
+    #[allow(dead_code)]
+    fn fresh_label(&mut self) -> String {
+        let label = format!("!{}", self.next_label);
+        self.next_label += 1;
+        label
+    }
+}
+
+/// Entry point: resolve all ancestor references in a freshly-parsed AST.
+pub fn resolve_ancestry(ast: AstNode) -> Result<AstNode, AstTransformError> {
+    let mut labels = LabelGen::new();
+    transform_node(ast, &mut labels)
+}
+
+/// Recursively rebuild `node`, resolving any `%`/`@`/`#` found within.
+/// Mirrors jsonata-js's processAST's generic per-node-type dispatch.
+fn transform_node(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
+    match node {
+        AstNode::Path { steps } => {
+            let transformed_steps = transform_path_steps(steps, labels)?;
+            Ok(AstNode::Path {
+                steps: transformed_steps,
+            })
+        }
+        AstNode::Block(exprs) => {
+            let transformed: Result<Vec<AstNode>, AstTransformError> = exprs
+                .into_iter()
+                .map(|e| transform_node(e, labels))
+                .collect();
+            Ok(AstNode::Block(transformed?))
+        }
+        // Parent/FocusBind/IndexBind found OUTSIDE a path context (e.g. a
+        // bare top-level `%`) can't derive an ancestor -- S0217.
+        AstNode::Parent => Err(coded(
+            "S0217",
+            "The parent operator % cannot be used at this point in the expression",
+        )),
+        // Recurse into every other node's children unchanged (no ancestor
+        // resolution needed for nodes that aren't paths/blocks/parent refs).
+        // Binary/Unary/Function/etc. are handled generically here; Task 4
+        // extends this with predicate/sort-term-specific recursion once
+        // basic path resolution (this task) is proven correct.
+        other => transform_children(other, labels),
+    }
+}
+
+/// Recurse into a node's child expressions without any path-specific
+/// ancestor logic (used for node types that can't themselves be paths).
+fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
+    match node {
+        AstNode::Binary { op, lhs, rhs } => Ok(AstNode::Binary {
+            op,
+            lhs: Box::new(transform_node(*lhs, labels)?),
+            rhs: Box::new(transform_node(*rhs, labels)?),
+        }),
+        AstNode::Unary { op, operand } => Ok(AstNode::Unary {
+            op,
+            operand: Box::new(transform_node(*operand, labels)?),
+        }),
+        AstNode::Array(elements) => {
+            let transformed: Result<Vec<AstNode>, AstTransformError> = elements
+                .into_iter()
+                .map(|e| transform_node(e, labels))
+                .collect();
+            Ok(AstNode::Array(transformed?))
+        }
+        // Leaf nodes and everything else pass through unchanged.
+        other => Ok(other),
+    }
+}
+
+/// Resolve a path's steps: migrate `#`/`@` markers into step-level flags,
+/// then walk backward from the last step resolving any `%` references
+/// (mirrors resolveAncestry, parser.js ~L1002-1030).
+fn transform_path_steps(
+    steps: Vec<PathStep>,
+    labels: &mut LabelGen,
+) -> Result<Vec<PathStep>, AstTransformError> {
+    // Task 3 scope: migrate #/@ into step flags and resolve a *single*
+    // trailing `%` reference with no intervening predicates/sort terms.
+    // Multi-level `%.%` chains and predicate/sort-term ancestor resolution
+    // are Task 4.
+    let mut resolved: Vec<PathStep> = Vec::with_capacity(steps.len());
+    for step in steps {
+        resolved.push(migrate_binding_markers(step, labels)?);
+    }
+    Ok(resolved)
+}
+
+/// Convert a step's raw-parse-time binding marker (if any) into the
+/// unified PathStep flags, recursing into the step's own node first (a
+/// step's node can itself be a Block/nested Path containing `%`/`@`/`#`).
+fn migrate_binding_markers(
+    mut step: PathStep,
+    labels: &mut LabelGen,
+) -> Result<PathStep, AstTransformError> {
+    match step.node {
+        AstNode::Binary {
+            op: BinaryOp::FocusBind,
+            lhs,
+            rhs,
+        } => {
+            let var_name = match *rhs {
+                AstNode::Variable(name) => name,
+                _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
+            };
+            step.node = transform_node(*lhs, labels)?;
+            step.focus = Some(var_name);
+            step.is_tuple = true;
+        }
+        AstNode::IndexBind { input, variable } => {
+            step.node = transform_node(*input, labels)?;
+            step.index_var = Some(variable);
+            step.is_tuple = true;
+        }
+        other => {
+            step.node = transform_node(other, labels)?;
+        }
+    }
+    Ok(step)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Stage;
+
+    #[test]
+    fn test_focus_bind_becomes_step_flag() {
+        // Order@$o  -->  Path{steps: [Name("Order") with focus=Some("o"), is_tuple=true]}
+        let ast = AstNode::Path {
+            steps: vec![PathStep::new(AstNode::Binary {
+                op: BinaryOp::FocusBind,
+                lhs: Box::new(AstNode::Name("Order".to_string())),
+                rhs: Box::new(AstNode::Variable("o".to_string())),
+            })],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 1);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Order"));
+                assert_eq!(steps[0].focus, Some("o".to_string()));
+                assert!(steps[0].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_index_bind_becomes_step_flag() {
+        // arr#$i  -->  Path{steps: [Name("arr") with index_var=Some("i"), is_tuple=true]}
+        let ast = AstNode::Path {
+            steps: vec![PathStep::new(AstNode::IndexBind {
+                input: Box::new(AstNode::Name("arr".to_string())),
+                variable: "i".to_string(),
+            })],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 1);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "arr"));
+                assert_eq!(steps[0].index_var, Some("i".to_string()));
+                assert!(steps[0].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_bare_parent_at_top_level_is_s0217() {
+        let err = resolve_ancestry(AstNode::Parent).unwrap_err();
+        assert!(err.to_string().starts_with("S0217"));
+    }
+
+    #[test]
+    fn test_path_step_with_stages_preserved() {
+        // Ensure stages (predicates) survive the transform unchanged when
+        // there's no binding marker involved.
+        let ast = AstNode::Path {
+            steps: vec![PathStep::with_stages(
+                AstNode::Name("Order".to_string()),
+                vec![Stage::Filter(Box::new(AstNode::Boolean(true)))],
+            )],
+        };
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps[0].stages.len(), 1);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+}

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -985,16 +985,18 @@ fn seek_parent_step(
         // leading `(Account.Order)` with no `.` before it, or a multi-
         // statement `(...)`) -- mirrors seekParent's 'block' case: recurse
         // into the LAST expression.
-        AstNode::Block(exprs) => {
-            step.is_tuple = true;
-            match exprs.last_mut() {
-                Some(last) => seek_parent_wrapped(last, label, level, state),
-                None => Err(coded(
-                    "S0217",
-                    "The parent operator % cannot derive an ancestor from an empty block",
-                )),
+        AstNode::Block(exprs) => match exprs.last_mut() {
+            Some(last) => {
+                step.is_tuple = true;
+                seek_parent_wrapped(last, label, level, state)
             }
-        }
+            // An empty block `()` produces no ancestor and no tuple; the walk
+            // simply steps over it with the level unchanged (mirrors jsonata-js
+            // seekParent's `if(node.expressions.length > 0)` guard, which leaves
+            // the slot untouched for an empty block). Lets `Account.Order.().%`
+            // resolve `%` against `Order` rather than raising S0217.
+            None => Ok(level),
+        },
         _ => Err(coded(
             "S0217",
             "The parent operator % cannot derive an ancestor from this kind of path step",
@@ -1017,6 +1019,13 @@ fn seek_parent_wrapped(
 ) -> Result<usize, AstTransformError> {
     match node {
         AstNode::Path { steps } => walk_backward(steps, label, level, state),
+        // A nested block (e.g. the inner `()` of `.()`, or `(a; b)`): recurse
+        // into its last expression, or -- for an empty block -- step over it
+        // leaving the level unchanged (jsonata-js seekParent's block guard).
+        AstNode::Block(exprs) => match exprs.last_mut() {
+            Some(last) => seek_parent_wrapped(last, label, level, state),
+            None => Ok(level),
+        },
         _ => Err(coded(
             "S0217",
             "The parent operator % cannot derive an ancestor from this kind of expression",

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -5,6 +5,7 @@
 // tree and rebuilds an enriched one with ancestor/tuple metadata resolved.
 
 use crate::ast::{AstNode, BinaryOp, PathStep};
+use std::collections::HashMap;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -20,38 +21,225 @@ fn coded(code: &'static str, message: impl Into<String>) -> AstTransformError {
     }
 }
 
-/// Monotonic counters for synthetic ancestor labels ("!0", "!1", ...),
-/// mirroring jsonata-js's module-level `ancestorLabel`/`ancestorIndex`
-/// counters. Threaded explicitly through the pass rather than using global
-/// mutable state, since Rust doesn't have JS's implicit module-scope `var`.
-///
-/// Not yet consumed: this task's scope stops at single-step `@`/`#`
-/// migration and top-level bare-`%` detection, neither of which needs a
-/// fresh label. `fresh_label` is wired up by Task 4's `%`/`%.%` chain
-/// resolution (`pushAncestry`/`resolveAncestry`), which is the reason this
-/// struct is threaded through `transform_node` already.
-#[allow(dead_code)]
-struct LabelGen {
-    next_label: usize,
+/// A `%` reference still seeking its ancestor step, mirroring jsonata-js's
+/// `slot` object (`{label, level, index}` -- we don't need `index`, since
+/// that's only used by jsonata-js to index into its global mutable
+/// `ancestry` array for the in-place relabeling trick; see `AncestryState`
+/// for how we get the same "reuse an existing label" behavior without it).
+#[derive(Debug, Clone)]
+struct PendingAncestor {
+    label: String,
+    /// Remaining backward steps needed before this reference resolves.
+    /// A fresh `%` starts at level 1 (its own immediately-preceding step);
+    /// walking backward over ANOTHER not-yet-resolved `%` step increments
+    /// this (mirrors seekParent's `case 'parent': slot.level++`).
+    level: usize,
 }
 
-impl LabelGen {
+/// Threaded through the whole pass: generates fresh synthetic ancestor
+/// labels ("!0", "!1", ...) and records label aliases.
+///
+/// Rust's immutable-rebuild model can't replicate jsonata-js's in-place
+/// mutation `ancestry[slot.index].slot.label = node.ancestor.label` (used
+/// when a *second* `%` resolves to a step some *earlier* `%` already
+/// tagged -- jsonata-js renames the second slot's label to match the first,
+/// by mutating a shared JS object referenced from both the `ancestry` array
+/// and the corresponding `AstNode::Parent` node already sitting in the
+/// tree). Since our tree nodes are owned values already moved by the time a
+/// later reuse is discovered, we can't reach back in and rewrite an
+/// already-built `Parent(label)` node in place. Instead: record the alias
+/// (`new_label -> canonical_label`) here as resolution proceeds, then run
+/// one final substitution pass (`substitute_labels`, called from
+/// `resolve_ancestry` after the whole tree is built) that rewrites every
+/// `AstNode::Parent(label)` to its canonical form. `PathStep.ancestor_label`
+/// itself never needs substitution: it's set at most once per step (the
+/// first `%` to resolve there), so it's always already canonical.
+struct AncestryState {
+    next_label: usize,
+    aliases: HashMap<String, String>,
+}
+
+impl AncestryState {
     fn new() -> Self {
-        LabelGen { next_label: 0 }
+        AncestryState {
+            next_label: 0,
+            aliases: HashMap::new(),
+        }
     }
 
-    #[allow(dead_code)]
     fn fresh_label(&mut self) -> String {
         let label = format!("!{}", self.next_label);
         self.next_label += 1;
         label
     }
+
+    /// Follow the alias chain to a label's canonical form. Chains longer
+    /// than one hop shouldn't arise (a step's `ancestor_label`, once set, is
+    /// never itself replaced -- only newcomers get aliased to it) but this
+    /// still follows the chain defensively rather than assuming depth 1.
+    fn canonical(&self, label: &str) -> String {
+        let mut cur = label;
+        while let Some(next) = self.aliases.get(cur) {
+            cur = next;
+        }
+        cur.to_string()
+    }
+}
+
+/// The result of transforming a node: the rebuilt node, plus any `%`
+/// references within it that are still seeking an ancestor step, bubbling
+/// up to whatever contains this node -- mirrors jsonata-js's `seekingParent`
+/// array property, attached to whatever node `pushAncestry` was called on.
+struct Transformed {
+    node: AstNode,
+    pending: Vec<PendingAncestor>,
+}
+
+impl Transformed {
+    fn leaf(node: AstNode) -> Self {
+        Transformed {
+            node,
+            pending: Vec::new(),
+        }
+    }
 }
 
 /// Entry point: resolve all ancestor references in a freshly-parsed AST.
 pub fn resolve_ancestry(ast: AstNode) -> Result<AstNode, AstTransformError> {
-    let mut labels = LabelGen::new();
-    transform_node(ast, &mut labels)
+    let mut state = AncestryState::new();
+    let transformed = transform_node(ast, &mut state)?;
+    // Mirrors jsonata-js's final check (parser.js ~L1404): a bare `%` as the
+    // WHOLE expression, or any dangling (never-resolved) pending ancestor
+    // reference that bubbled all the way to the top, means there was no
+    // enclosing path to derive an ancestor from.
+    if !transformed.pending.is_empty() || matches!(transformed.node, AstNode::Parent(_)) {
+        return Err(coded(
+            "S0217",
+            "The parent operator % cannot be used at this point in the expression",
+        ));
+    }
+    Ok(substitute_labels(transformed.node, &state))
+}
+
+/// Final pass: rewrite every `AstNode::Parent(label)` in the tree to its
+/// canonical (alias-resolved) label. See `AncestryState` for why this is a
+/// separate pass rather than done inline. Mirrors `transform_children`'s
+/// traversal shape exactly (every composite node type), since by this point
+/// there's no error case left to handle -- the tree is already fully valid.
+fn substitute_labels(node: AstNode, state: &AncestryState) -> AstNode {
+    match node {
+        AstNode::Parent(label) => AstNode::Parent(state.canonical(&label)),
+        AstNode::Path { steps } => AstNode::Path {
+            steps: steps
+                .into_iter()
+                .map(|s| PathStep {
+                    node: substitute_labels(s.node, state),
+                    ..s
+                })
+                .collect(),
+        },
+        AstNode::Block(exprs) => AstNode::Block(
+            exprs
+                .into_iter()
+                .map(|e| substitute_labels(e, state))
+                .collect(),
+        ),
+        AstNode::Binary { op, lhs, rhs } => AstNode::Binary {
+            op,
+            lhs: Box::new(substitute_labels(*lhs, state)),
+            rhs: Box::new(substitute_labels(*rhs, state)),
+        },
+        AstNode::Unary { op, operand } => AstNode::Unary {
+            op,
+            operand: Box::new(substitute_labels(*operand, state)),
+        },
+        AstNode::Array(elements) => AstNode::Array(
+            elements
+                .into_iter()
+                .map(|e| substitute_labels(e, state))
+                .collect(),
+        ),
+        AstNode::Function {
+            name,
+            args,
+            is_builtin,
+        } => AstNode::Function {
+            name,
+            args: args
+                .into_iter()
+                .map(|a| substitute_labels(a, state))
+                .collect(),
+            is_builtin,
+        },
+        AstNode::Call { procedure, args } => AstNode::Call {
+            procedure: Box::new(substitute_labels(*procedure, state)),
+            args: args
+                .into_iter()
+                .map(|a| substitute_labels(a, state))
+                .collect(),
+        },
+        AstNode::Lambda {
+            params,
+            body,
+            signature,
+            thunk,
+        } => AstNode::Lambda {
+            params,
+            body: Box::new(substitute_labels(*body, state)),
+            signature,
+            thunk,
+        },
+        AstNode::Object(pairs) => AstNode::Object(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (substitute_labels(k, state), substitute_labels(v, state)))
+                .collect(),
+        ),
+        AstNode::ObjectTransform { input, pattern } => AstNode::ObjectTransform {
+            input: Box::new(substitute_labels(*input, state)),
+            pattern: pattern
+                .into_iter()
+                .map(|(k, v)| (substitute_labels(k, state), substitute_labels(v, state)))
+                .collect(),
+        },
+        AstNode::Conditional {
+            condition,
+            then_branch,
+            else_branch,
+        } => AstNode::Conditional {
+            condition: Box::new(substitute_labels(*condition, state)),
+            then_branch: Box::new(substitute_labels(*then_branch, state)),
+            else_branch: else_branch.map(|e| Box::new(substitute_labels(*e, state))),
+        },
+        AstNode::Sort { input, terms } => AstNode::Sort {
+            input: Box::new(substitute_labels(*input, state)),
+            terms: terms
+                .into_iter()
+                .map(|(e, asc)| (substitute_labels(e, state), asc))
+                .collect(),
+        },
+        AstNode::Transform {
+            location,
+            update,
+            delete,
+        } => AstNode::Transform {
+            location: Box::new(substitute_labels(*location, state)),
+            update: Box::new(substitute_labels(*update, state)),
+            delete: delete.map(|d| Box::new(substitute_labels(*d, state))),
+        },
+        AstNode::FunctionApplication(inner) => {
+            AstNode::FunctionApplication(Box::new(substitute_labels(*inner, state)))
+        }
+        AstNode::ArrayGroup(elements) => AstNode::ArrayGroup(
+            elements
+                .into_iter()
+                .map(|e| substitute_labels(e, state))
+                .collect(),
+        ),
+        AstNode::Predicate(inner) => AstNode::Predicate(Box::new(substitute_labels(*inner, state))),
+        // Leaf nodes and everything else pass through unchanged.
+        other => other,
+    }
 }
 
 /// A raw parse-time binding marker (`@$var` or `#$var`) that still needs to
@@ -79,7 +267,8 @@ fn apply_marker_to_step(step: &mut PathStep, marker: BindingMarker) {
 /// Core shared logic for both call sites that need to migrate a `@$var`/
 /// `#$var` marker: given the already-`transform_node`-recursed `lhs`/`input`
 /// that the marker was parsed against, produce the flat sequence of
-/// `PathStep`s the marker should resolve to.
+/// `PathStep`s the marker should resolve to, plus whatever pending ancestor
+/// references bubbled up from transforming that `lhs`/`input`.
 ///
 /// Mirrors jsonata-js's `processAST` `case '@'`/`case '#'`:
 /// `result = processAST(expr.lhs); step = result; if (result.type ===
@@ -87,26 +276,74 @@ fn apply_marker_to_step(step: &mut PathStep, marker: BindingMarker) {
 /// (the possibly-multi-step path) is always what gets kept/spliced in, and
 /// only `step` (the thing that gets the marker's flags stamped onto it) is
 /// reassigned to the LAST step of that path when `result` is itself a path.
+/// Note jsonata-js's `@`/`#` cases do NOT call `pushAncestry` on the lhs --
+/// we deviate slightly (forwarding the lhs's pending through as this
+/// marker's own pending) since dropping it silently seems more surprising
+/// than propagating it, and no test data combines `%` with `@`/`#` closely
+/// enough to distinguish the two choices.
 ///
 /// - If `transformed` is a multi-step `Path`, the marker's flags land on its
 ///   LAST step, and ALL of its steps are returned to be spliced into the
 ///   caller's flat steps list (never wrapped in a new outer step).
 /// - Otherwise (e.g. a bare `Name` with no `.` at all), wrap it into a new
 ///   single-step `Path` and stamp the marker onto that one step.
-fn splice_marker_steps(transformed: AstNode, marker: BindingMarker) -> Vec<PathStep> {
-    match transformed {
+///
+/// S0215/S0216 validation for `@` (focus binding only -- `#`/index binding
+/// has no such restriction in jsonata-js): the target must not already have
+/// predicates/stages attached, and must not itself be a `Sort` node.
+fn check_focus_bind_target(
+    marker: &BindingMarker,
+    target_stages: &[crate::ast::Stage],
+    target_node: &AstNode,
+) -> Result<(), AstTransformError> {
+    if !matches!(marker, BindingMarker::Focus(_)) {
+        return Ok(());
+    }
+    if !target_stages.is_empty() {
+        return Err(coded(
+            "S0215",
+            "A context variable binding must precede any predicates on a step",
+        ));
+    }
+    if matches!(target_node, AstNode::Sort { .. }) {
+        return Err(coded(
+            "S0216",
+            "A context variable binding must precede the 'order-by' clause on a step",
+        ));
+    }
+    Ok(())
+}
+///
+/// Fallible because `@` (focus binding) specifically -- not `#` -- rejects
+/// being applied to a step that already has predicates/stages (S0215) or
+/// that is itself a sort step (S0216), mirroring jsonata-js's `case '@'`
+/// checks (parser.js ~L1183-1199): `step = result; if (result.type ===
+/// 'path') { step = result.steps[...length-1]; }` -- note `step` can be the
+/// bare (non-Path) `result` itself, e.g. `Account.Order^(...)@$o.Product`
+/// parses `Account.Order^(...)` into a bare top-level `Sort` node (not
+/// wrapped in a Path) *before* `@$o` wraps around it, so the S0216 check
+/// must inspect the raw `other` node too, not just a `Path`'s last step.
+fn splice_marker_steps(
+    transformed: Transformed,
+    marker: BindingMarker,
+) -> Result<(Vec<PathStep>, Vec<PendingAncestor>), AstTransformError> {
+    let Transformed { node, pending } = transformed;
+    let steps = match node {
         AstNode::Path { mut steps } => {
             if let Some(last) = steps.last_mut() {
+                check_focus_bind_target(&marker, &last.stages, &last.node)?;
                 apply_marker_to_step(last, marker);
             }
             steps
         }
         other => {
+            check_focus_bind_target(&marker, &[], &other)?;
             let mut step = PathStep::new(other);
             apply_marker_to_step(&mut step, marker);
             vec![step]
         }
-    }
+    };
+    Ok((steps, pending))
 }
 
 /// Handle a `@$var`/`#$var` marker reaching `transform_node` as the raw node
@@ -116,35 +353,60 @@ fn splice_marker_steps(transformed: AstNode, marker: BindingMarker) -> Vec<PathS
 /// non-Path leaf) *before* wrapping the whole thing in the marker node. At
 /// this (top-level) call site there's no outer steps list to splice into, so
 /// the spliced steps become the whole resulting `Path`.
-fn wrap_marker_as_path(transformed: AstNode, marker: BindingMarker) -> AstNode {
-    AstNode::Path {
-        steps: splice_marker_steps(transformed, marker),
-    }
+fn wrap_marker_as_path(
+    transformed: Transformed,
+    marker: BindingMarker,
+) -> Result<Transformed, AstTransformError> {
+    let (steps, pending) = splice_marker_steps(transformed, marker)?;
+    Ok(Transformed {
+        node: AstNode::Path { steps },
+        pending,
+    })
 }
 
 /// Recursively rebuild `node`, resolving any `%`/`@`/`#` found within.
 /// Mirrors jsonata-js's processAST's generic per-node-type dispatch.
-fn transform_node(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
+fn transform_node(
+    node: AstNode,
+    state: &mut AncestryState,
+) -> Result<Transformed, AstTransformError> {
     match node {
         AstNode::Path { steps } => {
-            let transformed_steps = transform_path_steps(steps, labels)?;
-            Ok(AstNode::Path {
-                steps: transformed_steps,
+            let (transformed_steps, pending) = transform_path_steps(steps, state)?;
+            Ok(Transformed {
+                node: AstNode::Path {
+                    steps: transformed_steps,
+                },
+                pending,
             })
         }
         AstNode::Block(exprs) => {
-            let transformed: Result<Vec<AstNode>, AstTransformError> = exprs
-                .into_iter()
-                .map(|e| transform_node(e, labels))
-                .collect();
-            Ok(AstNode::Block(transformed?))
+            let mut pending = Vec::new();
+            let mut transformed_exprs = Vec::with_capacity(exprs.len());
+            for e in exprs {
+                let t = transform_node(e, state)?;
+                pending.extend(t.pending);
+                transformed_exprs.push(t.node);
+            }
+            Ok(Transformed {
+                node: AstNode::Block(transformed_exprs),
+                pending,
+            })
         }
-        // Parent/FocusBind/IndexBind found OUTSIDE a path context (e.g. a
-        // bare top-level `%`) can't derive an ancestor -- S0217.
-        AstNode::Parent => Err(coded(
-            "S0217",
-            "The parent operator % cannot be used at this point in the expression",
-        )),
+        // A bare `%` -- mirrors jsonata-js's `case 'parent'`, which assigns
+        // a fresh slot the MOMENT any recursive processAST call first sees a
+        // 'parent'-type node (not just at the top of transform_node), i.e.
+        // eagerly, before any backward walk starts. The one pending
+        // reference this produces starts at level 1 (its own immediately
+        // preceding step); `%.%` chains extend the level as the backward
+        // walk crosses further `%` steps (see `seek_parent_step`).
+        AstNode::Parent(_) => {
+            let label = state.fresh_label();
+            Ok(Transformed {
+                node: AstNode::Parent(label.clone()),
+                pending: vec![PendingAncestor { label, level: 1 }],
+            })
+        }
         // `@$var` reaching transform_node as the raw top-level node itself
         // (not nested inside an existing PathStep) -- e.g. `Order@$o` or
         // `Account.Order@$o`, where the parser's flat infix loop applies `@`
@@ -159,70 +421,127 @@ fn transform_node(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTr
                 AstNode::Variable(name) => name,
                 _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
             };
-            let transformed_lhs = transform_node(*lhs, labels)?;
-            Ok(wrap_marker_as_path(
-                transformed_lhs,
-                BindingMarker::Focus(var_name),
-            ))
+            let transformed_lhs = transform_node(*lhs, state)?;
+            wrap_marker_as_path(transformed_lhs, BindingMarker::Focus(var_name))
         }
-        // Same story as FocusBind above, but for bare top-level `#$var`.
-        AstNode::IndexBind { input, variable } => {
-            let transformed_input = transform_node(*input, labels)?;
-            Ok(wrap_marker_as_path(
-                transformed_input,
-                BindingMarker::Index(variable),
-            ))
+        // Same story as FocusBind above, but for bare top-level `#$var`
+        // (now represented the same generic way as FocusBind -- see
+        // BinaryOp::IndexBind's doc comment in ast.rs).
+        AstNode::Binary {
+            op: BinaryOp::IndexBind,
+            lhs,
+            rhs,
+        } => {
+            let var_name = match *rhs {
+                AstNode::Variable(name) => name,
+                _ => unreachable!("parser guarantees IndexBind's rhs is always Variable"),
+            };
+            let transformed_lhs = transform_node(*lhs, state)?;
+            wrap_marker_as_path(transformed_lhs, BindingMarker::Index(var_name))
         }
         // Recurse into every other node's children unchanged (no ancestor
         // resolution needed for nodes that aren't paths/blocks/parent refs).
-        other => transform_children(other, labels),
+        other => transform_children(other, state),
     }
 }
 
 /// Recurse into a node's child expressions without any path-specific
-/// ancestor logic (used for node types that can't themselves be paths).
-fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
+/// ancestor logic (used for node types that can't themselves be paths),
+/// aggregating pending ancestor references from every child -- mirrors
+/// jsonata-js's per-case `pushAncestry` calls in processAST.
+///
+/// Two deliberate asymmetries with the generic "bubble everything" rule,
+/// both matching jsonata-js exactly:
+/// - `Call`'s `procedure` does NOT bubble (only `args` do) -- jsonata-js's
+///   function/partial case never calls `pushAncestry` on `result.procedure`.
+/// - `Lambda`'s `body` does NOT bubble at all -- jsonata-js's lambda case
+///   has no `pushAncestry` call for the body. A `%` inside a lambda body
+///   refers to that lambda's OWN invocation-time ancestry chain (irrelevant
+///   at definition/parse time), so it's correctly not resolved here; it
+///   simply remains an inert `AstNode::Parent(label)` in the body until the
+///   lambda is invoked (matching jsonata-js: `function(){%}` parses fine,
+///   with the raw `%` untouched inside the body).
+fn transform_children(
+    node: AstNode,
+    state: &mut AncestryState,
+) -> Result<Transformed, AstTransformError> {
     match node {
-        AstNode::Binary { op, lhs, rhs } => Ok(AstNode::Binary {
-            op,
-            lhs: Box::new(transform_node(*lhs, labels)?),
-            rhs: Box::new(transform_node(*rhs, labels)?),
-        }),
-        AstNode::Unary { op, operand } => Ok(AstNode::Unary {
-            op,
-            operand: Box::new(transform_node(*operand, labels)?),
-        }),
+        AstNode::Binary { op, lhs, rhs } => {
+            let lhs_t = transform_node(*lhs, state)?;
+            let rhs_t = transform_node(*rhs, state)?;
+            let mut pending = lhs_t.pending;
+            pending.extend(rhs_t.pending);
+            Ok(Transformed {
+                node: AstNode::Binary {
+                    op,
+                    lhs: Box::new(lhs_t.node),
+                    rhs: Box::new(rhs_t.node),
+                },
+                pending,
+            })
+        }
+        AstNode::Unary { op, operand } => {
+            let t = transform_node(*operand, state)?;
+            Ok(Transformed {
+                node: AstNode::Unary {
+                    op,
+                    operand: Box::new(t.node),
+                },
+                pending: t.pending,
+            })
+        }
         AstNode::Array(elements) => {
-            let transformed: Result<Vec<AstNode>, AstTransformError> = elements
-                .into_iter()
-                .map(|e| transform_node(e, labels))
-                .collect();
-            Ok(AstNode::Array(transformed?))
+            let mut pending = Vec::new();
+            let mut transformed = Vec::with_capacity(elements.len());
+            for e in elements {
+                let t = transform_node(e, state)?;
+                pending.extend(t.pending);
+                transformed.push(t.node);
+            }
+            Ok(Transformed {
+                node: AstNode::Array(transformed),
+                pending,
+            })
         }
         AstNode::Function {
             name,
             args,
             is_builtin,
         } => {
-            let transformed: Result<Vec<AstNode>, AstTransformError> = args
-                .into_iter()
-                .map(|a| transform_node(a, labels))
-                .collect();
-            Ok(AstNode::Function {
-                name,
-                args: transformed?,
-                is_builtin,
+            let mut pending = Vec::new();
+            let mut transformed = Vec::with_capacity(args.len());
+            for a in args {
+                let t = transform_node(a, state)?;
+                pending.extend(t.pending);
+                transformed.push(t.node);
+            }
+            Ok(Transformed {
+                node: AstNode::Function {
+                    name,
+                    args: transformed,
+                    is_builtin,
+                },
+                pending,
             })
         }
         AstNode::Call { procedure, args } => {
-            let transformed_procedure = transform_node(*procedure, labels)?;
-            let transformed_args: Result<Vec<AstNode>, AstTransformError> = args
-                .into_iter()
-                .map(|a| transform_node(a, labels))
-                .collect();
-            Ok(AstNode::Call {
-                procedure: Box::new(transformed_procedure),
-                args: transformed_args?,
+            // Only args bubble (see doc comment above) -- procedure is
+            // still structurally transformed, just doesn't contribute to
+            // this Call's own pending.
+            let procedure_t = transform_node(*procedure, state)?;
+            let mut pending = Vec::new();
+            let mut transformed_args = Vec::with_capacity(args.len());
+            for a in args {
+                let t = transform_node(a, state)?;
+                pending.extend(t.pending);
+                transformed_args.push(t.node);
+            }
+            Ok(Transformed {
+                node: AstNode::Call {
+                    procedure: Box::new(procedure_t.node),
+                    args: transformed_args,
+                },
+                pending,
             })
         }
         AstNode::Lambda {
@@ -230,28 +549,48 @@ fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, A
             body,
             signature,
             thunk,
-        } => Ok(AstNode::Lambda {
-            params,
-            body: Box::new(transform_node(*body, labels)?),
-            signature,
-            thunk,
-        }),
+        } => {
+            // body's pending is deliberately dropped -- see doc comment above.
+            let body_t = transform_node(*body, state)?;
+            Ok(Transformed::leaf(AstNode::Lambda {
+                params,
+                body: Box::new(body_t.node),
+                signature,
+                thunk,
+            }))
+        }
         AstNode::Object(pairs) => {
-            let transformed: Result<Vec<(AstNode, AstNode)>, AstTransformError> = pairs
-                .into_iter()
-                .map(|(k, v)| Ok((transform_node(k, labels)?, transform_node(v, labels)?)))
-                .collect();
-            Ok(AstNode::Object(transformed?))
+            let mut pending = Vec::new();
+            let mut transformed = Vec::with_capacity(pairs.len());
+            for (k, v) in pairs {
+                let k_t = transform_node(k, state)?;
+                pending.extend(k_t.pending);
+                let v_t = transform_node(v, state)?;
+                pending.extend(v_t.pending);
+                transformed.push((k_t.node, v_t.node));
+            }
+            Ok(Transformed {
+                node: AstNode::Object(transformed),
+                pending,
+            })
         }
         AstNode::ObjectTransform { input, pattern } => {
-            let transformed_input = transform_node(*input, labels)?;
-            let transformed_pattern: Result<Vec<(AstNode, AstNode)>, AstTransformError> = pattern
-                .into_iter()
-                .map(|(k, v)| Ok((transform_node(k, labels)?, transform_node(v, labels)?)))
-                .collect();
-            Ok(AstNode::ObjectTransform {
-                input: Box::new(transformed_input),
-                pattern: transformed_pattern?,
+            let input_t = transform_node(*input, state)?;
+            let mut pending = input_t.pending;
+            let mut transformed_pattern = Vec::with_capacity(pattern.len());
+            for (k, v) in pattern {
+                let k_t = transform_node(k, state)?;
+                pending.extend(k_t.pending);
+                let v_t = transform_node(v, state)?;
+                pending.extend(v_t.pending);
+                transformed_pattern.push((k_t.node, v_t.node));
+            }
+            Ok(Transformed {
+                node: AstNode::ObjectTransform {
+                    input: Box::new(input_t.node),
+                    pattern: transformed_pattern,
+                },
+                pending,
             })
         }
         AstNode::Conditional {
@@ -259,27 +598,50 @@ fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, A
             then_branch,
             else_branch,
         } => {
-            let transformed_condition = transform_node(*condition, labels)?;
-            let transformed_then = transform_node(*then_branch, labels)?;
-            let transformed_else = match else_branch {
-                Some(e) => Some(Box::new(transform_node(*e, labels)?)),
+            let condition_t = transform_node(*condition, state)?;
+            let then_t = transform_node(*then_branch, state)?;
+            let mut pending = condition_t.pending;
+            pending.extend(then_t.pending);
+            let else_t = match else_branch {
+                Some(e) => Some(transform_node(*e, state)?),
                 None => None,
             };
-            Ok(AstNode::Conditional {
-                condition: Box::new(transformed_condition),
-                then_branch: Box::new(transformed_then),
-                else_branch: transformed_else,
+            let else_node = else_t.map(|t| {
+                pending.extend(t.pending);
+                Box::new(t.node)
+            });
+            Ok(Transformed {
+                node: AstNode::Conditional {
+                    condition: Box::new(condition_t.node),
+                    then_branch: Box::new(then_t.node),
+                    else_branch: else_node,
+                },
+                pending,
             })
         }
         AstNode::Sort { input, terms } => {
-            let transformed_input = transform_node(*input, labels)?;
-            let transformed_terms: Result<Vec<(AstNode, bool)>, AstTransformError> = terms
-                .into_iter()
-                .map(|(expr, asc)| Ok((transform_node(expr, labels)?, asc)))
-                .collect();
-            Ok(AstNode::Sort {
-                input: Box::new(transformed_input),
-                terms: transformed_terms?,
+            // Structural transform + generic pending bubbling only.
+            // Deliberately NOT integrating Sort as a resolvable step against
+            // EARLIER steps of its own `input` path (jsonata-js's '^' case
+            // pushes a synthetic sortStep onto input's own steps list and
+            // re-runs resolveAncestry on the combined path) -- that
+            // sort-term-specific ancestor resolution is Task 6 scope. Here,
+            // a `%` inside a sort term simply bubbles up as this Sort node's
+            // own pending, same as any other composite node's children.
+            let input_t = transform_node(*input, state)?;
+            let mut pending = input_t.pending;
+            let mut transformed_terms = Vec::with_capacity(terms.len());
+            for (expr, asc) in terms {
+                let t = transform_node(expr, state)?;
+                pending.extend(t.pending);
+                transformed_terms.push((t.node, asc));
+            }
+            Ok(Transformed {
+                node: AstNode::Sort {
+                    input: Box::new(input_t.node),
+                    terms: transformed_terms,
+                },
+                pending,
             })
         }
         AstNode::Transform {
@@ -287,62 +649,223 @@ fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, A
             update,
             delete,
         } => {
-            let transformed_location = transform_node(*location, labels)?;
-            let transformed_update = transform_node(*update, labels)?;
-            let transformed_delete = match delete {
-                Some(d) => Some(Box::new(transform_node(*d, labels)?)),
+            let location_t = transform_node(*location, state)?;
+            let update_t = transform_node(*update, state)?;
+            let mut pending = location_t.pending;
+            pending.extend(update_t.pending);
+            let delete_t = match delete {
+                Some(d) => Some(transform_node(*d, state)?),
                 None => None,
             };
-            Ok(AstNode::Transform {
-                location: Box::new(transformed_location),
-                update: Box::new(transformed_update),
-                delete: transformed_delete,
+            let delete_node = delete_t.map(|t| {
+                pending.extend(t.pending);
+                Box::new(t.node)
+            });
+            Ok(Transformed {
+                node: AstNode::Transform {
+                    location: Box::new(location_t.node),
+                    update: Box::new(update_t.node),
+                    delete: delete_node,
+                },
+                pending,
             })
         }
-        AstNode::FunctionApplication(inner) => Ok(AstNode::FunctionApplication(Box::new(
-            transform_node(*inner, labels)?,
-        ))),
-        AstNode::ArrayGroup(elements) => {
-            let transformed: Result<Vec<AstNode>, AstTransformError> = elements
-                .into_iter()
-                .map(|e| transform_node(e, labels))
-                .collect();
-            Ok(AstNode::ArrayGroup(transformed?))
+        AstNode::FunctionApplication(inner) => {
+            let t = transform_node(*inner, state)?;
+            Ok(Transformed {
+                node: AstNode::FunctionApplication(Box::new(t.node)),
+                pending: t.pending,
+            })
         }
-        AstNode::Predicate(inner) => Ok(AstNode::Predicate(Box::new(transform_node(
-            *inner, labels,
-        )?))),
+        AstNode::ArrayGroup(elements) => {
+            let mut pending = Vec::new();
+            let mut transformed = Vec::with_capacity(elements.len());
+            for e in elements {
+                let t = transform_node(e, state)?;
+                pending.extend(t.pending);
+                transformed.push(t.node);
+            }
+            Ok(Transformed {
+                node: AstNode::ArrayGroup(transformed),
+                pending,
+            })
+        }
+        AstNode::Predicate(inner) => {
+            let t = transform_node(*inner, state)?;
+            Ok(Transformed {
+                node: AstNode::Predicate(Box::new(t.node)),
+                pending: t.pending,
+            })
+        }
         // Leaf nodes and everything else pass through unchanged.
-        other => Ok(other),
+        other => Ok(Transformed::leaf(other)),
     }
 }
 
 /// Resolve a path's steps: migrate `#`/`@` markers into step-level flags,
-/// then walk backward from the last step resolving any `%` references
-/// (mirrors resolveAncestry, parser.js ~L1002-1030).
+/// then walk backward resolving any `%`/`%.%` references, left to right in
+/// step-encounter order. Mirrors resolveAncestry (parser.js ~L1002-1030),
+/// collapsed from jsonata-js's incremental per-'.' invocation into a single
+/// pass: our parser already flattens an entire dotted chain into one flat
+/// `steps` list up front (unlike jsonata-js's nested binary '.' AST nodes,
+/// processed one dot at a time), so resolving every step's own pending
+/// reference against the FULL flattened list-so-far in left-to-right order
+/// produces the same result as jsonata-js's incremental resolution.
 fn transform_path_steps(
     steps: Vec<PathStep>,
-    labels: &mut LabelGen,
-) -> Result<Vec<PathStep>, AstTransformError> {
-    // Task 3 scope: migrate #/@ into step flags and resolve a *single*
-    // trailing `%` reference with no intervening predicates/sort terms.
-    // Multi-level `%.%` chains and predicate/sort-term ancestor resolution
-    // are Task 4.
-    //
-    // NOTE: this is a flat-map, not a 1:1 map -- a single input step whose
-    // node is a `@$var`/`#$var` marker over a multi-step `lhs`/`input` (e.g.
-    // `Account.Order@$o.Product`, where the parser wraps the ALREADY-BUILT
-    // 2-step `Path{Account,Order}` in a marker node and that whole marker
-    // node becomes ONE PathStep in the outer 2-step `[marker-step, Product]`
-    // list) must expand back into multiple output steps -- see
-    // `migrate_binding_markers`/`splice_marker_steps`. A single `.push()`
-    // per input step would leave the inner multi-step path nested inside a
-    // single wrapping step instead of flattened into the outer list.
+    state: &mut AncestryState,
+) -> Result<(Vec<PathStep>, Vec<PendingAncestor>), AstTransformError> {
+    // Pass 1: migrate #/@ into step flags, recursing into nested content
+    // (which may itself bubble up pending `%` references, e.g. an object
+    // constructor or array containing a `%`). `own_pending[i]` is whatever
+    // pending arose from producing `resolved[i]` -- attached to the LAST
+    // step of a marker's splice, since that's the step position pending
+    // ancestor resolution should walk backward from.
     let mut resolved: Vec<PathStep> = Vec::with_capacity(steps.len());
+    let mut own_pending: Vec<Vec<PendingAncestor>> = Vec::with_capacity(steps.len());
     for step in steps {
-        resolved.extend(migrate_binding_markers(step, labels)?);
+        let (spliced, pending) = migrate_binding_markers(step, state)?;
+        let last_idx = spliced.len().saturating_sub(1);
+        let mut pending_opt = Some(pending);
+        for (i, s) in spliced.into_iter().enumerate() {
+            resolved.push(s);
+            if i == last_idx {
+                own_pending.push(pending_opt.take().unwrap_or_default());
+            } else {
+                own_pending.push(Vec::new());
+            }
+        }
     }
-    Ok(resolved)
+
+    // Pass 2: for each step (in ascending/encounter order) with its own
+    // pending, walk backward through the steps BEFORE it, resolving each
+    // pending reference. Any reference that runs off the front of this path
+    // (never finding a target) bubbles up as this whole Path's own pending.
+    let mut path_pending: Vec<PendingAncestor> = Vec::new();
+    for i in 0..resolved.len() {
+        let pending_here = std::mem::take(&mut own_pending[i]);
+        for pending in pending_here {
+            let remaining =
+                walk_backward(&mut resolved[..i], &pending.label, pending.level, state)?;
+            if remaining > 0 {
+                path_pending.push(PendingAncestor {
+                    label: pending.label,
+                    level: remaining,
+                });
+            }
+        }
+    }
+
+    Ok((resolved, path_pending))
+}
+
+/// Walk backward through `steps` (from its last element) trying to resolve
+/// a single pending ancestor reference at `level`. Returns the remaining
+/// level: 0 means fully resolved (some step in `steps` was tagged); >0 means
+/// `steps` ran out before the reference resolved, so the caller must keep
+/// walking further back through whatever contains `steps` (or, if there is
+/// nothing further back, treat it as still-pending / bubble it up).
+fn walk_backward(
+    steps: &mut [PathStep],
+    label: &str,
+    mut level: usize,
+    state: &mut AncestryState,
+) -> Result<usize, AstTransformError> {
+    let mut index = steps.len();
+    while level > 0 {
+        if index == 0 {
+            return Ok(level);
+        }
+        index -= 1;
+        level = seek_parent_step(&mut steps[index], label, level, state)?;
+    }
+    Ok(0)
+}
+
+/// Try to resolve one level of a pending ancestor reference against a
+/// single candidate step. Returns the remaining level (0 = tagged here).
+/// Mirrors jsonata-js's seekParent (parser.js ~L941-986).
+fn seek_parent_step(
+    step: &mut PathStep,
+    label: &str,
+    level: usize,
+    state: &mut AncestryState,
+) -> Result<usize, AstTransformError> {
+    match &mut step.node {
+        AstNode::Name(_) | AstNode::Wildcard => {
+            let remaining = level - 1;
+            if remaining == 0 {
+                match &step.ancestor_label {
+                    // Reuse: an earlier `%` already tagged this exact step.
+                    // Record the alias instead of overwriting (see
+                    // AncestryState's doc comment).
+                    Some(existing) => {
+                        state.aliases.insert(label.to_string(), existing.clone());
+                    }
+                    None => {
+                        step.ancestor_label = Some(label.to_string());
+                    }
+                }
+                step.is_tuple = true;
+            }
+            Ok(remaining)
+        }
+        // Chained %.%: this step is itself another (already independently
+        // resolved-or-pending) `%` -- extend the level and keep walking
+        // further back, exactly mirroring seekParent's `case 'parent':
+        // slot.level++` (which notably does NOT set `.tuple` here).
+        AstNode::Parent(_) => Ok(level + 1),
+        // Parenthesized sub-path as a path step (e.g. `Account.(Order.Product).%`
+        // parses `(Order.Product)` as `FunctionApplication(Path{...})`) --
+        // mirrors seekParent's 'block'/'path' cases layered together: this
+        // outer step becomes tuple-producing regardless of where inside the
+        // parens the actual ancestor tag lands, and we recurse inward to
+        // find it.
+        AstNode::FunctionApplication(inner) => {
+            step.is_tuple = true;
+            seek_parent_wrapped(inner.as_mut(), label, level, state)
+        }
+        // A parenthesized block reached directly as a path step (e.g. a
+        // leading `(Account.Order)` with no `.` before it, or a multi-
+        // statement `(...)`) -- mirrors seekParent's 'block' case: recurse
+        // into the LAST expression.
+        AstNode::Block(exprs) => {
+            step.is_tuple = true;
+            match exprs.last_mut() {
+                Some(last) => seek_parent_wrapped(last, label, level, state),
+                None => Err(coded(
+                    "S0217",
+                    "The parent operator % cannot derive an ancestor from an empty block",
+                )),
+            }
+        }
+        _ => Err(coded(
+            "S0217",
+            "The parent operator % cannot derive an ancestor from this kind of path step",
+        )),
+    }
+}
+
+/// Recurse into a "wrapped" target (a `FunctionApplication`'s sole inner
+/// expression, or a `Block`'s last expression) that must itself resolve to
+/// a nested `Path` for us to walk backward through it -- mirrors how
+/// jsonata-js's block/path seekParent cases can be layered on top of each
+/// other for doubly-nested parens (e.g. `Account.(Order.(Product)).%`).
+/// Anything else (a literal, a function call, ...) can't derive an
+/// ancestor: S0217.
+fn seek_parent_wrapped(
+    node: &mut AstNode,
+    label: &str,
+    level: usize,
+    state: &mut AncestryState,
+) -> Result<usize, AstTransformError> {
+    match node {
+        AstNode::Path { steps } => walk_backward(steps, label, level, state),
+        _ => Err(coded(
+            "S0217",
+            "The parent operator % cannot derive an ancestor from this kind of expression",
+        )),
+    }
 }
 
 /// Convert a step's raw-parse-time binding marker (if any) into the unified
@@ -354,10 +877,12 @@ fn transform_path_steps(
 /// -- in which case ALL of those steps must be spliced into the caller's
 /// flat list in place of this one input step, with the marker's flags
 /// stamped onto the LAST of them (not onto a step wrapping the whole thing).
+/// Also returns whatever pending ancestor references bubbled up from
+/// transforming this step's content.
 fn migrate_binding_markers(
     mut step: PathStep,
-    labels: &mut LabelGen,
-) -> Result<Vec<PathStep>, AstTransformError> {
+    state: &mut AncestryState,
+) -> Result<(Vec<PathStep>, Vec<PendingAncestor>), AstTransformError> {
     match step.node {
         AstNode::Binary {
             op: BinaryOp::FocusBind,
@@ -368,22 +893,25 @@ fn migrate_binding_markers(
                 AstNode::Variable(name) => name,
                 _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
             };
-            let transformed_lhs = transform_node(*lhs, labels)?;
-            Ok(splice_marker_steps(
-                transformed_lhs,
-                BindingMarker::Focus(var_name),
-            ))
+            let transformed_lhs = transform_node(*lhs, state)?;
+            splice_marker_steps(transformed_lhs, BindingMarker::Focus(var_name))
         }
-        AstNode::IndexBind { input, variable } => {
-            let transformed_input = transform_node(*input, labels)?;
-            Ok(splice_marker_steps(
-                transformed_input,
-                BindingMarker::Index(variable),
-            ))
+        AstNode::Binary {
+            op: BinaryOp::IndexBind,
+            lhs,
+            rhs,
+        } => {
+            let var_name = match *rhs {
+                AstNode::Variable(name) => name,
+                _ => unreachable!("parser guarantees IndexBind's rhs is always Variable"),
+            };
+            let transformed_lhs = transform_node(*lhs, state)?;
+            splice_marker_steps(transformed_lhs, BindingMarker::Index(var_name))
         }
         other => {
-            step.node = transform_node(other, labels)?;
-            Ok(vec![step])
+            let t = transform_node(other, state)?;
+            step.node = t.node;
+            Ok((vec![step], t.pending))
         }
     }
 }
@@ -419,9 +947,10 @@ mod tests {
     fn test_index_bind_becomes_step_flag() {
         // arr#$i  -->  Path{steps: [Name("arr") with index_var=Some("i"), is_tuple=true]}
         let ast = AstNode::Path {
-            steps: vec![PathStep::new(AstNode::IndexBind {
-                input: Box::new(AstNode::Name("arr".to_string())),
-                variable: "i".to_string(),
+            steps: vec![PathStep::new(AstNode::Binary {
+                op: BinaryOp::IndexBind,
+                lhs: Box::new(AstNode::Name("arr".to_string())),
+                rhs: Box::new(AstNode::Variable("i".to_string())),
             })],
         };
         let result = resolve_ancestry(ast).unwrap();
@@ -438,7 +967,7 @@ mod tests {
 
     #[test]
     fn test_bare_parent_at_top_level_is_s0217() {
-        let err = resolve_ancestry(AstNode::Parent).unwrap_err();
+        let err = resolve_ancestry(AstNode::Parent(String::new())).unwrap_err();
         assert!(err.to_string().starts_with("S0217"));
     }
 
@@ -461,22 +990,31 @@ mod tests {
         }
     }
 
-    // --- Regression tests using the REAL parser (review findings) ---
+    // --- Regression tests using the REAL parser (Task 3 review findings) ---
     //
-    // The 4 tests above hand-build synthetic ASTs and, per the review, only
-    // exercise the shapes that happen to already work. These tests instead
-    // go through `crate::parser::parse()` on real source text, which is what
-    // surfaced the two root-cause bugs: (1) transform_children not
-    // recursing into most composite node types, and (2) `@$var`/`#$var`
-    // never being migrated when the marker is the TOP-LEVEL node reaching
-    // transform_node (only when already nested inside a PathStep).
+    // Hand-built synthetic ASTs only exercise the shapes that happen to
+    // already work. These tests go through `crate::parser::parse()` on real
+    // source text, which is what surfaced two root-cause bugs in Task 3:
+    // (1) transform_children not recursing into most composite node types,
+    // and (2) `@$var`/`#$var` never being migrated when the marker is the
+    // TOP-LEVEL node reaching transform_node (only when already nested
+    // inside a PathStep). The same discipline applies to Task 4's `%`
+    // resolution below: expected label/level assertions are checked for
+    // internal consistency (same target step -> same label; different
+    // targets -> different labels) rather than against jsonata-js's exact
+    // "!0"/"!1"/... strings, since those are implementation-internal and
+    // arbitrary -- but the STEPS that get tagged are cross-checked against
+    // jsonata-js's actual `.ast()` output (see comments below).
 
     #[test]
     fn test_real_parser_bare_focus_bind_no_dot() {
         // "Order@$o" -- bare single-step, no dot anywhere. The parser
         // produces Binary{FocusBind, lhs: Name("Order"), rhs: Variable("o")}
         // at the top level (no Path at all, since there's no `.`).
-        let ast = crate::parser::parse("Order@$o").unwrap();
+        let ast = crate::parser::Parser::new("Order@$o".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
         let result = resolve_ancestry(ast).unwrap();
         match result {
             AstNode::Path { steps } => {
@@ -494,7 +1032,10 @@ mod tests {
         // "Account.Order@$o" -- 2-step path, marker on the final step, no
         // trailing dot. Previously: `@` wrapped the whole 2-step Path in a
         // top-level Binary{FocusBind,...} that was never migrated (Bug 2).
-        let ast = crate::parser::parse("Account.Order@$o").unwrap();
+        let ast = crate::parser::Parser::new("Account.Order@$o".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
         let result = resolve_ancestry(ast).unwrap();
         match result {
             AstNode::Path { steps } => {
@@ -514,7 +1055,10 @@ mod tests {
     fn test_real_parser_bare_index_bind() {
         // "arr#$i" -- bare index bind, no dot. Previously never migrated
         // when reaching transform_node as the raw top-level IndexBind node.
-        let ast = crate::parser::parse("arr#$i").unwrap();
+        let ast = crate::parser::Parser::new("arr#$i".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
         let result = resolve_ancestry(ast).unwrap();
         match result {
             AstNode::Path { steps } => {
@@ -533,27 +1077,25 @@ mod tests {
         // Previously transform_children didn't recurse into Function args
         // at all (Bug 1), so this silently returned Ok(unchanged) instead
         // of raising S0217.
-        let ast = crate::parser::parse("$count(%)").unwrap();
+        let ast = crate::parser::Parser::new("$count(%)".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
         let err = resolve_ancestry(ast).unwrap_err();
         assert!(err.to_string().starts_with("S0217"));
     }
 
     // --- Regression tests for the "nested Path from multi-step @/# marker"
-    // finding (second review round) ---
-    //
-    // `Account.Order@$o.Product` has >=2 path segments before the marker AND
-    // >=1 segment after. At parse time, `@$o` wraps the ALREADY-BUILT 2-step
-    // `Path{Account,Order}` in a `Binary{FocusBind,...}` node, and that whole
-    // node becomes step 0 of an outer 2-step list `[marker-step, Product]`.
-    // Previously `migrate_binding_markers` assigned the transformed lhs
-    // directly to `step.node` and stamped the marker onto that WRAPPING
-    // step, producing a corrupted nested shape instead of a flat path.
+    // finding (Task 3, second review round) ---
 
     #[test]
     fn test_real_parser_focus_bind_multistep_prefix_and_suffix_is_flat() {
         // "Account.Order@$o.Product" must produce a FLAT 3-step path, not a
         // 2-step path whose first step's node is itself a nested 2-step Path.
-        let ast = crate::parser::parse("Account.Order@$o.Product").unwrap();
+        let ast = crate::parser::Parser::new("Account.Order@$o.Product".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
         let result = resolve_ancestry(ast).unwrap();
         match result {
             AstNode::Path { steps } => {
@@ -574,7 +1116,10 @@ mod tests {
     #[test]
     fn test_real_parser_index_bind_multistep_prefix_and_suffix_is_flat() {
         // Same shape as above but for `#$i` (IndexBind) instead of `@$o`.
-        let ast = crate::parser::parse("Account.Order#$i.Product").unwrap();
+        let ast = crate::parser::Parser::new("Account.Order#$i.Product".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
         let result = resolve_ancestry(ast).unwrap();
         match result {
             AstNode::Path { steps } => {
@@ -590,5 +1135,405 @@ mod tests {
             }
             other => panic!("expected flat Path, got {:?}", other),
         }
+    }
+
+    // --- Task 4: `%`/`%.%` ancestor resolution, real-parser-based ---
+    //
+    // Ground truth for every test below was independently verified against
+    // jsonata-js's OWN `.ast()` output (`node -e 'jsonata(expr).ast()'` in
+    // tests/jsonata-js), not derived by hand. This is what caught the task
+    // brief's off-by-one (it asserted the wrong target steps for a `%.%`
+    // chain) before any code was written against it.
+
+    #[test]
+    fn test_real_parser_single_level_parent_resolves_to_previous_step() {
+        // "Account.Order.%" -- jsonata-js tags `Order` (steps[1]), and the
+        // trailing `%` step (steps[2]) carries the matching label. `%`
+        // refers to Order's own INPUT (i.e. what produced it, Account) --
+        // confirmed by live evaluation: Account.Order.% evaluates to the
+        // Account object, not the Order object.
+        let ast = crate::parser::Parser::new("Account.Order.%".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 3);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Account"));
+                assert!(steps[0].ancestor_label.is_none());
+                assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "Order"));
+                assert!(steps[1].ancestor_label.is_some());
+                assert!(steps[1].is_tuple);
+                match &steps[2].node {
+                    AstNode::Parent(label) => {
+                        assert_eq!(Some(label.clone()), steps[1].ancestor_label);
+                    }
+                    other => panic!("expected Parent(label), got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_chained_parent_resolves_two_levels_back() {
+        // "Account.Order.Product.%.%" (mirrors parent002.jsonata's shape).
+        // Ground truth from jsonata-js: the FIRST `%` tags Product
+        // (steps[2]), the SECOND `%` tags Order (steps[1]) -- NOT Order and
+        // Account as a naive reading might suggest. Each `%` targets the
+        // step whose INPUT it refers to: the first `%`'s target is Product
+        // (whose input is Order), the second `%` walks one step further
+        // back to Order (whose input is Account).
+        let ast = crate::parser::Parser::new("Account.Order.Product.%.%".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 5);
+                assert!(steps[0].ancestor_label.is_none(), "Account untagged");
+                let order_label = steps[1].ancestor_label.clone();
+                let product_label = steps[2].ancestor_label.clone();
+                assert!(order_label.is_some(), "Order must be tagged");
+                assert!(product_label.is_some(), "Product must be tagged");
+                assert_ne!(
+                    order_label, product_label,
+                    "two distinct % chains must get distinct labels"
+                );
+                match &steps[3].node {
+                    AstNode::Parent(label) => assert_eq!(Some(label.clone()), product_label),
+                    other => panic!("expected Parent(label), got {:?}", other),
+                }
+                match &steps[4].node {
+                    AstNode::Parent(label) => assert_eq!(Some(label.clone()), order_label),
+                    other => panic!("expected Parent(label), got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_object_constructor_percent_tags_preceding_step() {
+        // parent000.jsonata's shape: "Account.Order.Product.{'order': %.OrderID}"
+        // -- % lives INSIDE the object constructor's value, not as its own
+        // trailing path step. Ground truth (jsonata-js): Product (steps[2])
+        // gets tagged, and the nested %'s label matches.
+        let ast =
+            crate::parser::Parser::new("Account.Order.Product.{'order': %.OrderID}".to_string())
+                .unwrap()
+                .parse()
+                .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 4);
+                assert!(matches!(steps[2].node, AstNode::Name(ref n) if n == "Product"));
+                let product_label = steps[2].ancestor_label.clone();
+                assert!(product_label.is_some());
+                assert!(steps[2].is_tuple);
+                match &steps[3].node {
+                    AstNode::Object(pairs) => {
+                        assert_eq!(pairs.len(), 1);
+                        match &pairs[0].1 {
+                            AstNode::Path { steps: inner } => {
+                                assert_eq!(inner.len(), 2);
+                                match &inner[0].node {
+                                    AstNode::Parent(label) => {
+                                        assert_eq!(Some(label.clone()), product_label)
+                                    }
+                                    other => panic!("expected Parent(label), got {:?}", other),
+                                }
+                            }
+                            other => panic!("expected inner Path, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected Object, got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_object_constructor_two_percent_chains_share_and_differ() {
+        // parent002.jsonata's actual shape:
+        // "Account.Order.Product.{'Product':`Product Name`,'Order':%.OrderID,'Account':%.%.`Account Name`}"
+        // Ground truth (jsonata-js, verified via live .ast() dump): the
+        // 'Order' value's single `%` and the 'Account' value's FIRST `%`
+        // (of its `%.%` chain) both resolve to Product -- i.e. they share
+        // ONE label (the "reuse an existing label" mechanic) -- while the
+        // 'Account' value's SECOND `%` resolves to Order, getting a
+        // DIFFERENT label.
+        let ast = crate::parser::Parser::new(
+            "Account.Order.Product.{'Product':`Product Name`,'Order':%.OrderID,'Account':%.%.`Account Name`}"
+                .to_string(),
+        )
+        .unwrap()
+        .parse()
+        .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 4);
+                let product_label = steps[2].ancestor_label.clone();
+                let order_label = steps[1].ancestor_label.clone();
+                assert!(product_label.is_some(), "Product must be tagged");
+                assert!(order_label.is_some(), "Order must be tagged");
+                assert_ne!(product_label, order_label);
+
+                match &steps[3].node {
+                    AstNode::Object(pairs) => {
+                        assert_eq!(pairs.len(), 3);
+                        // pairs[1] = 'Order': %.OrderID
+                        match &pairs[1].1 {
+                            AstNode::Path { steps: inner } => match &inner[0].node {
+                                AstNode::Parent(label) => {
+                                    assert_eq!(Some(label.clone()), product_label)
+                                }
+                                other => panic!("expected Parent(label), got {:?}", other),
+                            },
+                            other => panic!("expected inner Path, got {:?}", other),
+                        }
+                        // pairs[2] = 'Account': %.%.`Account Name`
+                        match &pairs[2].1 {
+                            AstNode::Path { steps: inner } => {
+                                assert_eq!(inner.len(), 3);
+                                match &inner[0].node {
+                                    AstNode::Parent(label) => {
+                                        // Reuse: same label as the 'Order'
+                                        // value's % (both target Product).
+                                        assert_eq!(Some(label.clone()), product_label)
+                                    }
+                                    other => panic!("expected Parent(label), got {:?}", other),
+                                }
+                                match &inner[1].node {
+                                    AstNode::Parent(label) => {
+                                        assert_eq!(Some(label.clone()), order_label)
+                                    }
+                                    other => panic!("expected Parent(label), got {:?}", other),
+                                }
+                            }
+                            other => panic!("expected inner Path, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected Object, got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_percent_through_parenthesized_step_function_application() {
+        // parent001.jsonata's shape: "Account.(Order.Product).%" -- parens
+        // around a multi-step sub-path parse as a FunctionApplication step
+        // wrapping a nested Path. `%` must walk INTO that nested path to
+        // find Product (its last step) as the target, exactly as if the
+        // parens weren't there.
+        let ast = crate::parser::Parser::new("Account.(Order.Product).%".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 3);
+                assert!(steps[1].is_tuple, "the wrapping step must be flagged tuple");
+                match &steps[1].node {
+                    AstNode::FunctionApplication(inner) => match inner.as_ref() {
+                        AstNode::Path { steps: inner_steps } => {
+                            assert_eq!(inner_steps.len(), 2);
+                            assert!(
+                                matches!(inner_steps[0].node, AstNode::Name(ref n) if n == "Order")
+                            );
+                            assert!(
+                                matches!(inner_steps[1].node, AstNode::Name(ref n) if n == "Product")
+                            );
+                            let product_label = inner_steps[1].ancestor_label.clone();
+                            assert!(product_label.is_some(), "Product must be tagged");
+                            match &steps[2].node {
+                                AstNode::Parent(label) => {
+                                    assert_eq!(Some(label.clone()), product_label)
+                                }
+                                other => panic!("expected Parent(label), got {:?}", other),
+                            }
+                        }
+                        other => panic!("expected inner Path, got {:?}", other),
+                    },
+                    other => panic!("expected FunctionApplication, got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_percent_through_leading_paren_block() {
+        // parent006.jsonata's shape: "(Account.Order).(Product).{...}" -- a
+        // LEADING bare paren (not preceded by `.`) parses as a generic
+        // `Block` (not FunctionApplication), then becomes the first step of
+        // the outer path via the normal-dot fallback; `.(Product)` becomes a
+        // second, `FunctionApplication`-wrapped step.
+        //
+        // Ground truth from jsonata-js (verified via live `.ast()` dump,
+        // NOT hand-derived -- an earlier draft of this test wrongly assumed
+        // % must walk past the `(Product)` step into the `(Account.Order)`
+        // step to find Order; jsonata-js instead resolves it in ONE level,
+        // same as the un-parenthesized `Account.Order.Product.%` case):
+        // `%` (level 1) resolves entirely WITHIN the immediately preceding
+        // step -- the `(Product)` FunctionApplication -- tagging Product
+        // itself. The `(Account.Order)` block is never even visited.
+        let ast =
+            crate::parser::Parser::new("(Account.Order).(Product).{'x': %.OrderID}".to_string())
+                .unwrap()
+                .parse()
+                .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 3);
+                // steps[0]: the untouched (Account.Order) block.
+                match &steps[0].node {
+                    AstNode::Block(exprs) => {
+                        assert_eq!(exprs.len(), 1);
+                        match &exprs[0] {
+                            AstNode::Path { steps: inner } => {
+                                assert_eq!(inner.len(), 2);
+                                assert!(
+                                    matches!(inner[0].node, AstNode::Name(ref n) if n == "Account")
+                                );
+                                assert!(
+                                    matches!(inner[1].node, AstNode::Name(ref n) if n == "Order")
+                                );
+                                assert!(
+                                    inner[1].ancestor_label.is_none(),
+                                    "Order must NOT be tagged -- % resolves one level back, at Product"
+                                );
+                            }
+                            other => panic!("expected inner Path, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected Block, got {:?}", other),
+                }
+                assert!(!steps[0].is_tuple);
+                // steps[1]: the (Product) FunctionApplication -- this is
+                // where % actually resolves.
+                assert!(steps[1].is_tuple, "the wrapping step must be flagged tuple");
+                match &steps[1].node {
+                    AstNode::FunctionApplication(inner) => match inner.as_ref() {
+                        AstNode::Path { steps: inner_steps } => {
+                            assert_eq!(inner_steps.len(), 1);
+                            assert!(
+                                matches!(inner_steps[0].node, AstNode::Name(ref n) if n == "Product")
+                            );
+                            let product_label = inner_steps[0].ancestor_label.clone();
+                            assert!(product_label.is_some(), "Product must be tagged");
+                            match &steps[2].node {
+                                AstNode::Object(pairs) => match &pairs[0].1 {
+                                    AstNode::Path { steps: value_steps } => {
+                                        match &value_steps[0].node {
+                                            AstNode::Parent(label) => {
+                                                assert_eq!(Some(label.clone()), product_label)
+                                            }
+                                            other => {
+                                                panic!("expected Parent(label), got {:?}", other)
+                                            }
+                                        }
+                                    }
+                                    other => panic!("expected value Path, got {:?}", other),
+                                },
+                                other => panic!("expected Object, got {:?}", other),
+                            }
+                        }
+                        other => panic!("expected inner Path, got {:?}", other),
+                    },
+                    other => panic!("expected FunctionApplication, got {:?}", other),
+                }
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_percent_cannot_derive_ancestor_from_literal() {
+        // A `%` immediately after a step that isn't name/wildcard/block/path
+        // (here, a string literal step is folded to a Name by the parser's
+        // own S0213-adjacent handling, so use a case that stays non-
+        // resolvable: % with nothing at all before it in an enclosing path).
+        let ast = crate::parser::Parser::new("%.OrderID".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        let err = resolve_ancestry(ast).unwrap_err();
+        assert!(err.to_string().starts_with("S0217"));
+    }
+
+    #[test]
+    fn test_real_parser_lambda_body_percent_does_not_bubble_or_error() {
+        // "function(){ % }" -- jsonata-js parses this successfully (the raw
+        // `%` is left untouched inside the lambda body, only failing at
+        // runtime when/if the lambda is invoked). Confirms Lambda bodies
+        // don't bubble their pending to the enclosing scope.
+        let ast = crate::parser::Parser::new("function(){ % }".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Lambda { body, .. } => {
+                assert!(matches!(*body, AstNode::Parent(_)));
+            }
+            other => panic!("expected Lambda, got {:?}", other),
+        }
+    }
+
+    // --- S0215/S0216: `@` (focus binding) rejects a step that already has
+    // predicates or is a sort step. These checks were a pre-existing gap
+    // (never implemented, not even by Task 3) that only surfaced once
+    // ast_transform started running unconditionally via parser::parse():
+    // previously an unresolved `@`/`#` reaching the evaluator always threw
+    // (for the WRONG reason -- "must be resolved by ast_transform pass"),
+    // and the reference-suite harness lenient-accepts any error without an
+    // extractable code, masking the missing S0215/S0216 checks entirely.
+    // Ground truth: tests/jsonata-js/test/test-suite/groups/joins/errors.json.
+
+    #[test]
+    fn test_real_parser_focus_bind_after_predicate_is_s0215() {
+        let ast = crate::parser::Parser::new("Account.Order[1]@$o.Product".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        let err = resolve_ancestry(ast).unwrap_err();
+        assert!(err.to_string().starts_with("S0215"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_real_parser_focus_bind_after_sort_is_s0216() {
+        let ast = crate::parser::Parser::new(
+            "Account.Order^(>OrderID)@$o.Product.{ 'name':`Product Name`, 'orderid':$o.OrderID }"
+                .to_string(),
+        )
+        .unwrap()
+        .parse()
+        .unwrap();
+        let err = resolve_ancestry(ast).unwrap_err();
+        assert!(err.to_string().starts_with("S0216"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_real_parser_index_bind_after_predicate_is_not_an_error() {
+        // Unlike `@`, `#` has NO S0215-equivalent restriction in jsonata-js
+        // -- it's allowed after predicates (it just appends an index stage
+        // rather than setting a plain `index` field when stages already
+        // exist). Confirms `check_focus_bind_target`'s marker-kind guard
+        // correctly only fires for Focus, not Index.
+        let ast = crate::parser::Parser::new("Account.Order[1]#$o.Product".to_string())
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(resolve_ancestry(ast).is_ok());
     }
 }

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -54,6 +54,53 @@ pub fn resolve_ancestry(ast: AstNode) -> Result<AstNode, AstTransformError> {
     transform_node(ast, &mut labels)
 }
 
+/// A raw parse-time binding marker (`@$var` or `#$var`) that still needs to
+/// be migrated into `PathStep.focus`/`PathStep.index_var` + `is_tuple`.
+/// Shared between the "marker nested inside an existing `PathStep`" case
+/// (`migrate_binding_markers`) and the "marker is the top-level/raw node
+/// itself" case (`wrap_marker_as_path`), so the stamping logic itself lives
+/// in exactly one place: `apply_marker_to_step`.
+enum BindingMarker {
+    Focus(String),
+    Index(String),
+}
+
+/// Stamp a binding marker onto a step: sets `focus` or `index_var` (per the
+/// marker kind) and `is_tuple = true`. The single place that knows how a
+/// marker maps onto `PathStep` fields.
+fn apply_marker_to_step(step: &mut PathStep, marker: BindingMarker) {
+    match marker {
+        BindingMarker::Focus(var_name) => step.focus = Some(var_name),
+        BindingMarker::Index(var_name) => step.index_var = Some(var_name),
+    }
+    step.is_tuple = true;
+}
+
+/// Handle a `@$var`/`#$var` marker reaching `transform_node` as the raw node
+/// itself (not already nested inside a `PathStep`) -- e.g. `Order@$o` or
+/// `Account.Order@$o` where the parser's flat infix loop has already merged
+/// any preceding `.` steps into a `Path` (or, for a single bare name, left a
+/// non-Path leaf) *before* wrapping the whole thing in the marker node.
+///
+/// - If `transformed` is already a `Path`, the marker binds to its LAST step.
+/// - Otherwise (e.g. a bare `Name` with no `.` at all), wrap it into a new
+///   single-step `Path` and stamp the marker onto that one step.
+fn wrap_marker_as_path(transformed: AstNode, marker: BindingMarker) -> AstNode {
+    match transformed {
+        AstNode::Path { mut steps } => {
+            if let Some(last) = steps.last_mut() {
+                apply_marker_to_step(last, marker);
+            }
+            AstNode::Path { steps }
+        }
+        other => {
+            let mut step = PathStep::new(other);
+            apply_marker_to_step(&mut step, marker);
+            AstNode::Path { steps: vec![step] }
+        }
+    }
+}
+
 /// Recursively rebuild `node`, resolving any `%`/`@`/`#` found within.
 /// Mirrors jsonata-js's processAST's generic per-node-type dispatch.
 fn transform_node(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTransformError> {
@@ -77,11 +124,36 @@ fn transform_node(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, AstTr
             "S0217",
             "The parent operator % cannot be used at this point in the expression",
         )),
+        // `@$var` reaching transform_node as the raw top-level node itself
+        // (not nested inside an existing PathStep) -- e.g. `Order@$o` or
+        // `Account.Order@$o`, where the parser's flat infix loop applies `@`
+        // to the already-built lhs (a Path, or a bare leaf if there was no
+        // `.` at all) rather than to a single step. See `wrap_marker_as_path`.
+        AstNode::Binary {
+            op: BinaryOp::FocusBind,
+            lhs,
+            rhs,
+        } => {
+            let var_name = match *rhs {
+                AstNode::Variable(name) => name,
+                _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
+            };
+            let transformed_lhs = transform_node(*lhs, labels)?;
+            Ok(wrap_marker_as_path(
+                transformed_lhs,
+                BindingMarker::Focus(var_name),
+            ))
+        }
+        // Same story as FocusBind above, but for bare top-level `#$var`.
+        AstNode::IndexBind { input, variable } => {
+            let transformed_input = transform_node(*input, labels)?;
+            Ok(wrap_marker_as_path(
+                transformed_input,
+                BindingMarker::Index(variable),
+            ))
+        }
         // Recurse into every other node's children unchanged (no ancestor
         // resolution needed for nodes that aren't paths/blocks/parent refs).
-        // Binary/Unary/Function/etc. are handled generically here; Task 4
-        // extends this with predicate/sort-term-specific recursion once
-        // basic path resolution (this task) is proven correct.
         other => transform_children(other, labels),
     }
 }
@@ -106,6 +178,119 @@ fn transform_children(node: AstNode, labels: &mut LabelGen) -> Result<AstNode, A
                 .collect();
             Ok(AstNode::Array(transformed?))
         }
+        AstNode::Function {
+            name,
+            args,
+            is_builtin,
+        } => {
+            let transformed: Result<Vec<AstNode>, AstTransformError> = args
+                .into_iter()
+                .map(|a| transform_node(a, labels))
+                .collect();
+            Ok(AstNode::Function {
+                name,
+                args: transformed?,
+                is_builtin,
+            })
+        }
+        AstNode::Call { procedure, args } => {
+            let transformed_procedure = transform_node(*procedure, labels)?;
+            let transformed_args: Result<Vec<AstNode>, AstTransformError> = args
+                .into_iter()
+                .map(|a| transform_node(a, labels))
+                .collect();
+            Ok(AstNode::Call {
+                procedure: Box::new(transformed_procedure),
+                args: transformed_args?,
+            })
+        }
+        AstNode::Lambda {
+            params,
+            body,
+            signature,
+            thunk,
+        } => Ok(AstNode::Lambda {
+            params,
+            body: Box::new(transform_node(*body, labels)?),
+            signature,
+            thunk,
+        }),
+        AstNode::Object(pairs) => {
+            let transformed: Result<Vec<(AstNode, AstNode)>, AstTransformError> = pairs
+                .into_iter()
+                .map(|(k, v)| Ok((transform_node(k, labels)?, transform_node(v, labels)?)))
+                .collect();
+            Ok(AstNode::Object(transformed?))
+        }
+        AstNode::ObjectTransform { input, pattern } => {
+            let transformed_input = transform_node(*input, labels)?;
+            let transformed_pattern: Result<Vec<(AstNode, AstNode)>, AstTransformError> = pattern
+                .into_iter()
+                .map(|(k, v)| Ok((transform_node(k, labels)?, transform_node(v, labels)?)))
+                .collect();
+            Ok(AstNode::ObjectTransform {
+                input: Box::new(transformed_input),
+                pattern: transformed_pattern?,
+            })
+        }
+        AstNode::Conditional {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            let transformed_condition = transform_node(*condition, labels)?;
+            let transformed_then = transform_node(*then_branch, labels)?;
+            let transformed_else = match else_branch {
+                Some(e) => Some(Box::new(transform_node(*e, labels)?)),
+                None => None,
+            };
+            Ok(AstNode::Conditional {
+                condition: Box::new(transformed_condition),
+                then_branch: Box::new(transformed_then),
+                else_branch: transformed_else,
+            })
+        }
+        AstNode::Sort { input, terms } => {
+            let transformed_input = transform_node(*input, labels)?;
+            let transformed_terms: Result<Vec<(AstNode, bool)>, AstTransformError> = terms
+                .into_iter()
+                .map(|(expr, asc)| Ok((transform_node(expr, labels)?, asc)))
+                .collect();
+            Ok(AstNode::Sort {
+                input: Box::new(transformed_input),
+                terms: transformed_terms?,
+            })
+        }
+        AstNode::Transform {
+            location,
+            update,
+            delete,
+        } => {
+            let transformed_location = transform_node(*location, labels)?;
+            let transformed_update = transform_node(*update, labels)?;
+            let transformed_delete = match delete {
+                Some(d) => Some(Box::new(transform_node(*d, labels)?)),
+                None => None,
+            };
+            Ok(AstNode::Transform {
+                location: Box::new(transformed_location),
+                update: Box::new(transformed_update),
+                delete: transformed_delete,
+            })
+        }
+        AstNode::FunctionApplication(inner) => Ok(AstNode::FunctionApplication(Box::new(
+            transform_node(*inner, labels)?,
+        ))),
+        AstNode::ArrayGroup(elements) => {
+            let transformed: Result<Vec<AstNode>, AstTransformError> = elements
+                .into_iter()
+                .map(|e| transform_node(e, labels))
+                .collect();
+            Ok(AstNode::ArrayGroup(transformed?))
+        }
+        AstNode::Predicate(inner) => Ok(AstNode::Predicate(Box::new(transform_node(
+            *inner, labels,
+        )?))),
         // Leaf nodes and everything else pass through unchanged.
         other => Ok(other),
     }
@@ -147,13 +332,11 @@ fn migrate_binding_markers(
                 _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
             };
             step.node = transform_node(*lhs, labels)?;
-            step.focus = Some(var_name);
-            step.is_tuple = true;
+            apply_marker_to_step(&mut step, BindingMarker::Focus(var_name));
         }
         AstNode::IndexBind { input, variable } => {
             step.node = transform_node(*input, labels)?;
-            step.index_var = Some(variable);
-            step.is_tuple = true;
+            apply_marker_to_step(&mut step, BindingMarker::Index(variable));
         }
         other => {
             step.node = transform_node(other, labels)?;
@@ -233,5 +416,82 @@ mod tests {
             }
             other => panic!("expected Path, got {:?}", other),
         }
+    }
+
+    // --- Regression tests using the REAL parser (review findings) ---
+    //
+    // The 4 tests above hand-build synthetic ASTs and, per the review, only
+    // exercise the shapes that happen to already work. These tests instead
+    // go through `crate::parser::parse()` on real source text, which is what
+    // surfaced the two root-cause bugs: (1) transform_children not
+    // recursing into most composite node types, and (2) `@$var`/`#$var`
+    // never being migrated when the marker is the TOP-LEVEL node reaching
+    // transform_node (only when already nested inside a PathStep).
+
+    #[test]
+    fn test_real_parser_bare_focus_bind_no_dot() {
+        // "Order@$o" -- bare single-step, no dot anywhere. The parser
+        // produces Binary{FocusBind, lhs: Name("Order"), rhs: Variable("o")}
+        // at the top level (no Path at all, since there's no `.`).
+        let ast = crate::parser::parse("Order@$o").unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 1);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Order"));
+                assert_eq!(steps[0].focus, Some("o".to_string()));
+                assert!(steps[0].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_focus_bind_on_final_step_of_multistep_path() {
+        // "Account.Order@$o" -- 2-step path, marker on the final step, no
+        // trailing dot. Previously: `@` wrapped the whole 2-step Path in a
+        // top-level Binary{FocusBind,...} that was never migrated (Bug 2).
+        let ast = crate::parser::parse("Account.Order@$o").unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 2);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Account"));
+                assert!(steps[0].focus.is_none());
+                assert!(!steps[0].is_tuple);
+                assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "Order"));
+                assert_eq!(steps[1].focus, Some("o".to_string()));
+                assert!(steps[1].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_bare_index_bind() {
+        // "arr#$i" -- bare index bind, no dot. Previously never migrated
+        // when reaching transform_node as the raw top-level IndexBind node.
+        let ast = crate::parser::parse("arr#$i").unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 1);
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "arr"));
+                assert_eq!(steps[0].index_var, Some("i".to_string()));
+                assert!(steps[0].is_tuple);
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_bare_parent_inside_function_args_is_s0217() {
+        // "$count(%)" -- a bare `%` nested inside a Function call's args.
+        // Previously transform_children didn't recurse into Function args
+        // at all (Bug 1), so this silently returned Ok(unchanged) instead
+        // of raising S0217.
+        let ast = crate::parser::parse("$count(%)").unwrap();
+        let err = resolve_ancestry(ast).unwrap_err();
+        assert!(err.to_string().starts_with("S0217"));
     }
 }

--- a/src/ast_transform.rs
+++ b/src/ast_transform.rs
@@ -76,28 +76,49 @@ fn apply_marker_to_step(step: &mut PathStep, marker: BindingMarker) {
     step.is_tuple = true;
 }
 
-/// Handle a `@$var`/`#$var` marker reaching `transform_node` as the raw node
-/// itself (not already nested inside a `PathStep`) -- e.g. `Order@$o` or
-/// `Account.Order@$o` where the parser's flat infix loop has already merged
-/// any preceding `.` steps into a `Path` (or, for a single bare name, left a
-/// non-Path leaf) *before* wrapping the whole thing in the marker node.
+/// Core shared logic for both call sites that need to migrate a `@$var`/
+/// `#$var` marker: given the already-`transform_node`-recursed `lhs`/`input`
+/// that the marker was parsed against, produce the flat sequence of
+/// `PathStep`s the marker should resolve to.
 ///
-/// - If `transformed` is already a `Path`, the marker binds to its LAST step.
+/// Mirrors jsonata-js's `processAST` `case '@'`/`case '#'`:
+/// `result = processAST(expr.lhs); step = result; if (result.type ===
+/// 'path') { step = result.steps[result.steps.length - 1]; }` -- `result`
+/// (the possibly-multi-step path) is always what gets kept/spliced in, and
+/// only `step` (the thing that gets the marker's flags stamped onto it) is
+/// reassigned to the LAST step of that path when `result` is itself a path.
+///
+/// - If `transformed` is a multi-step `Path`, the marker's flags land on its
+///   LAST step, and ALL of its steps are returned to be spliced into the
+///   caller's flat steps list (never wrapped in a new outer step).
 /// - Otherwise (e.g. a bare `Name` with no `.` at all), wrap it into a new
 ///   single-step `Path` and stamp the marker onto that one step.
-fn wrap_marker_as_path(transformed: AstNode, marker: BindingMarker) -> AstNode {
+fn splice_marker_steps(transformed: AstNode, marker: BindingMarker) -> Vec<PathStep> {
     match transformed {
         AstNode::Path { mut steps } => {
             if let Some(last) = steps.last_mut() {
                 apply_marker_to_step(last, marker);
             }
-            AstNode::Path { steps }
+            steps
         }
         other => {
             let mut step = PathStep::new(other);
             apply_marker_to_step(&mut step, marker);
-            AstNode::Path { steps: vec![step] }
+            vec![step]
         }
+    }
+}
+
+/// Handle a `@$var`/`#$var` marker reaching `transform_node` as the raw node
+/// itself (not already nested inside a `PathStep`) -- e.g. `Order@$o` or
+/// `Account.Order@$o` where the parser's flat infix loop has already merged
+/// any preceding `.` steps into a `Path` (or, for a single bare name, left a
+/// non-Path leaf) *before* wrapping the whole thing in the marker node. At
+/// this (top-level) call site there's no outer steps list to splice into, so
+/// the spliced steps become the whole resulting `Path`.
+fn wrap_marker_as_path(transformed: AstNode, marker: BindingMarker) -> AstNode {
+    AstNode::Path {
+        steps: splice_marker_steps(transformed, marker),
     }
 }
 
@@ -307,20 +328,36 @@ fn transform_path_steps(
     // trailing `%` reference with no intervening predicates/sort terms.
     // Multi-level `%.%` chains and predicate/sort-term ancestor resolution
     // are Task 4.
+    //
+    // NOTE: this is a flat-map, not a 1:1 map -- a single input step whose
+    // node is a `@$var`/`#$var` marker over a multi-step `lhs`/`input` (e.g.
+    // `Account.Order@$o.Product`, where the parser wraps the ALREADY-BUILT
+    // 2-step `Path{Account,Order}` in a marker node and that whole marker
+    // node becomes ONE PathStep in the outer 2-step `[marker-step, Product]`
+    // list) must expand back into multiple output steps -- see
+    // `migrate_binding_markers`/`splice_marker_steps`. A single `.push()`
+    // per input step would leave the inner multi-step path nested inside a
+    // single wrapping step instead of flattened into the outer list.
     let mut resolved: Vec<PathStep> = Vec::with_capacity(steps.len());
     for step in steps {
-        resolved.push(migrate_binding_markers(step, labels)?);
+        resolved.extend(migrate_binding_markers(step, labels)?);
     }
     Ok(resolved)
 }
 
-/// Convert a step's raw-parse-time binding marker (if any) into the
-/// unified PathStep flags, recursing into the step's own node first (a
-/// step's node can itself be a Block/nested Path containing `%`/`@`/`#`).
+/// Convert a step's raw-parse-time binding marker (if any) into the unified
+/// PathStep flags, recursing into the step's own node first (a step's node
+/// can itself be a Block/nested Path containing `%`/`@`/`#`).
+///
+/// Returns a `Vec` (not a single `PathStep`) because a marker's `lhs`/`input`
+/// can itself turn out to be a multi-step `Path` -- see `splice_marker_steps`
+/// -- in which case ALL of those steps must be spliced into the caller's
+/// flat list in place of this one input step, with the marker's flags
+/// stamped onto the LAST of them (not onto a step wrapping the whole thing).
 fn migrate_binding_markers(
     mut step: PathStep,
     labels: &mut LabelGen,
-) -> Result<PathStep, AstTransformError> {
+) -> Result<Vec<PathStep>, AstTransformError> {
     match step.node {
         AstNode::Binary {
             op: BinaryOp::FocusBind,
@@ -331,18 +368,24 @@ fn migrate_binding_markers(
                 AstNode::Variable(name) => name,
                 _ => unreachable!("parser guarantees FocusBind's rhs is always Variable"),
             };
-            step.node = transform_node(*lhs, labels)?;
-            apply_marker_to_step(&mut step, BindingMarker::Focus(var_name));
+            let transformed_lhs = transform_node(*lhs, labels)?;
+            Ok(splice_marker_steps(
+                transformed_lhs,
+                BindingMarker::Focus(var_name),
+            ))
         }
         AstNode::IndexBind { input, variable } => {
-            step.node = transform_node(*input, labels)?;
-            apply_marker_to_step(&mut step, BindingMarker::Index(variable));
+            let transformed_input = transform_node(*input, labels)?;
+            Ok(splice_marker_steps(
+                transformed_input,
+                BindingMarker::Index(variable),
+            ))
         }
         other => {
             step.node = transform_node(other, labels)?;
+            Ok(vec![step])
         }
     }
-    Ok(step)
 }
 
 #[cfg(test)]
@@ -493,5 +536,59 @@ mod tests {
         let ast = crate::parser::parse("$count(%)").unwrap();
         let err = resolve_ancestry(ast).unwrap_err();
         assert!(err.to_string().starts_with("S0217"));
+    }
+
+    // --- Regression tests for the "nested Path from multi-step @/# marker"
+    // finding (second review round) ---
+    //
+    // `Account.Order@$o.Product` has >=2 path segments before the marker AND
+    // >=1 segment after. At parse time, `@$o` wraps the ALREADY-BUILT 2-step
+    // `Path{Account,Order}` in a `Binary{FocusBind,...}` node, and that whole
+    // node becomes step 0 of an outer 2-step list `[marker-step, Product]`.
+    // Previously `migrate_binding_markers` assigned the transformed lhs
+    // directly to `step.node` and stamped the marker onto that WRAPPING
+    // step, producing a corrupted nested shape instead of a flat path.
+
+    #[test]
+    fn test_real_parser_focus_bind_multistep_prefix_and_suffix_is_flat() {
+        // "Account.Order@$o.Product" must produce a FLAT 3-step path, not a
+        // 2-step path whose first step's node is itself a nested 2-step Path.
+        let ast = crate::parser::parse("Account.Order@$o.Product").unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 3, "expected a flat 3-step path");
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Account"));
+                assert!(steps[0].focus.is_none());
+                assert!(!steps[0].is_tuple);
+                assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "Order"));
+                assert_eq!(steps[1].focus, Some("o".to_string()));
+                assert!(steps[1].is_tuple);
+                assert!(matches!(steps[2].node, AstNode::Name(ref n) if n == "Product"));
+                assert!(steps[2].focus.is_none());
+            }
+            other => panic!("expected flat Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_real_parser_index_bind_multistep_prefix_and_suffix_is_flat() {
+        // Same shape as above but for `#$i` (IndexBind) instead of `@$o`.
+        let ast = crate::parser::parse("Account.Order#$i.Product").unwrap();
+        let result = resolve_ancestry(ast).unwrap();
+        match result {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 3, "expected a flat 3-step path");
+                assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Account"));
+                assert!(steps[0].index_var.is_none());
+                assert!(!steps[0].is_tuple);
+                assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "Order"));
+                assert_eq!(steps[1].index_var, Some("i".to_string()));
+                assert!(steps[1].is_tuple);
+                assert!(matches!(steps[2].node, AstNode::Name(ref n) if n == "Product"));
+                assert!(steps[2].index_var.is_none());
+            }
+            other => panic!("expected flat Path, got {:?}", other),
+        }
     }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3368,6 +3368,11 @@ impl Evaluator {
                     Ok(JValue::string("<lambda>"))
                 }
             }
+
+            // Parent-reference operator: should be resolved by ast_transform pass (Task 2)
+            AstNode::Parent => Err(EvaluatorError::EvaluationError(
+                "Parent operator (%) must be resolved by ast_transform pass".to_string(),
+            )),
         }
     }
 
@@ -5279,6 +5284,11 @@ impl Evaluator {
             BinaryOp::Concatenate => self.concatenate(&left, &right),
             BinaryOp::Range => self.range(&left, &right),
             BinaryOp::In => self.in_operator(&left, &right),
+
+            // Focus binding: should be resolved by ast_transform pass (Task 2)
+            BinaryOp::FocusBind => Err(EvaluatorError::EvaluationError(
+                "Focus binding operator (@) must be resolved by ast_transform pass".to_string(),
+            )),
 
             // These operators are all handled as special cases earlier in evaluate_binary_op
             BinaryOp::ColonEqual | BinaryOp::Coalesce | BinaryOp::Default | BinaryOp::ChainPipe => {
@@ -9036,6 +9046,7 @@ impl Evaluator {
             | AstNode::Regex { .. }
             | AstNode::Wildcard
             | AstNode::Descendant
+            | AstNode::Parent
             | AstNode::ParentVariable(_) => {}
         }
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -5112,6 +5112,44 @@ impl Evaluator {
                 .collect()
         };
 
+        // A sort step in a tuple stream orders the WHOLE stream (not per element)
+        // and re-tuples with the index = sorted position, mirroring jsonata-js
+        // evaluateTupleStep's `sort` case. `$^($)#$pos[$pos<3]` must sort the
+        // array, then number the sorted values, then filter by `$pos`.
+        if let AstNode::Sort { terms, .. } = &step.node {
+            let stream = JValue::array(
+                incoming
+                    .iter()
+                    .map(|t| JValue::object((**t).clone()))
+                    .collect(),
+            );
+            // evaluate_sort is tuple-aware (orders by each wrapper's `@`, with the
+            // carried keys bound), returning the wrappers in sorted order.
+            let sorted = self.evaluate_sort(&stream, terms)?;
+            let sorted_arr: Vec<JValue> = match sorted {
+                JValue::Array(a) => a.iter().cloned().collect(),
+                JValue::Null | JValue::Undefined => Vec::new(),
+                other => vec![other],
+            };
+            let mut result = Vec::new();
+            for (ss, elem) in sorted_arr.into_iter().enumerate() {
+                let mut new_tuple = match elem {
+                    JValue::Object(o) => (*o).clone(),
+                    other => {
+                        let mut m = IndexMap::new();
+                        m.insert("@".to_string(), other);
+                        m
+                    }
+                };
+                if let Some(index_var) = &step.index_var {
+                    new_tuple.insert(format!("${}", index_var), JValue::from(ss as i64));
+                }
+                new_tuple.insert("__tuple__".to_string(), JValue::Bool(true));
+                result.push(JValue::object(new_tuple));
+            }
+            return Ok(result);
+        }
+
         let mut result = Vec::new();
         for tuple_obj in incoming {
             // Bind every carried tuple key into a real scope frame so the step

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4012,15 +4012,6 @@ impl Evaluator {
                 return Ok(JValue::Undefined);
             }
 
-            // Tuple-binding step (@ focus / # index / % parent): create/extend the
-            // tuple stream, mirroring jsonata-js's evaluateTupleStep. Downstream
-            // (non-binding) steps then consume the {@, $var, !label, __tuple__}
-            // wrappers via the existing tuple-aware handling below.
-            if Self::step_creates_tuple(step) {
-                current = JValue::array(self.create_tuple_stream(step, &current)?);
-                continue;
-            }
-
             // Check if current is a tuple array - if so, we need to bind tuple variables
             // to context so they're available in nested expressions (like predicates)
             let is_tuple_array = if let JValue::Array(arr) = &current {
@@ -4034,6 +4025,28 @@ impl Evaluator {
             } else {
                 false
             };
+
+            // Tuple-binding step (@ focus / # index / % parent): create/extend the
+            // tuple stream, mirroring jsonata-js's evaluateTupleStep. Downstream
+            // (non-binding) steps then consume the {@, $var, !label, __tuple__}
+            // wrappers via the existing tuple-aware handling below.
+            //
+            // A `%` reference used AS a path step (`AstNode::Parent`, e.g. the
+            // `.%` in `Account.Order.Product.Price.%[...]`) must also extend the
+            // stream, but ONLY when it is consuming an existing tuple stream:
+            // its ancestor label lives in those incoming tuples, so
+            // create_tuple_stream's per-tuple frame binding is what lets
+            // `evaluate_internal(Parent, ..)` resolve it (and any predicate
+            // stage on the `%` step then resolves in the same frame). A `%`
+            // that instead LEADS a fresh path (e.g. the `%.OrderID` inside a
+            // predicate, whose input is plain data, not a tuple stream) must
+            // NOT be routed here -- it's an ordinary scope lookup.
+            let is_parent_step_over_tuple =
+                matches!(step.node, AstNode::Parent(_)) && is_tuple_array;
+            if Self::step_creates_tuple(step) || is_parent_step_over_tuple {
+                current = JValue::array(self.create_tuple_stream(step, &current)?);
+                continue;
+            }
 
             // For tuple arrays with certain step types, we need special handling to bind
             // tuple variables to context so they're available in nested expressions.
@@ -4575,6 +4588,7 @@ impl Evaluator {
     /// True when a path step carries a tuple-binding flag (`@$var` focus,
     /// `#$var` index, or a resolved `%` ancestor label) and must therefore
     /// produce/extend a tuple stream rather than be evaluated as a plain step.
+    ///
     fn step_creates_tuple(step: &PathStep) -> bool {
         step.focus.is_some() || step.index_var.is_some() || step.ancestor_label.is_some()
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3912,7 +3912,7 @@ impl Evaluator {
         // stream up front, mirroring jsonata-js's evaluateTupleStep for the
         // first path step where tupleBindings is undefined.
         let mut current: JValue = if Self::step_creates_tuple(&steps[0]) {
-            JValue::array(self.create_tuple_stream(&steps[0], data)?)
+            JValue::array(self.create_tuple_stream(&steps[0], data, true)?)
         } else {
             match &steps[0].node {
                 AstNode::Wildcard => {
@@ -4101,7 +4101,7 @@ impl Evaluator {
             let is_parent_step_over_tuple =
                 matches!(step.node, AstNode::Parent(_)) && is_tuple_array;
             if Self::step_creates_tuple(step) || is_parent_step_over_tuple {
-                current = JValue::array(self.create_tuple_stream(step, &current)?);
+                current = JValue::array(self.create_tuple_stream(step, &current, false)?);
                 continue;
             }
 
@@ -4167,9 +4167,27 @@ impl Evaluator {
                                     // Variable lookup - check context (which now has bindings)
                                     self.evaluate_internal(&step.node, tuple)?
                                 }
-                                AstNode::Object(_) | AstNode::FunctionApplication(_) => {
-                                    // Object constructor or function application - evaluate on actual data
+                                AstNode::Object(_) => {
+                                    // Object constructor - evaluate on actual data
                                     self.evaluate_internal(&step.node, &actual_data)?
+                                }
+                                AstNode::FunctionApplication(inner) => {
+                                    // A parenthesized step `(expr)` consuming a tuple stream
+                                    // (e.g. `Account.Order.Product.( %.OrderID )` or
+                                    // `Employee@$e.(Contact)[...]`): evaluate the INNER
+                                    // expression on the tuple's `@` value with `$` bound to
+                                    // it, mirroring the non-tuple FunctionApplication step
+                                    // handling. Routing the wrapper node itself through
+                                    // evaluate_internal raises "Function application can only
+                                    // be used in path expressions".
+                                    let saved_dollar = self.context.lookup("$").cloned();
+                                    self.context.bind("$".to_string(), actual_data.clone());
+                                    let v = self.evaluate_internal(inner, &actual_data);
+                                    match saved_dollar {
+                                        Some(s) => self.context.bind("$".to_string(), s),
+                                        None => self.context.unbind("$"),
+                                    }
+                                    v?
                                 }
                                 _ => unreachable!(), // We only match specific types above
                             };
@@ -4385,9 +4403,55 @@ impl Evaluator {
                                                 };
 
                                                 if !stages.is_empty() {
+                                                    // Bind this tuple's carried focus/index/ancestor
+                                                    // bindings so a filter predicate that references
+                                                    // them resolves -- e.g. `library.loans@$l.books[$l.isbn=isbn]`,
+                                                    // where the `[$l.isbn=isbn]` stage on the (non-focus)
+                                                    // `books` step must see `$l` from the enclosing
+                                                    // `@$l` focus stream. Without this the predicate
+                                                    // evaluates `$l` as unbound and filters everything out.
+                                                    let saved_tuple: Vec<(String, Option<JValue>)> =
+                                                        obj.iter()
+                                                            .filter_map(|(k, _)| {
+                                                                if let Some(n) = k.strip_prefix('$')
+                                                                {
+                                                                    (!n.is_empty())
+                                                                        .then(|| n.to_string())
+                                                                } else if k.starts_with('!') {
+                                                                    Some(k.clone())
+                                                                } else {
+                                                                    None
+                                                                }
+                                                            })
+                                                            .map(|n| {
+                                                                (
+                                                                    n.clone(),
+                                                                    self.context
+                                                                        .lookup(&n)
+                                                                        .cloned(),
+                                                                )
+                                                            })
+                                                            .collect();
+                                                    for (k, v) in obj.iter() {
+                                                        if let Some(n) = k.strip_prefix('$') {
+                                                            if !n.is_empty() {
+                                                                self.context
+                                                                    .bind(n.to_string(), v.clone());
+                                                            }
+                                                        } else if k.starts_with('!') {
+                                                            self.context.bind(k.clone(), v.clone());
+                                                        }
+                                                    }
                                                     // Apply stages to the extracted value
                                                     let processed_val =
-                                                        self.apply_stages(val, stages)?;
+                                                        self.apply_stages(val, stages);
+                                                    for (n, old) in saved_tuple.into_iter().rev() {
+                                                        match old {
+                                                            Some(v) => self.context.bind(n, v),
+                                                            None => self.context.unbind(&n),
+                                                        }
+                                                    }
+                                                    let processed_val = processed_val?;
                                                     // Stages always return an array (or null); extend results
                                                     match processed_val {
                                                         JValue::Array(arr) => {
@@ -4675,6 +4739,7 @@ impl Evaluator {
         &mut self,
         step: &PathStep,
         input: &JValue,
+        is_first_path_step: bool,
     ) -> Result<Vec<JValue>, EvaluatorError> {
         use std::rc::Rc;
 
@@ -4702,7 +4767,22 @@ impl Evaluator {
             }
         } else {
             let items: Vec<JValue> = match input {
-                JValue::Array(arr) => arr.iter().cloned().collect(),
+                // Mirrors jsonata-js evaluatePath's inputSequence rule
+                // (`if (Array.isArray(input) && expr.steps[0].type !== 'variable')`):
+                // ONLY when the path's FIRST step is a variable reference (`$`/`$$`)
+                // is the input array taken as a SINGLE sequence value
+                // (`createSequence(input)`) rather than iterated per-element. This
+                // is what makes `$#$pos` bind `$pos` to each element's position
+                // within the whole array (one incoming tuple whose `@` is the
+                // array, then the inner `bb` counter walks its elements) instead of
+                // producing one singleton tuple per element (index always 0). The
+                // rule is scoped to step 0 so `$.$#$pos` (where `$#$pos` is a later
+                // step) still iterates per-element.
+                JValue::Array(arr)
+                    if !(is_first_path_step && matches!(&step.node, AstNode::Variable(_))) =>
+                {
+                    arr.iter().cloned().collect()
+                }
                 single => vec![single.clone()],
             };
             items
@@ -4786,6 +4866,10 @@ impl Evaluator {
                     new_tuple.insert("@".to_string(), value);
                 }
                 if let Some(index_var) = &step.index_var {
+                    // Index binding records the position of this value WITHIN the
+                    // per-binding result row (jsonata-js evaluateTupleStep: the
+                    // inner `bb` counter, `tuple[expr.index] = bb`), which resets
+                    // for each incoming tuple.
                     new_tuple.insert(format!("${}", index_var), JValue::from(position as i64));
                 }
                 if let Some(ancestor_label) = &step.ancestor_label {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2446,6 +2446,46 @@ impl Default for Context {
 /// the top level. This recurses through both array elements and (non-tuple)
 /// object field values so both shapes are cleaned up, not just a bare
 /// top-level tuple array.
+/// Merge a group of tuple wrappers into a single tuple, appending each key's
+/// values across the group. Mirrors jsonata-js `reduceTupleStream`
+/// (`Object.assign(result, tuple[0]); result[prop] = append(result[prop], ...)`):
+/// a key present in one tuple stays a scalar; a key present in several becomes an
+/// array of the collected values (used by group-by value evaluation so a group
+/// of N tuples exposes `@` as the N collected `@` values and each `$focus` as the
+/// N collected focus values).
+fn reduce_tuple_stream(group: &[JValue]) -> IndexMap<String, JValue> {
+    fn append(acc: Option<JValue>, v: JValue) -> JValue {
+        match acc {
+            None => v,
+            Some(a) => {
+                let mut out: Vec<JValue> = match a {
+                    JValue::Array(arr) => arr.iter().cloned().collect(),
+                    other => vec![other],
+                };
+                match v {
+                    JValue::Array(arr) => out.extend(arr.iter().cloned()),
+                    other => out.push(other),
+                }
+                JValue::array(out)
+            }
+        }
+    }
+    let mut result: IndexMap<String, JValue> = IndexMap::new();
+    for tuple in group {
+        if let JValue::Object(obj) = tuple {
+            for (k, v) in obj.iter() {
+                if k == "__tuple__" {
+                    result.insert(k.clone(), v.clone());
+                    continue;
+                }
+                let merged = append(result.shift_remove(k), v.clone());
+                result.insert(k.clone(), merged);
+            }
+        }
+    }
+    result
+}
+
 fn unwrap_tuple_output(value: JValue) -> JValue {
     match value {
         JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)) => obj
@@ -3148,6 +3188,51 @@ impl Evaluator {
                     items
                 };
 
+                // Grouping over a tuple stream ("reduce" mode, mirroring
+                // jsonata-js evaluateGroupExpression): each item is a
+                // `{@, $var, !label, __tuple__}` wrapper. The key/value
+                // expressions are evaluated against the tuple's `@` value with the
+                // carried focus/index/ancestor keys bound into scope (so
+                // `...@$e...{ $e.FirstName: Phone[type='mobile'].number }` reads
+                // `$e` AND resolves the relative `Phone` against the Contact `@`),
+                // and grouped tuples are reduced (per-key values appended) before
+                // the value expression sees them.
+                let reduce = items.first().is_some_and(|it| {
+                    matches!(it, JValue::Object(o) if o.get("__tuple__") == Some(&JValue::Bool(true)))
+                });
+
+                // Bind a tuple wrapper's carried `$var`/`!label` keys into scope;
+                // returns the saved prior values so they can be restored.
+                let bind_tuple = |ev: &mut Self,
+                                  tuple: &IndexMap<String, JValue>|
+                 -> Vec<(String, Option<JValue>)> {
+                    let mut saved = Vec::new();
+                    for (k, v) in tuple.iter() {
+                        let name = if let Some(n) = k.strip_prefix('$') {
+                            if n.is_empty() {
+                                continue;
+                            } else {
+                                n.to_string()
+                            }
+                        } else if k.starts_with('!') {
+                            k.clone()
+                        } else {
+                            continue;
+                        };
+                        saved.push((name.clone(), ev.context.lookup(&name).cloned()));
+                        ev.context.bind(name, v.clone());
+                    }
+                    saved
+                };
+                let restore = |ev: &mut Self, saved: Vec<(String, Option<JValue>)>| {
+                    for (name, old) in saved.into_iter().rev() {
+                        match old {
+                            Some(v) => ev.context.bind(name, v),
+                            None => ev.context.unbind(&name),
+                        }
+                    }
+                };
+
                 // Phase 1: Group items by key expression
                 // groups maps key -> (grouped_data, expr_index)
                 // When multiple items have same key, their data is appended together
@@ -3157,18 +3242,32 @@ impl Evaluator {
                 let saved_dollar = self.context.lookup("$").cloned();
 
                 for item in &items {
-                    // Bind $ to the current item for key evaluation
-                    self.context.bind("$".to_string(), item.clone());
+                    // In reduce mode evaluate the key against `@` with tuple keys
+                    // bound; otherwise against the item itself.
+                    let (key_data, tuple_saved) = match (reduce, item) {
+                        (true, JValue::Object(o)) => {
+                            let saved = bind_tuple(self, o);
+                            (
+                                o.get("@").cloned().unwrap_or(JValue::Undefined),
+                                Some(saved),
+                            )
+                        }
+                        _ => (item.clone(), None),
+                    };
+                    self.context.bind("$".to_string(), key_data.clone());
 
                     for (pair_index, (key_node, _value_node)) in pattern.iter().enumerate() {
                         // Evaluate key with current item as context
-                        let key = match self.evaluate_internal(key_node, item)? {
+                        let key = match self.evaluate_internal(key_node, &key_data)? {
                             JValue::String(s) => s,
                             JValue::Null => continue, // Skip null keys
                             other => {
                                 // Skip undefined keys
                                 if other.is_undefined() {
                                     continue;
+                                }
+                                if let Some(saved) = tuple_saved {
+                                    restore(self, saved);
                                 }
                                 return Err(EvaluatorError::TypeError(format!(
                                     "T1003: Object key must be a string, got: {:?}",
@@ -3181,6 +3280,9 @@ impl Evaluator {
                         if let Some((existing_data, existing_idx)) = groups.get_mut(&*key) {
                             // Key already exists - check if from same expression index
                             if *existing_idx != pair_index {
+                                if let Some(saved) = tuple_saved {
+                                    restore(self, saved);
+                                }
                                 // D1009: multiple key expressions evaluate to same key
                                 return Err(EvaluatorError::EvaluationError(format!(
                                     "D1009: Multiple key expressions evaluate to same key: {}",
@@ -3194,6 +3296,10 @@ impl Evaluator {
                             groups.insert(key.to_string(), (vec![item.clone()], pair_index));
                         }
                     }
+
+                    if let Some(saved) = tuple_saved {
+                        restore(self, saved);
+                    }
                 }
 
                 // Phase 2: Evaluate value expression for each group
@@ -3202,6 +3308,26 @@ impl Evaluator {
                 for (key, (grouped_data, expr_index)) in groups {
                     // Get the value expression for this group
                     let (_key_node, value_node) = &pattern[expr_index];
+
+                    if reduce {
+                        // Reduce the grouped tuples into one (per-key values
+                        // appended), mirroring jsonata-js reduceTupleStream, then
+                        // evaluate the value against the merged `@` with the merged
+                        // focus/index/ancestor keys bound.
+                        let merged = reduce_tuple_stream(&grouped_data);
+                        let context = merged.get("@").cloned().unwrap_or(JValue::Undefined);
+                        let mut tuple_no_at = merged.clone();
+                        tuple_no_at.shift_remove("@");
+                        let saved = bind_tuple(self, &tuple_no_at);
+                        self.context.bind("$".to_string(), context.clone());
+                        let value = self.evaluate_internal(value_node, &context);
+                        restore(self, saved);
+                        let value = value?;
+                        if !value.is_undefined() {
+                            result.insert(key, value);
+                        }
+                        continue;
+                    }
 
                     // Determine the context for value evaluation:
                     // - If single item, use that item directly

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3302,37 +3302,6 @@ impl Evaluator {
                 self.evaluate_sort(&value, terms)
             }
 
-            // Index binding: evaluates input and creates tuple stream with index variable
-            AstNode::IndexBind { input, variable } => {
-                let value = self.evaluate_internal(input, data)?;
-
-                // Store the variable name and create indexed results
-                // This is a simplified implementation - full tuple stream would require more work
-                match value {
-                    JValue::Array(arr) => {
-                        // Store the index binding metadata in a special wrapper
-                        let mut result = Vec::new();
-                        for (idx, item) in arr.iter().enumerate() {
-                            // Create wrapper object with value and index
-                            let mut wrapper = IndexMap::new();
-                            wrapper.insert("@".to_string(), item.clone());
-                            wrapper.insert(format!("${}", variable), JValue::Number(idx as f64));
-                            wrapper.insert("__tuple__".to_string(), JValue::Bool(true));
-                            result.push(JValue::object(wrapper));
-                        }
-                        Ok(JValue::array(result))
-                    }
-                    // Single value: just return as-is with index 0
-                    other => {
-                        let mut wrapper = IndexMap::new();
-                        wrapper.insert("@".to_string(), other);
-                        wrapper.insert(format!("${}", variable), JValue::from(0i64));
-                        wrapper.insert("__tuple__".to_string(), JValue::Bool(true));
-                        Ok(JValue::object(wrapper))
-                    }
-                }
-            }
-
             // Transform: |location|update[,delete]|
             AstNode::Transform {
                 location,
@@ -3370,7 +3339,7 @@ impl Evaluator {
             }
 
             // Parent-reference operator: should be resolved by ast_transform pass (Task 2)
-            AstNode::Parent => Err(EvaluatorError::EvaluationError(
+            AstNode::Parent(_) => Err(EvaluatorError::EvaluationError(
                 "Parent operator (%) must be resolved by ast_transform pass".to_string(),
             )),
         }
@@ -3996,10 +3965,6 @@ impl Evaluator {
                 // Predicate as first step
                 self.evaluate_predicate(data, pred_expr)?
             }
-            AstNode::IndexBind { .. } => {
-                // Index binding as first step - evaluate the IndexBind to create tuple array
-                self.evaluate_internal(&steps[0].node, data)?
-            }
             _ => {
                 // Complex first step - evaluate it
                 self.evaluate_path_step(&steps[0].node, data, data)?
@@ -4503,32 +4468,6 @@ impl Evaluator {
                 AstNode::Sort { terms, .. } => {
                     // Sort as a path step - sort 'current' by the terms
                     self.evaluate_sort(&current, terms)?
-                }
-                AstNode::IndexBind { variable, .. } => {
-                    // Index binding as a path step - creates tuple stream from current
-                    // This wraps each element with an index binding
-                    match &current {
-                        JValue::Array(arr) => {
-                            let mut result = Vec::new();
-                            for (idx, item) in arr.iter().enumerate() {
-                                let mut wrapper = IndexMap::new();
-                                wrapper.insert("@".to_string(), item.clone());
-                                wrapper
-                                    .insert(format!("${}", variable), JValue::Number(idx as f64));
-                                wrapper.insert("__tuple__".to_string(), JValue::Bool(true));
-                                result.push(JValue::object(wrapper));
-                            }
-                            JValue::array(result)
-                        }
-                        other => {
-                            // Single value: wrap with index 0
-                            let mut wrapper = IndexMap::new();
-                            wrapper.insert("@".to_string(), other.clone());
-                            wrapper.insert(format!("${}", variable), JValue::from(0i64));
-                            wrapper.insert("__tuple__".to_string(), JValue::Bool(true));
-                            JValue::object(wrapper)
-                        }
-                    }
                 }
                 // Handle complex path steps (e.g., computed properties, object construction)
                 _ => self.evaluate_path_step(&step.node, &current, data)?,
@@ -5288,6 +5227,13 @@ impl Evaluator {
             // Focus binding: should be resolved by ast_transform pass (Task 2)
             BinaryOp::FocusBind => Err(EvaluatorError::EvaluationError(
                 "Focus binding operator (@) must be resolved by ast_transform pass".to_string(),
+            )),
+
+            // Index binding: should be resolved by ast_transform pass (Task 4,
+            // which retired the dedicated AstNode::IndexBind variant in favor
+            // of this generic Binary marker, mirroring FocusBind above)
+            BinaryOp::IndexBind => Err(EvaluatorError::EvaluationError(
+                "Index binding operator (#) must be resolved by ast_transform pass".to_string(),
             )),
 
             // These operators are all handled as special cases earlier in evaluate_binary_op
@@ -9021,9 +8967,6 @@ impl Evaluator {
                     Self::collect_free_vars_walk(expr, bound, free);
                 }
             }
-            AstNode::IndexBind { input, .. } => {
-                Self::collect_free_vars_walk(input, bound, free);
-            }
             AstNode::Transform {
                 location,
                 update,
@@ -9046,7 +8989,7 @@ impl Evaluator {
             | AstNode::Regex { .. }
             | AstNode::Wildcard
             | AstNode::Descendant
-            | AstNode::Parent
+            | AstNode::Parent(_)
             | AstNode::ParentVariable(_) => {}
         }
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4652,12 +4652,32 @@ impl Evaluator {
             let actual_data = tuple_obj.get("@").cloned().unwrap_or(JValue::Undefined);
             let step_value = self.evaluate_internal(&step.node, &actual_data);
 
-            for name in &bound_names {
-                self.context.unbind(name);
-            }
             let mut step_value = step_value?;
             if !step.stages.is_empty() {
+                // A `%` inside a filter predicate refers to the ancestry of
+                // THIS step (its own input for a level-1 `%`, or an earlier
+                // step's input for a `%.%` chain). ast_transform tags this step
+                // with `ancestor_label`; bind it to the step's input so the
+                // level-1 `%` resolves. The `%.%` chain's deeper references use
+                // labels carried in the INCOMING tuple, so those bindings
+                // (`bound_names`) must stay live through `apply_stages` -- their
+                // unbind is deferred until after it (previously they were
+                // unbound first, which silently broke `%.%` inside predicates).
+                let own_label = match &step.ancestor_label {
+                    Some(label) if !bound_names.contains(label) => {
+                        self.context.bind(label.clone(), actual_data.clone());
+                        Some(label.clone())
+                    }
+                    _ => None,
+                };
                 step_value = self.apply_stages(step_value, &step.stages)?;
+                if let Some(label) = own_label {
+                    self.context.unbind(&label);
+                }
+            }
+
+            for name in &bound_names {
+                self.context.unbind(name);
             }
 
             let row: Vec<JValue> = match step_value {
@@ -9756,6 +9776,30 @@ impl Evaluator {
         for (idx, element) in array.iter().enumerate() {
             let mut sort_keys = Vec::new();
 
+            // When sorting a tuple stream (the input path had a `%`/`@`/`#`
+            // step, so each element is a `{@, !label, $var, __tuple__}`
+            // wrapper), bind its carried ancestor/focus/index keys into scope
+            // so a `%` (or `$focus`) inside a sort term resolves -- mirroring
+            // create_tuple_stream's per-tuple frame binding. Sort terms attach
+            // to a synthetic step after the last input step, so `%` refers to
+            // the last input step's ancestry, carried under `!label` here.
+            let mut tuple_bound: Vec<String> = Vec::new();
+            if let JValue::Object(obj) = element {
+                if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
+                    for (key, value) in obj.iter() {
+                        if let Some(name) = key.strip_prefix('$') {
+                            if !name.is_empty() {
+                                self.context.bind(name.to_string(), value.clone());
+                                tuple_bound.push(name.to_string());
+                            }
+                        } else if key.starts_with('!') {
+                            self.context.bind(key.clone(), value.clone());
+                            tuple_bound.push(key.clone());
+                        }
+                    }
+                }
+            }
+
             // Evaluate each sort term with $ bound to the element
             for (term_expr, _ascending) in terms {
                 // Save current $ binding
@@ -9775,6 +9819,10 @@ impl Evaluator {
                 }
 
                 sort_keys.push(sort_value);
+            }
+
+            for name in &tuple_bound {
+                self.context.unbind(name);
             }
 
             indexed_array.push((idx, sort_keys));

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4843,17 +4843,22 @@ impl Evaluator {
             let items: Vec<JValue> = match input {
                 // Mirrors jsonata-js evaluatePath's inputSequence rule
                 // (`if (Array.isArray(input) && expr.steps[0].type !== 'variable')`):
-                // ONLY when the path's FIRST step is a variable reference (`$`/`$$`)
-                // is the input array taken as a SINGLE sequence value
-                // (`createSequence(input)`) rather than iterated per-element. This
-                // is what makes `$#$pos` bind `$pos` to each element's position
-                // within the whole array (one incoming tuple whose `@` is the
-                // array, then the inner `bb` counter walks its elements) instead of
-                // producing one singleton tuple per element (index always 0). The
-                // rule is scoped to step 0 so `$.$#$pos` (where `$#$pos` is a later
-                // step) still iterates per-element.
+                // when the path's FIRST step is a variable reference (`$`/`$$`) the
+                // input array is taken as a SINGLE sequence value
+                // (`createSequence(input)`) rather than iterated per-element. We
+                // only need this for a leading INDEX bind (`$#$pos`): the whole
+                // array becomes one incoming tuple whose `@` is the array, then
+                // the inner position counter walks its elements so `$pos` runs
+                // 0..n-1 (not 0 for every singleton). A leading FOCUS bind
+                // (`$@$i`) must instead iterate per-element -- focus keeps `@` as
+                // the step input, so a single binding would yield one copy of the
+                // whole array per element (`$@$i` on [1,2,3] must give [1,2,3],
+                // not [[1,2,3],[1,2,3],[1,2,3]]). The rule is scoped to step 0 so
+                // `$.$#$pos` (a later step) still iterates per-element.
                 JValue::Array(arr)
-                    if !(is_first_path_step && matches!(&step.node, AstNode::Variable(_))) =>
+                    if !(is_first_path_step
+                        && matches!(&step.node, AstNode::Variable(_))
+                        && step.index_var.is_some()) =>
                 {
                     arr.iter().cloned().collect()
                 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4986,22 +4986,12 @@ impl Evaluator {
         // JSONata singleton unwrapping: singleton results are unwrapped when we did array operations
         // BUT NOT when there's an explicit array-keeping operation like [] (empty predicate)
 
-        // Check for explicit array-keeping operations
-        // Empty predicate [] can be represented as:
-        // 1. Predicate(Boolean(true)) as a path step node
-        // 2. Stage::Filter(Boolean(true)) as a stage
-        let has_explicit_array_keep = steps.iter().any(|step| {
-            // Check if the step itself is an empty predicate
-            if let AstNode::Predicate(pred) = &step.node {
-                if matches!(**pred, AstNode::Boolean(true)) {
-                    return true;
-                }
-            }
-            // Check if any stage is an empty predicate
-            step.stages.iter().any(|stage| {
-                matches!(stage, crate::ast::Stage::Filter(pred) if matches!(**pred, AstNode::Boolean(true)))
-            })
-        });
+        // Check for explicit array-keeping operations. Empty predicate `[]` can
+        // be a `Predicate(Boolean(true))` step node or a `Filter(Boolean(true))`
+        // stage; it also counts when it sits inside a `Sort` step's input path
+        // (e.g. `$#$pos[][$pos<3]^($)[-1]`), whose keep-array-ness must survive
+        // the sort and the trailing index so the singleton stays `[4]`.
+        let has_explicit_array_keep = Self::path_keeps_singleton_array(steps);
 
         // Unwrap when:
         // 1. Any step has stages (predicates, sorts, etc.) which are array operations, OR
@@ -5028,6 +5018,17 @@ impl Evaluator {
             _ => current,
         };
 
+        // An explicit `[]` keep-array forces the result to remain an array even
+        // after a later singleton index collapses it to a scalar (jsonata's
+        // keepSingleton), e.g. `$#$pos[][$pos<3]^($)[-1]` must yield `[4]`.
+        let result = if has_explicit_array_keep
+            && !matches!(result, JValue::Array(_) | JValue::Null | JValue::Undefined)
+        {
+            JValue::array(vec![result])
+        } else {
+            result
+        };
+
         Ok(result)
     }
 
@@ -5037,6 +5038,32 @@ impl Evaluator {
     ///
     fn step_creates_tuple(step: &PathStep) -> bool {
         step.focus.is_some() || step.index_var.is_some() || step.ancestor_label.is_some()
+    }
+
+    /// True when a path contains an explicit empty predicate `[]` (keep-array),
+    /// either directly as a step/stage or nested inside a `Sort` step's input
+    /// path. The keep-array-ness of an inner `[]` must survive an enclosing sort
+    /// and trailing index so a singleton result stays wrapped (`$#$pos[]...^()[-1]`
+    /// -> `[4]`).
+    fn path_keeps_singleton_array(steps: &[PathStep]) -> bool {
+        steps.iter().any(|step| {
+            if let AstNode::Predicate(pred) = &step.node {
+                if matches!(**pred, AstNode::Boolean(true)) {
+                    return true;
+                }
+            }
+            if step.stages.iter().any(
+                |s| matches!(s, Stage::Filter(pred) if matches!(**pred, AstNode::Boolean(true))),
+            ) {
+                return true;
+            }
+            if let AstNode::Sort { input, .. } = &step.node {
+                if let AstNode::Path { steps: inner } = input.as_ref() {
+                    return Self::path_keeps_singleton_array(inner);
+                }
+            }
+            false
+        })
     }
 
     /// Create or extend a tuple stream for a tuple-binding path step, mirroring

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1426,6 +1426,17 @@ fn try_compile_path(
     //     previous step's filter slot, since both encodings have identical runtime semantics.
     let mut compiled_steps = Vec::with_capacity(field_steps.len());
     for step in field_steps {
+        // Tuple-stream steps (@ focus / # index / % parent binding) require the
+        // tree-walker's tuple machinery (create_tuple_stream / evaluate_path's
+        // tuple handling). Never compile them to the flat bytecode field path,
+        // which is unaware of the binding flags and would silently drop them.
+        if step.focus.is_some()
+            || step.index_var.is_some()
+            || step.ancestor_label.is_some()
+            || step.is_tuple
+        {
+            return None;
+        }
         match &step.node {
             AstNode::Name(name) => {
                 let filter = match step.stages.as_slice() {
@@ -3338,10 +3349,17 @@ impl Evaluator {
                 }
             }
 
-            // Parent-reference operator: should be resolved by ast_transform pass (Task 2)
-            AstNode::Parent(_) => Err(EvaluatorError::EvaluationError(
-                "Parent operator (%) must be resolved by ast_transform pass".to_string(),
-            )),
+            // Parent-reference operator (%): ast_transform has already resolved
+            // this to a synthetic ancestor label ("!0", "!1", ...). The enclosing
+            // tuple step binds that label into scope (create_tuple_stream +
+            // needs_tuple_context_binding), so resolving it is an ordinary scope
+            // lookup, mirroring jsonata-js's
+            // `case 'parent': result = environment.lookup(expr.slot.label);`.
+            AstNode::Parent(label) => Ok(self
+                .context
+                .lookup(label)
+                .cloned()
+                .unwrap_or(JValue::Undefined)),
         }
     }
 
@@ -3627,8 +3645,10 @@ impl Evaluator {
         }
 
         // Fast path: single field access on object
-        // This is a very common pattern, so optimize it
-        if steps.len() == 1 {
+        // This is a very common pattern, so optimize it.
+        // Skipped for tuple-binding steps (@/#/%), which need full tuple-stream
+        // creation handled below.
+        if steps.len() == 1 && !Self::step_creates_tuple(&steps[0]) {
             if let AstNode::Name(field_name) = &steps[0].node {
                 return match data {
                     JValue::Object(obj) => {
@@ -3830,144 +3850,154 @@ impl Evaluator {
         // Track whether we did array mapping (for singleton unwrapping)
         let mut did_array_mapping = false;
 
-        // For the first step, work with a reference
-        let mut current: JValue = match &steps[0].node {
-            AstNode::Wildcard => {
-                // Wildcard as first step
-                match data {
-                    JValue::Object(obj) => {
-                        let mut result = Vec::new();
-                        for value in obj.values() {
-                            // Flatten arrays into the result
-                            match value {
-                                JValue::Array(arr) => result.extend(arr.iter().cloned()),
-                                _ => result.push(value.clone()),
+        // For the first step, work with a reference.
+        // Tuple-binding first steps (e.g. `items#$i`, `foo@$v`) create a tuple
+        // stream up front, mirroring jsonata-js's evaluateTupleStep for the
+        // first path step where tupleBindings is undefined.
+        let mut current: JValue = if Self::step_creates_tuple(&steps[0]) {
+            JValue::array(self.create_tuple_stream(&steps[0], data)?)
+        } else {
+            match &steps[0].node {
+                AstNode::Wildcard => {
+                    // Wildcard as first step
+                    match data {
+                        JValue::Object(obj) => {
+                            let mut result = Vec::new();
+                            for value in obj.values() {
+                                // Flatten arrays into the result
+                                match value {
+                                    JValue::Array(arr) => result.extend(arr.iter().cloned()),
+                                    _ => result.push(value.clone()),
+                                }
                             }
+                            JValue::array(result)
                         }
-                        JValue::array(result)
-                    }
-                    JValue::Array(arr) => JValue::Array(arr.clone()),
-                    _ => JValue::Null,
-                }
-            }
-            AstNode::Descendant => {
-                // Descendant as first step
-                let descendants = self.collect_descendants(data);
-                JValue::array(descendants)
-            }
-            AstNode::ParentVariable(name) => {
-                // Parent variable as first step
-                let parent_data = self.context.get_parent().ok_or_else(|| {
-                    EvaluatorError::ReferenceError("Parent context not available".to_string())
-                })?;
-
-                if name.is_empty() {
-                    // $$ alone returns parent context
-                    parent_data.clone()
-                } else {
-                    // $$field accesses field on parent
-                    match parent_data {
-                        JValue::Object(obj) => obj.get(name).cloned().unwrap_or(JValue::Null),
+                        JValue::Array(arr) => JValue::Array(arr.clone()),
                         _ => JValue::Null,
                     }
                 }
-            }
-            AstNode::Name(field_name) => {
-                // Field/property access - get the stages for this step
-                let stages = &steps[0].stages;
+                AstNode::Descendant => {
+                    // Descendant as first step
+                    let descendants = self.collect_descendants(data);
+                    JValue::array(descendants)
+                }
+                AstNode::ParentVariable(name) => {
+                    // Parent variable as first step
+                    let parent_data = self.context.get_parent().ok_or_else(|| {
+                        EvaluatorError::ReferenceError("Parent context not available".to_string())
+                    })?;
 
-                match data {
-                    JValue::Object(obj) => {
-                        let val = obj.get(field_name).cloned().unwrap_or(JValue::Undefined);
-                        // Apply any stages to the extracted value
-                        if !stages.is_empty() {
-                            self.apply_stages(val, stages)?
-                        } else {
-                            val
+                    if name.is_empty() {
+                        // $$ alone returns parent context
+                        parent_data.clone()
+                    } else {
+                        // $$field accesses field on parent
+                        match parent_data {
+                            JValue::Object(obj) => obj.get(name).cloned().unwrap_or(JValue::Null),
+                            _ => JValue::Null,
                         }
                     }
-                    JValue::Array(arr) => {
-                        // Array mapping: extract field from each element and apply stages
-                        let mut result = Vec::new();
-                        for item in arr.iter() {
-                            match item {
-                                JValue::Object(obj) => {
-                                    let val =
-                                        obj.get(field_name).cloned().unwrap_or(JValue::Undefined);
-                                    if !val.is_null() && !val.is_undefined() {
-                                        if !stages.is_empty() {
-                                            // Apply stages to the extracted value
-                                            let processed_val = self.apply_stages(val, stages)?;
-                                            // Stages always return an array (or null); extend results
-                                            match processed_val {
-                                                JValue::Array(arr) => {
-                                                    result.extend(arr.iter().cloned())
-                                                }
-                                                JValue::Null => {} // Skip nulls from stage application
-                                                other => result.push(other), // Shouldn't happen, but handle it
-                                            }
-                                        } else {
-                                            // No stages: flatten arrays, push scalars
-                                            match val {
-                                                JValue::Array(arr) => {
-                                                    result.extend(arr.iter().cloned())
-                                                }
-                                                other => result.push(other),
-                                            }
-                                        }
-                                    }
-                                }
-                                JValue::Array(inner_arr) => {
-                                    // Recursively map over nested array
-                                    let nested_result = self.evaluate_path(
-                                        &[steps[0].clone()],
-                                        &JValue::Array(inner_arr.clone()),
-                                    )?;
-                                    match nested_result {
-                                        JValue::Array(nested) => {
-                                            result.extend(nested.iter().cloned())
-                                        }
-                                        JValue::Null => {} // Skip nulls from nested arrays
-                                        other => result.push(other),
-                                    }
-                                }
-                                _ => {} // Skip non-object items
+                }
+                AstNode::Name(field_name) => {
+                    // Field/property access - get the stages for this step
+                    let stages = &steps[0].stages;
+
+                    match data {
+                        JValue::Object(obj) => {
+                            let val = obj.get(field_name).cloned().unwrap_or(JValue::Undefined);
+                            // Apply any stages to the extracted value
+                            if !stages.is_empty() {
+                                self.apply_stages(val, stages)?
+                            } else {
+                                val
                             }
                         }
-                        JValue::array(result)
+                        JValue::Array(arr) => {
+                            // Array mapping: extract field from each element and apply stages
+                            let mut result = Vec::new();
+                            for item in arr.iter() {
+                                match item {
+                                    JValue::Object(obj) => {
+                                        let val = obj
+                                            .get(field_name)
+                                            .cloned()
+                                            .unwrap_or(JValue::Undefined);
+                                        if !val.is_null() && !val.is_undefined() {
+                                            if !stages.is_empty() {
+                                                // Apply stages to the extracted value
+                                                let processed_val =
+                                                    self.apply_stages(val, stages)?;
+                                                // Stages always return an array (or null); extend results
+                                                match processed_val {
+                                                    JValue::Array(arr) => {
+                                                        result.extend(arr.iter().cloned())
+                                                    }
+                                                    JValue::Null => {} // Skip nulls from stage application
+                                                    other => result.push(other), // Shouldn't happen, but handle it
+                                                }
+                                            } else {
+                                                // No stages: flatten arrays, push scalars
+                                                match val {
+                                                    JValue::Array(arr) => {
+                                                        result.extend(arr.iter().cloned())
+                                                    }
+                                                    other => result.push(other),
+                                                }
+                                            }
+                                        }
+                                    }
+                                    JValue::Array(inner_arr) => {
+                                        // Recursively map over nested array
+                                        let nested_result = self.evaluate_path(
+                                            &[steps[0].clone()],
+                                            &JValue::Array(inner_arr.clone()),
+                                        )?;
+                                        match nested_result {
+                                            JValue::Array(nested) => {
+                                                result.extend(nested.iter().cloned())
+                                            }
+                                            JValue::Null => {} // Skip nulls from nested arrays
+                                            other => result.push(other),
+                                        }
+                                    }
+                                    _ => {} // Skip non-object items
+                                }
+                            }
+                            JValue::array(result)
+                        }
+                        JValue::Null => JValue::Null,
+                        // Accessing field on non-object returns undefined (not an error)
+                        _ => JValue::Undefined,
                     }
-                    JValue::Null => JValue::Null,
-                    // Accessing field on non-object returns undefined (not an error)
-                    _ => JValue::Undefined,
                 }
-            }
-            AstNode::String(string_literal) => {
-                // String literal in path context - evaluate as literal and apply stages
-                // This handles cases like "Red"[true] where "Red" is a literal, not a field access
-                let stages = &steps[0].stages;
-                let val = JValue::string(string_literal.clone());
+                AstNode::String(string_literal) => {
+                    // String literal in path context - evaluate as literal and apply stages
+                    // This handles cases like "Red"[true] where "Red" is a literal, not a field access
+                    let stages = &steps[0].stages;
+                    let val = JValue::string(string_literal.clone());
 
-                if !stages.is_empty() {
-                    // Apply stages (predicates) to the string literal
-                    let result = self.apply_stages(val, stages)?;
-                    // Unwrap single-element arrays back to scalar
-                    // (string literals with predicates should return scalar or null, not arrays)
-                    match result {
-                        JValue::Array(arr) if arr.len() == 1 => arr[0].clone(),
-                        JValue::Array(arr) if arr.is_empty() => JValue::Null,
-                        other => other,
+                    if !stages.is_empty() {
+                        // Apply stages (predicates) to the string literal
+                        let result = self.apply_stages(val, stages)?;
+                        // Unwrap single-element arrays back to scalar
+                        // (string literals with predicates should return scalar or null, not arrays)
+                        match result {
+                            JValue::Array(arr) if arr.len() == 1 => arr[0].clone(),
+                            JValue::Array(arr) if arr.is_empty() => JValue::Null,
+                            other => other,
+                        }
+                    } else {
+                        val
                     }
-                } else {
-                    val
                 }
-            }
-            AstNode::Predicate(pred_expr) => {
-                // Predicate as first step
-                self.evaluate_predicate(data, pred_expr)?
-            }
-            _ => {
-                // Complex first step - evaluate it
-                self.evaluate_path_step(&steps[0].node, data, data)?
+                AstNode::Predicate(pred_expr) => {
+                    // Predicate as first step
+                    self.evaluate_predicate(data, pred_expr)?
+                }
+                _ => {
+                    // Complex first step - evaluate it
+                    self.evaluate_path_step(&steps[0].node, data, data)?
+                }
             }
         };
 
@@ -3980,6 +4010,15 @@ impl Evaluator {
             }
             if current.is_undefined() {
                 return Ok(JValue::Undefined);
+            }
+
+            // Tuple-binding step (@ focus / # index / % parent): create/extend the
+            // tuple stream, mirroring jsonata-js's evaluateTupleStep. Downstream
+            // (non-binding) steps then consume the {@, $var, !label, __tuple__}
+            // wrappers via the existing tuple-aware handling below.
+            if Self::step_creates_tuple(step) {
+                current = JValue::array(self.create_tuple_stream(step, &current)?);
+                continue;
             }
 
             // Check if current is a tuple array - if so, we need to bind tuple variables
@@ -4017,11 +4056,25 @@ impl Evaluator {
 
                     for tuple in arr.iter() {
                         if let JValue::Object(tuple_obj) = tuple {
-                            // Extract tuple bindings (variables starting with $)
+                            // Extract tuple bindings so nested expressions can see
+                            // them: `$var` focus/index bindings (stored `$name`,
+                            // bound as `name`) AND `!label` ancestor bindings for
+                            // `%` (stored and bound under the full `!label` key).
                             let bindings: Vec<(String, JValue)> = tuple_obj
                                 .iter()
-                                .filter(|(k, _)| k.starts_with('$') && k.len() > 1) // $i, $j, etc.
-                                .map(|(k, v)| (k[1..].to_string(), v.clone())) // Remove $ prefix for context binding
+                                .filter_map(|(k, v)| {
+                                    if let Some(name) = k.strip_prefix('$') {
+                                        if name.is_empty() {
+                                            None
+                                        } else {
+                                            Some((name.to_string(), v.clone()))
+                                        }
+                                    } else if k.starts_with('!') {
+                                        Some((k.clone(), v.clone()))
+                                    } else {
+                                        None
+                                    }
+                                })
                                 .collect();
 
                             // Save current bindings
@@ -4519,6 +4572,129 @@ impl Evaluator {
         Ok(result)
     }
 
+    /// True when a path step carries a tuple-binding flag (`@$var` focus,
+    /// `#$var` index, or a resolved `%` ancestor label) and must therefore
+    /// produce/extend a tuple stream rather than be evaluated as a plain step.
+    fn step_creates_tuple(step: &PathStep) -> bool {
+        step.focus.is_some() || step.index_var.is_some() || step.ancestor_label.is_some()
+    }
+
+    /// Create or extend a tuple stream for a tuple-binding path step, mirroring
+    /// jsonata-js's `evaluateTupleStep` (jsonata.js ~L315-380). The returned
+    /// vector holds `JValue::Object` tuple wrappers of the shape
+    /// `{ "@": value, "$focus"/"$index": ..., "!label": ..., "__tuple__": true }`
+    /// which downstream steps consume via the existing tuple-aware handling in
+    /// `evaluate_path`.
+    ///
+    /// `input` is the previous step's result: either an already-built tuple
+    /// stream (each wrapper carried forward, per JS's `tupleBindings`) or a
+    /// plain value/array entering tuple mode for the first time (each item
+    /// wrapped as `{'@': item}`, per JS's `input.map(item => {'@': item})`).
+    fn create_tuple_stream(
+        &mut self,
+        step: &PathStep,
+        input: &JValue,
+    ) -> Result<Vec<JValue>, EvaluatorError> {
+        use std::rc::Rc;
+
+        // Gather the incoming tuple bindings.
+        let is_tuple_input = matches!(
+            input,
+            JValue::Array(arr) if arr.first().is_some_and(|f| {
+                matches!(f, JValue::Object(o) if o.get("__tuple__") == Some(&JValue::Bool(true)))
+            })
+        );
+        let incoming: Vec<Rc<IndexMap<String, JValue>>> = if is_tuple_input {
+            match input {
+                JValue::Array(arr) => arr
+                    .iter()
+                    .filter_map(|t| match t {
+                        JValue::Object(o) => Some(o.clone()),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => unreachable!(),
+            }
+        } else {
+            let items: Vec<JValue> = match input {
+                JValue::Array(arr) => arr.iter().cloned().collect(),
+                single => vec![single.clone()],
+            };
+            items
+                .into_iter()
+                .map(|item| {
+                    let mut wrapper = IndexMap::new();
+                    wrapper.insert("@".to_string(), item);
+                    wrapper.insert("__tuple__".to_string(), JValue::Bool(true));
+                    Rc::new(wrapper)
+                })
+                .collect()
+        };
+
+        let mut result = Vec::new();
+        for tuple_obj in incoming {
+            // Bind every carried tuple key into a real scope frame so the step
+            // expression can see prior focus/index/ancestor bindings, mirroring
+            // createFrameFromTuple's "for every key in tuple, frame.bind(...)".
+            let mut bound_names: Vec<String> = Vec::new();
+            for (key, value) in tuple_obj.iter() {
+                if let Some(name) = key.strip_prefix('$') {
+                    if !name.is_empty() {
+                        self.context.bind(name.to_string(), value.clone());
+                        bound_names.push(name.to_string());
+                    }
+                } else if key.starts_with('!') {
+                    self.context.bind(key.clone(), value.clone());
+                    bound_names.push(key.clone());
+                }
+            }
+
+            let actual_data = tuple_obj.get("@").cloned().unwrap_or(JValue::Undefined);
+            let step_value = self.evaluate_internal(&step.node, &actual_data);
+
+            for name in &bound_names {
+                self.context.unbind(name);
+            }
+            let mut step_value = step_value?;
+            if !step.stages.is_empty() {
+                step_value = self.apply_stages(step_value, &step.stages)?;
+            }
+
+            let row: Vec<JValue> = match step_value {
+                JValue::Undefined => continue,
+                JValue::Array(arr) => arr.iter().cloned().collect(),
+                other => vec![other],
+            };
+
+            for (position, value) in row.into_iter().enumerate() {
+                if value.is_undefined() {
+                    continue;
+                }
+                let mut new_tuple = (*tuple_obj).clone();
+                if let Some(focus_var) = &step.focus {
+                    // Focus binding keeps `@` as this step's INPUT (already carried
+                    // in the cloned tuple) and binds the result to `$focus`,
+                    // matching jsonata-js: `tuple[expr.focus] = res[bb];
+                    // tuple['@'] = tupleBindings[ee]['@'];`.
+                    new_tuple.insert(format!("${}", focus_var), value);
+                } else {
+                    new_tuple.insert("@".to_string(), value);
+                }
+                if let Some(index_var) = &step.index_var {
+                    new_tuple.insert(format!("${}", index_var), JValue::from(position as i64));
+                }
+                if let Some(ancestor_label) = &step.ancestor_label {
+                    // `%` ancestor: preserve this step's INPUT under the label.
+                    new_tuple.insert(ancestor_label.clone(), actual_data.clone());
+                }
+                new_tuple.insert("__tuple__".to_string(), JValue::Bool(true));
+                result.push(JValue::object(new_tuple));
+            }
+        }
+
+        Ok(result)
+    }
+
     /// Helper to evaluate a complex path step
     fn evaluate_path_step(
         &mut self,
@@ -4616,6 +4792,7 @@ impl Evaluator {
                     | AstNode::Function { .. }
                     | AstNode::Variable(_)
                     | AstNode::ParentVariable(_)
+                    | AstNode::Parent(_)
                     | AstNode::Array(_)
                     | AstNode::Object(_)
                     | AstNode::Sort { .. }
@@ -11177,6 +11354,105 @@ mod tests {
                 JValue::Number(3.0)
             ]),
             "Empty brackets should preserve array"
+        );
+    }
+
+    // ---- Tuple-stream runtime: %/@/# binding operators (Task 5) ----
+    // Expected values below are ground-truthed against jsonata-js 2.x.
+
+    #[test]
+    fn test_index_bind_makes_variable_available_in_next_step() {
+        // `#$o` binds each Order's position; `$o` must resolve in the later step.
+        let data: JValue = serde_json::json!({
+            "Account": {
+                "Order": [
+                    {"OrderID": "o1", "Product": [{"Name": "Hat"}]},
+                    {"OrderID": "o2", "Product": [{"Name": "Cap"}, {"Name": "Sock"}]}
+                ]
+            }
+        })
+        .into();
+        let ast =
+            crate::parser::parse("Account.Order#$o.Product.{ 'name': Name, 'idx': $o }").unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([
+                {"name": "Hat", "idx": 0},
+                {"name": "Cap", "idx": 1},
+                {"name": "Sock", "idx": 1}
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn test_index_bind_with_predicate_stage() {
+        // Mirrors reference joins/index[13]: index binding, then a predicate on
+        // the next step, carrying the index binding through.
+        let data: JValue = serde_json::json!({
+            "Account": {
+                "Order": [
+                    {"Product": [{"ProductID": 1, "Name": "A"}, {"ProductID": 9, "Name": "B"}]},
+                    {"Product": [{"ProductID": 9, "Name": "C"}]}
+                ]
+            }
+        })
+        .into();
+        let ast =
+            crate::parser::parse("Account.Order#$o.Product[ProductID=9].{ 'n': Name, 'idx': $o }")
+                .unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([
+                {"n": "B", "idx": 0},
+                {"n": "C", "idx": 1}
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn test_focus_bind_makes_variable_available_in_next_step() {
+        // NOTE: `Account.Order@$o.Product` is `undefined` in jsonata-js (focus
+        // does NOT advance the context `@`); the variable itself is what carries
+        // forward. This asserts the real jsonata-js behaviour.
+        let data: JValue = serde_json::json!({
+            "Account": {
+                "Order": [
+                    {"OrderID": "o1"},
+                    {"OrderID": "o2"}
+                ]
+            }
+        })
+        .into();
+        let ast = crate::parser::parse("Account.Order@$o.$o.OrderID").unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(result, serde_json::json!(["o1", "o2"]).into());
+    }
+
+    #[test]
+    fn test_parent_reference_resolves_to_enclosing_step_value() {
+        let data: JValue = serde_json::json!({
+            "Account": {
+                "Order": [
+                    {"OrderID": "o1", "Product": [{"Name": "Hat"}]}
+                ]
+            }
+        })
+        .into();
+        let ast =
+            crate::parser::parse("Account.Order.Product.{ 'name': Name, 'order': %.OrderID }")
+                .unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([{"name": "Hat", "order": "o1"}]).into()
         );
     }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2505,6 +2505,37 @@ fn unwrap_tuple_output(value: JValue) -> JValue {
     }
 }
 
+/// Guard returned by [`Evaluator::bind_tuple_keys`]: remembers, for each
+/// tuple-carried `$name`/`!label` key that was just bound into scope, what
+/// (if anything) was bound under that name beforehand. `restore` puts the
+/// prior value back -- or removes the binding entirely if there wasn't
+/// one -- rather than unconditionally unbinding, so a tuple key that
+/// happens to share a name with a live outer `:=` binding in the same
+/// scope frame doesn't get permanently deleted once the tuple-row
+/// evaluation finishes.
+struct TupleKeyBindings {
+    saved: Vec<(String, Option<JValue>)>,
+}
+
+impl TupleKeyBindings {
+    /// True if `name` was one of the keys this guard bound (used by callers
+    /// that need to know whether a given tuple key is already in scope
+    /// before binding it a second time under a different role, e.g.
+    /// `create_tuple_stream`'s ancestor-label handling).
+    fn contains(&self, name: &str) -> bool {
+        self.saved.iter().any(|(n, _)| n == name)
+    }
+
+    fn restore(self, evaluator: &mut Evaluator) {
+        for (name, prior) in self.saved {
+            match prior {
+                Some(value) => evaluator.context.bind(name, value),
+                None => evaluator.context.unbind(&name),
+            }
+        }
+    }
+}
+
 /// Evaluator for JSONata expressions
 pub struct Evaluator {
     context: Context,
@@ -4326,33 +4357,10 @@ impl Evaluator {
                             // them: `$var` focus/index bindings (stored `$name`,
                             // bound as `name`) AND `!label` ancestor bindings for
                             // `%` (stored and bound under the full `!label` key).
-                            let bindings: Vec<(String, JValue)> = tuple_obj
-                                .iter()
-                                .filter_map(|(k, v)| {
-                                    if let Some(name) = k.strip_prefix('$') {
-                                        if name.is_empty() {
-                                            None
-                                        } else {
-                                            Some((name.to_string(), v.clone()))
-                                        }
-                                    } else if k.starts_with('!') {
-                                        Some((k.clone(), v.clone()))
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-
-                            // Save current bindings
-                            let saved_bindings: Vec<(String, Option<JValue>)> = bindings
-                                .iter()
-                                .map(|(name, _)| (name.clone(), self.context.lookup(name).cloned()))
-                                .collect();
-
-                            // Bind tuple variables to context
-                            for (name, value) in &bindings {
-                                self.context.bind(name.clone(), value.clone());
-                            }
+                            // Saves/restores rather than blindly unbinding, so a
+                            // tuple key that collides with a live outer `:=`
+                            // binding doesn't get deleted afterward.
+                            let tuple_bindings = self.bind_tuple_keys(tuple_obj);
 
                             // Get the actual value from the tuple (@ field)
                             let actual_data = tuple_obj.get("@").cloned().unwrap_or(JValue::Null);
@@ -4414,13 +4422,7 @@ impl Evaluator {
                             };
 
                             // Restore previous bindings
-                            for (name, saved_value) in &saved_bindings {
-                                if let Some(value) = saved_value {
-                                    self.context.bind(name.clone(), value.clone());
-                                } else {
-                                    self.context.unbind(name);
-                                }
-                            }
+                            tuple_bindings.restore(self);
 
                             // Rewrap results as tuples carrying this incoming
                             // tuple's focus/index/ancestor bindings, so that
@@ -5066,6 +5068,38 @@ impl Evaluator {
         })
     }
 
+    /// Bind a tuple wrapper's carried `$name`/`!label` keys into the current
+    /// scope, saving whatever was previously bound under each of those names
+    /// so [`TupleKeyBindings::restore`] can put it back afterward.
+    ///
+    /// This is the single shared implementation of the
+    /// "iterate a tuple wrapper's carried keys, bind, evaluate, then undo"
+    /// pattern that recurs across `create_tuple_stream`,
+    /// `needs_tuple_context_binding`'s handling in `evaluate_path`,
+    /// `apply_tuple_stages`, and `evaluate_sort` -- it exists specifically so
+    /// none of those call sites can regress to a blind `unbind` (which
+    /// deletes rather than restores a same-named outer `:=` binding that was
+    /// live in the same scope frame; see issue: chained `@`/`#`/sort-term
+    /// binding silently clobbering an outer variable of the same name).
+    fn bind_tuple_keys(&mut self, tuple_obj: &IndexMap<String, JValue>) -> TupleKeyBindings {
+        let mut saved = Vec::new();
+        for (key, value) in tuple_obj.iter() {
+            let name = if let Some(n) = key.strip_prefix('$') {
+                if n.is_empty() {
+                    continue;
+                }
+                n.to_string()
+            } else if key.starts_with('!') {
+                key.clone()
+            } else {
+                continue;
+            };
+            saved.push((name.clone(), self.context.lookup(&name).cloned()));
+            self.context.bind(name, value.clone());
+        }
+        TupleKeyBindings { saved }
+    }
+
     /// Create or extend a tuple stream for a tuple-binding path step, mirroring
     /// jsonata-js's `evaluateTupleStep` (jsonata.js ~L315-380). The returned
     /// vector holds `JValue::Object` tuple wrappers of the shape
@@ -5196,18 +5230,10 @@ impl Evaluator {
             // Bind every carried tuple key into a real scope frame so the step
             // expression can see prior focus/index/ancestor bindings, mirroring
             // createFrameFromTuple's "for every key in tuple, frame.bind(...)".
-            let mut bound_names: Vec<String> = Vec::new();
-            for (key, value) in tuple_obj.iter() {
-                if let Some(name) = key.strip_prefix('$') {
-                    if !name.is_empty() {
-                        self.context.bind(name.to_string(), value.clone());
-                        bound_names.push(name.to_string());
-                    }
-                } else if key.starts_with('!') {
-                    self.context.bind(key.clone(), value.clone());
-                    bound_names.push(key.clone());
-                }
-            }
+            // Saves/restores rather than blindly unbinding, so a tuple key
+            // whose name collides with a live outer `:=` binding doesn't get
+            // deleted once this tuple row's evaluation is done.
+            let tuple_bindings = self.bind_tuple_keys(&tuple_obj);
 
             let actual_data = tuple_obj.get("@").cloned().unwrap_or(JValue::Undefined);
             let step_value = self.evaluate_internal(&step.node, &actual_data);
@@ -5227,11 +5253,12 @@ impl Evaluator {
                 // with `ancestor_label`; bind it to the step's input so the
                 // level-1 `%` resolves. The `%.%` chain's deeper references use
                 // labels carried in the INCOMING tuple, so those bindings
-                // (`bound_names`) must stay live through `apply_stages` -- their
-                // unbind is deferred until after it (previously they were
-                // unbound first, which silently broke `%.%` inside predicates).
+                // (`tuple_bindings`) must stay live through `apply_stages` --
+                // their restore is deferred until after it (previously they
+                // were unbound first, which silently broke `%.%` inside
+                // predicates).
                 let own_label = match &step.ancestor_label {
-                    Some(label) if !bound_names.contains(label) => {
+                    Some(label) if !tuple_bindings.contains(label) => {
                         self.context.bind(label.clone(), actual_data.clone());
                         Some(label.clone())
                     }
@@ -5243,9 +5270,7 @@ impl Evaluator {
                 }
             }
 
-            for name in &bound_names {
-                self.context.unbind(name);
-            }
+            tuple_bindings.restore(self);
 
             let row: Vec<JValue> = match step_value {
                 JValue::Undefined => continue,
@@ -5315,30 +5340,12 @@ impl Evaluator {
                             continue;
                         };
                         // Bind this tuple's carried focus/index/ancestor keys so
-                        // the predicate can reference them.
-                        let mut saved: Vec<(String, Option<JValue>)> = Vec::new();
-                        for (k, v) in obj.iter() {
-                            let name = if let Some(n) = k.strip_prefix('$') {
-                                if n.is_empty() {
-                                    continue;
-                                }
-                                n.to_string()
-                            } else if k.starts_with('!') {
-                                k.clone()
-                            } else {
-                                continue;
-                            };
-                            saved.push((name.clone(), self.context.lookup(&name).cloned()));
-                            self.context.bind(name, v.clone());
-                        }
+                        // the predicate can reference them (save/restore rather
+                        // than blind unbind -- see bind_tuple_keys).
+                        let tuple_bindings = self.bind_tuple_keys(obj);
                         let at = obj.get("@").cloned().unwrap_or(JValue::Undefined);
                         let pred_res = self.evaluate_internal(pred, &at);
-                        for (name, old) in saved.into_iter().rev() {
-                            match old {
-                                Some(v) => self.context.bind(name, v),
-                                None => self.context.unbind(&name),
-                            }
-                        }
+                        tuple_bindings.restore(self);
                         if self.is_truthy(&pred_res?) {
                             kept.push(tup);
                         }
@@ -10434,22 +10441,15 @@ impl Evaluator {
             // create_tuple_stream's per-tuple frame binding. Sort terms attach
             // to a synthetic step after the last input step, so `%` refers to
             // the last input step's ancestry, carried under `!label` here.
-            let mut tuple_bound: Vec<String> = Vec::new();
-            if let JValue::Object(obj) = element {
-                if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
-                    for (key, value) in obj.iter() {
-                        if let Some(name) = key.strip_prefix('$') {
-                            if !name.is_empty() {
-                                self.context.bind(name.to_string(), value.clone());
-                                tuple_bound.push(name.to_string());
-                            }
-                        } else if key.starts_with('!') {
-                            self.context.bind(key.clone(), value.clone());
-                            tuple_bound.push(key.clone());
-                        }
-                    }
+            // Saves/restores rather than blindly unbinding, so a tuple key
+            // that collides with a live outer `:=` binding doesn't get
+            // deleted once this row's sort terms are evaluated.
+            let tuple_bindings = match element {
+                JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)) => {
+                    Some(self.bind_tuple_keys(obj))
                 }
-            }
+                _ => None,
+            };
 
             // When sorting a tuple stream, `$` and the term's data context are the
             // tuple's `@` value, not the `{@, $var, !label, __tuple__}` wrapper --
@@ -10484,8 +10484,8 @@ impl Evaluator {
                 sort_keys.push(sort_value);
             }
 
-            for name in &tuple_bound {
-                self.context.unbind(name);
+            if let Some(tuple_bindings) = tuple_bindings {
+                tuple_bindings.restore(self);
             }
 
             indexed_array.push((idx, sort_keys));
@@ -12287,5 +12287,48 @@ mod tests {
             result,
             serde_json::json!([{"name": "Hat", "order": "o1"}]).into()
         );
+    }
+
+    // Regression tests for a bug where create_tuple_stream/evaluate_sort bound
+    // a tuple-carried `$name`/`!label` key straight into the top scope and then
+    // UNCONDITIONALLY unbound it afterward, deleting (rather than restoring) a
+    // same-named outer `:=` binding that happened to be live in that scope
+    // frame. Expected values below are verified against jsonata-js (2.2.1
+    // reference, `tests/jsonata-js`).
+
+    #[test]
+    fn test_chained_focus_bind_does_not_clobber_outer_variable() {
+        let data: JValue = serde_json::json!({"a": {"b": {"c": 1}}}).into();
+        let ast = crate::parser::parse(r#"($x := "OUT"; a@$x.b@$y.c; $x)"#).unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(result, serde_json::json!("OUT").into());
+    }
+
+    #[test]
+    fn test_chained_index_bind_does_not_clobber_outer_variable() {
+        let data: JValue = serde_json::json!({"a": {"b": {"c": 1}}}).into();
+        let ast = crate::parser::parse(r#"($x := "OUT"; a#$x.b#$y.c; $x)"#).unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(result, serde_json::json!("OUT").into());
+    }
+
+    #[test]
+    fn test_mixed_focus_and_index_bind_does_not_clobber_outer_variable() {
+        let data: JValue = serde_json::json!({"a": {"b": {"c": 1}}}).into();
+        let ast = crate::parser::parse(r#"($x := "OUT"; a@$x.b#$y.c; $x)"#).unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(result, serde_json::json!("OUT").into());
+    }
+
+    #[test]
+    fn test_sort_term_tuple_binding_does_not_clobber_outer_variable() {
+        let data: JValue = serde_json::json!({"items": [{"v": 3}, {"v": 1}, {"v": 2}]}).into();
+        let ast = crate::parser::parse(r#"($x := "OUT"; items@$x.v^(%.v); $x)"#).unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_eq!(result, serde_json::json!("OUT").into());
     }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2483,6 +2483,15 @@ pub struct Evaluator {
     /// caller — keeps the vast majority of evaluations, which never touch
     /// `%`/`@`/`#`, at zero added cost.
     tuple_stream_created: bool,
+    /// When true, `evaluate_path` skips its end-of-path `@`-projection and returns
+    /// the raw `{@, $var, !label, __tuple__}` tuple wrappers. Set (saved/restored)
+    /// by the two consumers that read those carried bindings directly from the
+    /// wrappers: a `Sort` node evaluating its tuple-carrying input path (sort
+    /// terms reference `%`/`$focus`), and an `ObjectTransform` (group-by)
+    /// evaluating its input path (key/value expressions read `$focus` off the
+    /// wrapper). Mirrors jsonata-js keeping `path.tuple` for such a path instead
+    /// of projecting each tuple's `@`.
+    keep_tuple_stream: bool,
 }
 
 impl Evaluator {
@@ -2495,6 +2504,7 @@ impl Evaluator {
             max_recursion_depth: 302,
             next_lambda_id: 0,
             tuple_stream_created: false,
+            keep_tuple_stream: false,
         }
     }
 
@@ -2505,6 +2515,7 @@ impl Evaluator {
             max_recursion_depth: 302,
             next_lambda_id: 0,
             tuple_stream_created: false,
+            keep_tuple_stream: false,
         }
     }
 
@@ -3109,8 +3120,14 @@ impl Evaluator {
 
             // Object transform: group items by key, then evaluate value once per group
             AstNode::ObjectTransform { input, pattern } => {
-                // Evaluate the input expression
-                let input_value = self.evaluate_internal(input, data)?;
+                // Evaluate the input expression. Keep tuple wrappers alive so the
+                // group-by key/value expressions can read the carried `$focus`
+                // bindings off each wrapper (e.g. `...@$e...{ $e.FirstName: ... }`).
+                let saved_keep = self.keep_tuple_stream;
+                self.keep_tuple_stream = true;
+                let input_value = self.evaluate_internal(input, data);
+                self.keep_tuple_stream = saved_keep;
+                let input_value = input_value?;
 
                 // If input is undefined, return undefined (not empty object)
                 if input_value.is_undefined() {
@@ -3366,8 +3383,13 @@ impl Evaluator {
             )),
 
             AstNode::Sort { input, terms } => {
-                let value = self.evaluate_internal(input, data)?;
-                self.evaluate_sort(&value, terms)
+                // Keep the input path's tuple wrappers so the sort terms can read
+                // the carried `%`/`$focus`/`$index` bindings per element.
+                let saved = self.keep_tuple_stream;
+                self.keep_tuple_stream = true;
+                let value = self.evaluate_internal(input, data);
+                self.keep_tuple_stream = saved;
+                self.evaluate_sort(&value?, terms)
             }
 
             // Transform: |location|update[,delete]|
@@ -4067,8 +4089,19 @@ impl Evaluator {
                     self.evaluate_predicate(data, pred_expr)?
                 }
                 _ => {
-                    // Complex first step - evaluate it
-                    self.evaluate_path_step(&steps[0].node, data, data)?
+                    // Complex first step - evaluate it. When the step is
+                    // tuple-carrying (e.g. a parenthesized `(Account.Order.Product)`
+                    // whose `Product` is `%`-tagged, as in
+                    // `(Account.Order.Product)[%.OrderID='order104'].SKU`), keep the
+                    // inner path's tuple wrappers so the following predicate/step
+                    // can read the `!label` bindings.
+                    let saved_keep = self.keep_tuple_stream;
+                    if steps[0].is_tuple {
+                        self.keep_tuple_stream = true;
+                    }
+                    let v = self.evaluate_path_step(&steps[0].node, data, data);
+                    self.keep_tuple_stream = saved_keep;
+                    v?
                 }
             }
         };
@@ -4204,7 +4237,17 @@ impl Evaluator {
                                     // be used in path expressions".
                                     let saved_dollar = self.context.lookup("$").cloned();
                                     self.context.bind("$".to_string(), actual_data.clone());
+                                    // Keep tuple wrappers from the inner path alive:
+                                    // when `inner` is itself a tuple-carrying path
+                                    // (e.g. `(Order.Product)` whose `Product` is
+                                    // `%`-tagged), its `!label` wrappers must survive
+                                    // to be merged into this tuple by the rewrap below
+                                    // (they feed a later `%`/`%.%`). Without this the
+                                    // inner path projects to `@` and drops the labels.
+                                    let saved_keep = self.keep_tuple_stream;
+                                    self.keep_tuple_stream = true;
                                     let v = self.evaluate_internal(inner, &actual_data);
+                                    self.keep_tuple_stream = saved_keep;
                                     match saved_dollar {
                                         Some(s) => self.context.bind("$".to_string(), s),
                                         None => self.context.unbind("$"),
@@ -4659,7 +4702,17 @@ impl Evaluator {
                     // Function application: map expr over the current value
                     // .(expr) means evaluate expr for each element, with $ bound to that element
                     // Null/undefined results are filtered out
-                    match &current {
+                    //
+                    // When this parenthesized step is itself tuple-carrying (its
+                    // inner path has a `%`-tagged step, e.g. `Account.(Order.Product).{...}`),
+                    // keep the inner path's tuple wrappers so their `!label`
+                    // bindings survive to the following object/`%` step; the
+                    // end-of-path projection (or a later consumer) unwraps them.
+                    let saved_keep = self.keep_tuple_stream;
+                    if step.is_tuple {
+                        self.keep_tuple_stream = true;
+                    }
+                    let fa_result = match &current {
                         JValue::Array(arr) => {
                             // Produce the mapped result (compiled fast path or tree-walker fallback).
                             // Do NOT return early — singleton unwrapping is applied by the outer
@@ -4724,15 +4777,54 @@ impl Evaluator {
 
                             value
                         }
-                    }
+                    };
+                    self.keep_tuple_stream = saved_keep;
+                    fa_result
                 }
                 AstNode::Sort { terms, .. } => {
                     // Sort as a path step - sort 'current' by the terms
                     self.evaluate_sort(&current, terms)?
                 }
                 // Handle complex path steps (e.g., computed properties, object construction)
-                _ => self.evaluate_path_step(&step.node, &current, data)?,
+                _ => {
+                    let saved_keep = self.keep_tuple_stream;
+                    if step.is_tuple {
+                        self.keep_tuple_stream = true;
+                    }
+                    let v = self.evaluate_path_step(&step.node, &current, data);
+                    self.keep_tuple_stream = saved_keep;
+                    v?
+                }
             };
+        }
+
+        // End-of-path tuple projection, mirroring jsonata-js evaluatePath
+        // (jsonata.js ~L202-212): once the path is a tuple stream, its VISIBLE
+        // result is each tuple's `@` value; the `{@, $var, !label, __tuple__}`
+        // wrappers are internal bookkeeping and must not escape into an enclosing
+        // operator (e.g. `$#$pos[$pos<3] = $[[0..2]]`, where leaked wrappers make
+        // `=` compare wrapper objects and always yield false). Suppressed only for
+        // the two consumers that read the carried bindings directly off the
+        // wrappers (Sort input, ObjectTransform/group-by input), which set
+        // `keep_tuple_stream`. The top-level `evaluate()` still runs
+        // `unwrap_tuple_output` as a backstop for wrappers nested inside
+        // constructed output.
+        if !self.keep_tuple_stream {
+            if let JValue::Array(arr) = &current {
+                let is_tuple_stream = arr.first().is_some_and(|f| {
+                    matches!(f, JValue::Object(o) if o.get("__tuple__") == Some(&JValue::Bool(true)))
+                });
+                if is_tuple_stream {
+                    let projected: Vec<JValue> = arr
+                        .iter()
+                        .map(|t| match t {
+                            JValue::Object(o) => o.get("@").cloned().unwrap_or(JValue::Undefined),
+                            other => other.clone(),
+                        })
+                        .collect();
+                    current = JValue::array(projected);
+                }
+            }
         }
 
         // JSONata singleton unwrapping: singleton results are unwrapped when we did array operations

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3412,11 +3412,26 @@ impl Evaluator {
             // needs_tuple_context_binding), so resolving it is an ordinary scope
             // lookup, mirroring jsonata-js's
             // `case 'parent': result = environment.lookup(expr.slot.label);`.
-            AstNode::Parent(label) => Ok(self
-                .context
-                .lookup(label)
-                .cloned()
-                .unwrap_or(JValue::Undefined)),
+            AstNode::Parent(label) => {
+                if let Some(v) = self.context.lookup(label) {
+                    return Ok(v.clone());
+                }
+                // Fall back to the tuple wrapper carried as `data`: a `%` used
+                // inside a predicate/stage over a tuple stream -- e.g.
+                // `(Account.Order.Product)[%.OrderID='order104'].SKU`, where the
+                // predicate is evaluated per tuple with the wrapper as data --
+                // reads its ancestor from the tuple's `!label` key, which isn't
+                // separately bound into scope here (mirrors AstNode::Variable's
+                // tuple-binding fallback below).
+                if let JValue::Object(obj) = data {
+                    if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
+                        if let Some(v) = obj.get(label) {
+                            return Ok(v.clone());
+                        }
+                    }
+                }
+                Ok(JValue::Undefined)
+            }
         }
     }
 
@@ -4117,7 +4132,10 @@ impl Evaluator {
             let needs_tuple_context_binding = is_tuple_array
                 && matches!(
                     &step.node,
-                    AstNode::Object(_) | AstNode::FunctionApplication(_) | AstNode::Variable(_)
+                    AstNode::Object(_)
+                        | AstNode::FunctionApplication(_)
+                        | AstNode::Variable(_)
+                        | AstNode::ArrayGroup(_)
                 );
 
             if needs_tuple_context_binding {
@@ -4167,8 +4185,12 @@ impl Evaluator {
                                     // Variable lookup - check context (which now has bindings)
                                     self.evaluate_internal(&step.node, tuple)?
                                 }
-                                AstNode::Object(_) => {
-                                    // Object constructor - evaluate on actual data
+                                AstNode::Object(_) | AstNode::ArrayGroup(_) => {
+                                    // Object / array constructor step (e.g.
+                                    // `Product.[`Product Name`, %.OrderID]`) -
+                                    // evaluate on the tuple's `@` value with the
+                                    // carried `!label`/`$focus` bindings in scope
+                                    // so an embedded `%` resolves.
                                     self.evaluate_internal(&step.node, &actual_data)?
                                 }
                                 AstNode::FunctionApplication(inner) => {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4201,18 +4201,70 @@ impl Evaluator {
                                 }
                             }
 
-                            // Collect result
+                            // Rewrap results as tuples carrying this incoming
+                            // tuple's focus/index/ancestor bindings, so that
+                            // DOWNSTREAM steps keep seeing them: a predicate like
+                            // `[ssn = $e.SSN]` after `Employee@$e.(Contact)`, a
+                            // later `%`/`%.%` in `Account.Order.(Product).{...}`,
+                            // or a further path step all read those bindings from
+                            // the tuple wrapper (see AstNode::Variable's tuple
+                            // fallback). Without rewrapping, the tuple chain is
+                            // severed after a parenthesized/object/variable step
+                            // and those references resolve to nothing. The
+                            // wrappers are projected back to their `@` values by
+                            // the top-level `unwrap_tuple_output` pass.
+                            let carried: Vec<(String, JValue)> = tuple_obj
+                                .iter()
+                                .filter(|(k, _)| {
+                                    (k.starts_with('$') && k.len() > 1) || k.starts_with('!')
+                                })
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect();
+                            let wrap = |v: JValue| -> JValue {
+                                match v {
+                                    // If the step produced a nested tuple stream
+                                    // (e.g. `(Product)` whose inner `Product` is
+                                    // itself `%`-tagged), MERGE the inner tuple's
+                                    // keys over the carried outer bindings, mirroring
+                                    // jsonata-js's `res.tupleStream` branch
+                                    // (`Object.assign(tuple, res[bb])`) -- do NOT
+                                    // double-wrap, which would bury `@`/`!label`
+                                    // one level down and break a following `%`/`%.%`.
+                                    JValue::Object(inner)
+                                        if inner.get("__tuple__") == Some(&JValue::Bool(true)) =>
+                                    {
+                                        let mut w = IndexMap::new();
+                                        for (k, val) in &carried {
+                                            w.insert(k.clone(), val.clone());
+                                        }
+                                        for (k, val) in inner.iter() {
+                                            w.insert(k.clone(), val.clone());
+                                        }
+                                        w.insert("__tuple__".to_string(), JValue::Bool(true));
+                                        JValue::object(w)
+                                    }
+                                    other => {
+                                        let mut w = IndexMap::new();
+                                        w.insert("@".to_string(), other);
+                                        for (k, val) in &carried {
+                                            w.insert(k.clone(), val.clone());
+                                        }
+                                        w.insert("__tuple__".to_string(), JValue::Bool(true));
+                                        JValue::object(w)
+                                    }
+                                }
+                            };
                             if !step_result.is_null() && !step_result.is_undefined() {
-                                // For object constructors, collect results directly
-                                // For other steps, handle arrays
+                                // Object constructors yield one value per tuple;
+                                // other steps may yield an array to splice in.
                                 if matches!(&step.node, AstNode::Object(_)) {
-                                    results.push(step_result);
-                                } else if matches!(step_result, JValue::Array(_)) {
-                                    if let JValue::Array(arr) = step_result {
-                                        results.extend(arr.iter().cloned());
+                                    results.push(wrap(step_result));
+                                } else if let JValue::Array(arr) = step_result {
+                                    for it in arr.iter() {
+                                        results.push(wrap(it.clone()));
                                     }
                                 } else {
-                                    results.push(step_result);
+                                    results.push(wrap(step_result));
                                 }
                             }
                         }
@@ -9902,9 +9954,11 @@ impl Evaluator {
             }
         }
 
-        // For complex expressions, evaluate normally against the actual element
-        // but with the full tuple as the data context (so index bindings are accessible)
-        let result = self.evaluate_internal(term_expr, element)?;
+        // For complex expressions, evaluate against the tuple's `@` value (the
+        // real element), not the wrapper. The tuple's carried focus/index/ancestor
+        // bindings are reachable via context (bound by evaluate_sort), so a term
+        // like `$`, `%.Price`, or `$pos` still resolves correctly.
+        let result = self.evaluate_internal(term_expr, &actual_element)?;
 
         // If the result is null from a complex expression, we can't easily tell if it's
         // "missing field" or "explicit null". For now, treat null results as undefined
@@ -9969,13 +10023,25 @@ impl Evaluator {
                 }
             }
 
+            // When sorting a tuple stream, `$` and the term's data context are the
+            // tuple's `@` value, not the `{@, $var, !label, __tuple__}` wrapper --
+            // otherwise a term like `^($)` would try to order by the wrapper
+            // object and raise T2008. The carried focus/index/ancestor keys stay
+            // reachable via the context bindings established just above.
+            let term_data = match element {
+                JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)) => {
+                    obj.get("@").cloned().unwrap_or(JValue::Null)
+                }
+                other => other.clone(),
+            };
+
             // Evaluate each sort term with $ bound to the element
             for (term_expr, _ascending) in terms {
                 // Save current $ binding
                 let saved_dollar = self.context.lookup("$").cloned();
 
                 // Bind $ to current element
-                self.context.bind("$".to_string(), element.clone());
+                self.context.bind("$".to_string(), term_data.clone());
 
                 // Evaluate the sort expression, distinguishing missing fields from explicit null
                 let sort_value = self.evaluate_sort_term(term_expr, element)?;

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4243,6 +4243,21 @@ impl Evaluator {
                 return Ok(JValue::Undefined);
             }
 
+            // A lone tuple wrapper (e.g. from a numeric index predicate `[1]` over
+            // a tuple stream, which selects a single tuple and unwraps it out of
+            // the array) must stay a tuple stream so the following step keeps
+            // reading its carried `$focus`/`!label` bindings. Re-wrap it as a
+            // one-element array (e.g. `library.loans@$l.books@$b[...][1].{...}`).
+            if let JValue::Object(o) = &current {
+                if o.get("__tuple__") == Some(&JValue::Bool(true)) {
+                    current = JValue::array(vec![current.clone()]);
+                    // The lone wrapper came from a singleton index selection, so
+                    // the final result should unwrap back to a scalar (a following
+                    // object step must not leave a spurious 1-element array).
+                    did_array_mapping = true;
+                }
+            }
+
             // Check if current is a tuple array - if so, we need to bind tuple variables
             // to context so they're available in nested expressions (like predicates)
             let is_tuple_array = if let JValue::Array(arr) = &current {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2431,6 +2431,40 @@ impl Default for Context {
     }
 }
 
+/// Strip any lingering tuple-stream wrapper objects (`{"@":.., "__tuple__":true,
+/// ...}`) from a value about to leave the evaluator.
+///
+/// `%`/`@`/`#` are implemented internally by wrapping each element of a path
+/// step's result in a tuple object (see `create_tuple_stream`) so downstream
+/// steps can resolve ancestor/focus/index bindings. Ordinarily an intermediate
+/// path step consumes and re-wraps these as evaluation proceeds, but the
+/// *final* result of an `evaluate()` call can still be tuple-wrapped — either
+/// because the tuple-producing expression itself is the whole result (a bare
+/// `#`/`@`/`%` path), or because it's nested inside object/array construction
+/// (e.g. `{"skus": Product[%.OrderID=...].SKU}` or `[items#$i]`) where the
+/// wrapper ends up embedded in a field value or array element rather than at
+/// the top level. This recurses through both array elements and (non-tuple)
+/// object field values so both shapes are cleaned up, not just a bare
+/// top-level tuple array.
+fn unwrap_tuple_output(value: JValue) -> JValue {
+    match value {
+        JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)) => obj
+            .get("@")
+            .cloned()
+            .map(unwrap_tuple_output)
+            .unwrap_or(JValue::Undefined),
+        JValue::Object(obj) => {
+            let mut new_map = IndexMap::with_capacity(obj.len());
+            for (k, v) in obj.iter() {
+                new_map.insert(k.clone(), unwrap_tuple_output(v.clone()));
+            }
+            JValue::object(new_map)
+        }
+        JValue::Array(arr) => JValue::array(arr.iter().cloned().map(unwrap_tuple_output).collect()),
+        other => other,
+    }
+}
+
 /// Evaluator for JSONata expressions
 pub struct Evaluator {
     context: Context,
@@ -2442,6 +2476,13 @@ pub struct Evaluator {
     /// lambda expression was evaluated more than once (e.g. each level of Y-combinator
     /// or other repeated recursion), aliasing unrelated closures that shared an id.
     next_lambda_id: u64,
+    /// Set whenever `create_tuple_stream` builds a `{"@":.., "__tuple__":true}`
+    /// wrapper during this top-level `evaluate()` call. Reset at the start of
+    /// `evaluate()` and checked at the end to decide whether the (recursive,
+    /// O(result size)) tuple-unwrap pass is needed before returning to the
+    /// caller — keeps the vast majority of evaluations, which never touch
+    /// `%`/`@`/`#`, at zero added cost.
+    tuple_stream_created: bool,
 }
 
 impl Evaluator {
@@ -2453,6 +2494,7 @@ impl Evaluator {
             // True TCO would allow deeper recursion but requires parser-level thunk marking
             max_recursion_depth: 302,
             next_lambda_id: 0,
+            tuple_stream_created: false,
         }
     }
 
@@ -2462,6 +2504,7 @@ impl Evaluator {
             recursion_depth: 0,
             max_recursion_depth: 302,
             next_lambda_id: 0,
+            tuple_stream_created: false,
         }
     }
 
@@ -2717,13 +2760,27 @@ impl Evaluator {
     ///
     /// This is the main entry point for evaluation. It sets up the parent context
     /// to be the root data if not already set.
+    ///
+    /// Also the single choke point for stripping any lingering tuple-stream
+    /// wrapper objects (`{"@":.., "__tuple__":true, ...}`) from the result before
+    /// it reaches the caller — `%`/`@`/`#` are implemented internally via a
+    /// tuple-stream representation (see `create_tuple_stream`), and without this
+    /// a bare (or object/array-nested) tuple-producing expression would leak
+    /// that internal representation into user-visible output instead of the
+    /// plain value.
     pub fn evaluate(&mut self, node: &AstNode, data: &JValue) -> Result<JValue, EvaluatorError> {
         // Set parent context to root data if not already set
         if self.context.get_parent().is_none() {
             self.context.set_parent(data.clone());
         }
 
-        self.evaluate_internal(node, data)
+        self.tuple_stream_created = false;
+        let result = self.evaluate_internal(node, data)?;
+        Ok(if self.tuple_stream_created {
+            unwrap_tuple_output(result)
+        } else {
+            result
+        })
     }
 
     /// Fast evaluation for leaf nodes that don't need recursion tracking.
@@ -4604,12 +4661,26 @@ impl Evaluator {
     /// stream (each wrapper carried forward, per JS's `tupleBindings`) or a
     /// plain value/array entering tuple mode for the first time (each item
     /// wrapped as `{'@': item}`, per JS's `input.map(item => {'@': item})`).
+    ///
+    /// This is the sole *origin* of fresh `__tuple__` wrapper objects: the other
+    /// `"__tuple__".to_string()` insert sites in `evaluate_path`'s single-field
+    /// fast paths only *rebuild* a wrapper around a value pulled from an input
+    /// element that is already `__tuple__`-tagged, which can only be true if a
+    /// `create_tuple_stream` call already ran earlier in this evaluation and set
+    /// `tuple_stream_created`. If a future edit adds a wrapping site that can
+    /// fire on a value that did NOT come from an existing tuple stream, it must
+    /// also set `self.tuple_stream_created = true`, or `Evaluator::evaluate`'s
+    /// output-unwrap pass will be skipped and the wrapper will leak to callers.
     fn create_tuple_stream(
         &mut self,
         step: &PathStep,
         input: &JValue,
     ) -> Result<Vec<JValue>, EvaluatorError> {
         use std::rc::Rc;
+
+        // Mark that this evaluate() call produced tuple wrappers, so the
+        // top-level `evaluate()` knows to run the output-unwrap pass.
+        self.tuple_stream_created = true;
 
         // Gather the incoming tuple bindings.
         let is_tuple_input = matches!(
@@ -10727,6 +10798,128 @@ impl Default for Evaluator {
 mod tests {
     use super::*;
     use crate::ast::{BinaryOp, UnaryOp};
+
+    // --- Task 7: tuple-wrapper output leak -----------------------------------
+    //
+    // `%`/`@`/`#` are implemented internally via a tuple-stream representation
+    // (`create_tuple_stream`): each element gets wrapped as
+    // `{"@": value, "__tuple__": true, ...bindings}`. Intermediate path steps
+    // consume/re-wrap these, but the *final* evaluate() result can still carry
+    // a lingering wrapper -- confirmed for real by dumping actual output before
+    // this fix (see task-7-report.md for the raw before/after). These tests
+    // pin both the bare top-level case (Task 5's brief `#` example) and the
+    // object/array-construction-nested case (found while verifying the brief's
+    // illustrative fix against real output -- a plain per-element Array-only
+    // recursion does not reach into a constructed object's field values).
+
+    fn dataset5_for_tuple_tests() -> JValue {
+        let s = include_str!("../tests/jsonata-js/test/test-suite/datasets/dataset5.json");
+        serde_json::from_str::<serde_json::Value>(s).unwrap().into()
+    }
+
+    fn assert_no_tuple_wrapper(value: &JValue) {
+        match value {
+            JValue::Object(obj) => {
+                assert!(
+                    obj.get("__tuple__").is_none(),
+                    "tuple wrapper leaked into output: {:?}",
+                    value
+                );
+                for v in obj.values() {
+                    assert_no_tuple_wrapper(v);
+                }
+            }
+            JValue::Array(arr) => {
+                for item in arr.iter() {
+                    assert_no_tuple_wrapper(item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn test_bare_index_bind_result_does_not_leak_tuple_wrapper() {
+        let data: JValue = serde_json::json!({"items": [1, 2, 3]}).into();
+        let ast = crate::parser::parse("items#$i").unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_no_tuple_wrapper(&result);
+        assert_eq!(
+            result,
+            JValue::array(vec![
+                JValue::from(1i64),
+                JValue::from(2i64),
+                JValue::from(3i64)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_percent_predicate_result_does_not_leak_tuple_wrapper() {
+        // Confirmed by Task 6 to evaluate to the correct @-values but stay
+        // wrapped: Account.Order.Product[%.OrderID='order104'].SKU
+        let data = dataset5_for_tuple_tests();
+        let ast = crate::parser::parse("Account.Order.Product[%.OrderID='order104'].SKU").unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_no_tuple_wrapper(&result);
+        assert_eq!(
+            result,
+            JValue::array(vec![
+                JValue::string("040657863"),
+                JValue::string("0406654603"),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_percent_step_over_tuple_stream_does_not_leak_tuple_wrapper() {
+        // Confirmed by Task 6: Account.Order.Product.Price.%[%.OrderID='order103'].SKU
+        let data = dataset5_for_tuple_tests();
+        let ast = crate::parser::parse("Account.Order.Product.Price.%[%.OrderID='order103'].SKU")
+            .unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_no_tuple_wrapper(&result);
+        assert_eq!(
+            result,
+            JValue::array(vec![
+                JValue::string("0406654608"),
+                JValue::string("0406634348"),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_tuple_wrapper_does_not_leak_when_nested_in_object_construction() {
+        // A tuple-producing expression nested inside a constructed object's field
+        // value: the top-level result is a plain (non-tuple) Object, so a naive
+        // "unwrap only if the whole value is a tuple wrapper" check would miss
+        // this -- must recurse into field values too.
+        let data = dataset5_for_tuple_tests();
+        let ast =
+            crate::parser::parse(r#"{ "skus": Account.Order.Product[%.OrderID='order104'].SKU }"#)
+                .unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_no_tuple_wrapper(&result);
+        assert_eq!(
+            result,
+            JValue::from(serde_json::json!({
+                "skus": ["040657863", "0406654603"]
+            }))
+        );
+    }
+
+    #[test]
+    fn test_tuple_wrapper_does_not_leak_when_nested_in_array_construction() {
+        let data: JValue = serde_json::json!({"items": [1, 2, 3]}).into();
+        let ast = crate::parser::parse("[items#$i]").unwrap();
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.evaluate(&ast, &data).unwrap();
+        assert_no_tuple_wrapper(&result);
+    }
 
     #[test]
     fn test_evaluate_literals() {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4398,6 +4398,17 @@ impl Evaluator {
                                 _ => unreachable!(), // We only match specific types above
                             };
 
+                            // Apply this step's own filter stages (e.g. the
+                            // `[$substring(title,0,3)='The']` on `.$[...]` in
+                            // `library.books#$pos.$[...].$pos`) while the tuple
+                            // bindings are still in scope, so the predicate can
+                            // reference them and non-matching tuples are dropped.
+                            let step_result = if step.stages.is_empty() {
+                                step_result
+                            } else {
+                                self.apply_stages(step_result, &step.stages)?
+                            };
+
                             // Restore previous bindings
                             for (name, saved_value) in &saved_bindings {
                                 if let Some(value) = saved_value {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -5002,8 +5002,12 @@ impl Evaluator {
             && (steps.iter().any(|step| !step.stages.is_empty()) || did_array_mapping);
 
         let result = match &current {
-            // Empty arrays become null/undefined
-            JValue::Array(arr) if arr.is_empty() => JValue::Null,
+            // An empty result sequence is "no value" -> undefined (jsonata-js
+            // treats an empty sequence, e.g. from a filter that matched nothing,
+            // as undefined so a following `.field` and object/array construction
+            // drop it rather than keeping an explicit null). `[]` array-keep is
+            // handled separately above via has_explicit_array_keep.
+            JValue::Array(arr) if arr.is_empty() => JValue::Undefined,
             // Unwrap singleton arrays when appropriate
             JValue::Array(arr) if arr.len() == 1 && should_unwrap => arr[0].clone(),
             // Keep arrays otherwise

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3600,6 +3600,10 @@ impl Evaluator {
                     // When applying stages, use stage-specific predicate logic
                     result = self.evaluate_predicate_as_stage(&result, predicate_expr)?;
                 }
+                // Positional index stages are meaningful only over a tuple stream
+                // (they set a variable to each tuple's position); they are applied
+                // in `create_tuple_stream`, not on a plain value sequence here.
+                Stage::Index(_) => {}
             }
         }
         Ok(result)
@@ -4995,8 +4999,7 @@ impl Evaluator {
             }
             // Check if any stage is an empty predicate
             step.stages.iter().any(|stage| {
-                let crate::ast::Stage::Filter(pred) = stage;
-                matches!(**pred, AstNode::Boolean(true))
+                matches!(stage, crate::ast::Stage::Filter(pred) if matches!(**pred, AstNode::Boolean(true)))
             })
         });
 
@@ -5183,7 +5186,14 @@ impl Evaluator {
             let step_value = self.evaluate_internal(&step.node, &actual_data);
 
             let mut step_value = step_value?;
-            if !step.stages.is_empty() {
+            // When the step carries an ORDERED index stage (a second `#$var`,
+            // e.g. `books@$b#$ib[...]#$ib2`), its stages must be applied to the
+            // BUILT tuple stream in order (filter then re-number) so the filter
+            // sees the per-tuple focus/index bindings and each index reflects the
+            // position at its point in the sequence. Those steps defer all stage
+            // application to `apply_tuple_stages` after the stream is built.
+            let has_index_stage = step.stages.iter().any(|s| matches!(s, Stage::Index(_)));
+            if !step.stages.is_empty() && !has_index_stage {
                 // A `%` inside a filter predicate refers to the ancestry of
                 // THIS step (its own input for a level-1 `%`, or an earlier
                 // step's input for a `%.%` chain). ast_transform tags this step
@@ -5246,7 +5256,80 @@ impl Evaluator {
             }
         }
 
+        // Apply ordered filter/index stages to the built tuple stream when a
+        // second index binding deferred them (see the has_index_stage comment
+        // in the build loop above).
+        if step.stages.iter().any(|s| matches!(s, Stage::Index(_))) {
+            result = self.apply_tuple_stages(result, &step.stages)?;
+        }
+
         Ok(result)
+    }
+
+    /// Apply a step's stages, in order, to an already-built tuple stream --
+    /// mirrors jsonata-js `evaluateStages` (jsonata.js ~L288-305): a `filter`
+    /// keeps the tuples whose predicate is truthy (evaluated against each tuple's
+    /// `@` with its carried `$var`/`!label` bindings in scope), and an `index`
+    /// stage sets its variable on every surviving tuple to that tuple's position
+    /// in the CURRENT stream. Used for steps carrying a second `#$var` index
+    /// binding (e.g. `books@$b#$ib[$l.isbn=$b.isbn]#$ib2`), where `$ib` is the
+    /// pre-filter position and `$ib2` the post-filter position.
+    fn apply_tuple_stages(
+        &mut self,
+        mut tuples: Vec<JValue>,
+        stages: &[Stage],
+    ) -> Result<Vec<JValue>, EvaluatorError> {
+        for stage in stages {
+            match stage {
+                Stage::Filter(pred) => {
+                    let mut kept = Vec::with_capacity(tuples.len());
+                    for tup in tuples.into_iter() {
+                        let JValue::Object(obj) = &tup else {
+                            continue;
+                        };
+                        // Bind this tuple's carried focus/index/ancestor keys so
+                        // the predicate can reference them.
+                        let mut saved: Vec<(String, Option<JValue>)> = Vec::new();
+                        for (k, v) in obj.iter() {
+                            let name = if let Some(n) = k.strip_prefix('$') {
+                                if n.is_empty() {
+                                    continue;
+                                }
+                                n.to_string()
+                            } else if k.starts_with('!') {
+                                k.clone()
+                            } else {
+                                continue;
+                            };
+                            saved.push((name.clone(), self.context.lookup(&name).cloned()));
+                            self.context.bind(name, v.clone());
+                        }
+                        let at = obj.get("@").cloned().unwrap_or(JValue::Undefined);
+                        let pred_res = self.evaluate_internal(pred, &at);
+                        for (name, old) in saved.into_iter().rev() {
+                            match old {
+                                Some(v) => self.context.bind(name, v),
+                                None => self.context.unbind(&name),
+                            }
+                        }
+                        if self.is_truthy(&pred_res?) {
+                            kept.push(tup);
+                        }
+                    }
+                    tuples = kept;
+                }
+                Stage::Index(var) => {
+                    for (pos, tup) in tuples.iter_mut().enumerate() {
+                        if let JValue::Object(obj) = tup {
+                            let mut m = (**obj).clone();
+                            m.insert(format!("${}", var), JValue::from(pos as i64));
+                            *tup = JValue::object(m);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(tuples)
     }
 
     /// Helper to evaluate a complex path step
@@ -5639,6 +5722,7 @@ impl Evaluator {
                                                 filter_expr,
                                             )?;
                                         }
+                                        Stage::Index(_) => {}
                                     }
                                 }
 
@@ -5673,6 +5757,7 @@ impl Evaluator {
                                                 filter_expr,
                                             )?;
                                         }
+                                        Stage::Index(_) => {}
                                     }
                                 }
 
@@ -9633,6 +9718,9 @@ impl Evaluator {
                     for stage in &step.stages {
                         match stage {
                             Stage::Filter(expr) => Self::collect_free_vars_walk(expr, bound, free),
+                            // An index stage binds a variable; it introduces no
+                            // free variable references.
+                            Stage::Index(_) => {}
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,8 +299,7 @@ impl JsonataExpression {
 #[cfg(feature = "python")]
 #[pyfunction]
 fn compile(expression: &str) -> PyResult<JsonataExpression> {
-    let ast = parser::parse(expression)
-        .map_err(|e| PyValueError::new_err(format!("Parse error: {}", e)))?;
+    let ast = parser::parse(expression).map_err(parser_error_to_py)?;
 
     Ok(JsonataExpression {
         ast,
@@ -544,6 +543,22 @@ fn evaluator_error_to_py(e: evaluator::EvaluatorError) -> PyErr {
     }
 }
 
+/// Convert a ParserError to a PyErr
+/// Coded errors (e.g., S0214) have their message formatted as "code: message",
+/// so they are passed through directly without an additional "Parse error: " prefix.
+/// Other errors get the "Parse error: " prefix for clarity.
+#[cfg(feature = "python")]
+fn parser_error_to_py(e: parser::ParserError) -> PyErr {
+    let msg = e.to_string();
+    if matches!(e, parser::ParserError::Coded { .. }) {
+        // Coded errors already have the format "code: message"
+        PyValueError::new_err(msg)
+    } else {
+        // Other errors get the "Parse error: " prefix
+        PyValueError::new_err(format!("Parse error: {}", msg))
+    }
+}
+
 /// JSONata Python module
 #[cfg(feature = "python")]
 #[pymodule]
@@ -566,5 +581,48 @@ mod tests {
     fn test_module_creation() {
         // Basic smoke test
         assert!(!env!("CARGO_PKG_VERSION").is_empty());
+    }
+
+    #[cfg(feature = "python")]
+    mod parser_error_handling {
+        use super::super::*;
+
+        #[test]
+        fn test_parser_error_to_py_coded_error_no_prefix() {
+            // Test that coded errors (like S0214) are passed through without "Parse error: " prefix
+            let coded_error = parser::ParserError::Coded {
+                code: "S0214",
+                message: "Expected a variable reference after @".to_string(),
+            };
+            let py_err = parser_error_to_py(coded_error);
+            let msg = py_err.to_string();
+
+            // The message should start with the code, not "Parse error: "
+            assert!(
+                msg.starts_with("S0214:"),
+                "Expected message to start with 'S0214:', got: {}",
+                msg
+            );
+            assert!(
+                !msg.starts_with("Parse error:"),
+                "Expected no 'Parse error:' prefix, got: {}",
+                msg
+            );
+        }
+
+        #[test]
+        fn test_parser_error_to_py_non_coded_error_with_prefix() {
+            // Test that non-coded errors still get the "Parse error: " prefix
+            let non_coded_error = parser::ParserError::UnexpectedToken("foo".to_string());
+            let py_err = parser_error_to_py(non_coded_error);
+            let msg = py_err.to_string();
+
+            // The message should have the "Parse error: " prefix
+            assert!(
+                msg.starts_with("Parse error:"),
+                "Expected message to start with 'Parse error:', got: {}",
+                msg
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,20 +544,30 @@ fn evaluator_error_to_py(e: evaluator::EvaluatorError) -> PyErr {
     }
 }
 
-/// Convert a ParserError to a PyErr
+/// Format a ParserError's Python-facing message.
 /// Coded errors (e.g., S0214) have their message formatted as "code: message",
 /// so they are passed through directly without an additional "Parse error: " prefix.
 /// Other errors get the "Parse error: " prefix for clarity.
-#[cfg(feature = "python")]
-fn parser_error_to_py(e: parser::ParserError) -> PyErr {
+///
+/// Split out from `parser_error_to_py` so this formatting logic can be unit
+/// tested without constructing a `PyErr` (which requires an initialized
+/// Python interpreter -- fine under `maturin develop`/pytest, but panics
+/// under a plain `cargo test --all-features` with no embedded interpreter).
+fn format_parser_error_message(e: &parser::ParserError) -> String {
     let msg = e.to_string();
     if matches!(e, parser::ParserError::Coded { .. }) {
         // Coded errors already have the format "code: message"
-        PyValueError::new_err(msg)
+        msg
     } else {
         // Other errors get the "Parse error: " prefix
-        PyValueError::new_err(format!("Parse error: {}", msg))
+        format!("Parse error: {}", msg)
     }
+}
+
+/// Convert a ParserError to a PyErr
+#[cfg(feature = "python")]
+fn parser_error_to_py(e: parser::ParserError) -> PyErr {
+    PyValueError::new_err(format_parser_error_message(&e))
 }
 
 /// JSONata Python module
@@ -584,9 +594,16 @@ mod tests {
         assert!(!env!("CARGO_PKG_VERSION").is_empty());
     }
 
-    #[cfg(feature = "python")]
     mod parser_error_handling {
         use super::super::*;
+
+        // These test format_parser_error_message() directly (a plain string
+        // function) rather than parser_error_to_py(), which constructs a
+        // PyErr -- that requires an initialized Python interpreter, which
+        // isn't available under a bare `cargo test --all-features` run (no
+        // embedded interpreter, unlike the maturin-built extension loaded
+        // into a live Python process). The formatting logic under test is
+        // identical either way.
 
         #[test]
         fn test_parser_error_to_py_coded_error_no_prefix() {
@@ -595,8 +612,7 @@ mod tests {
                 code: "S0214",
                 message: "Expected a variable reference after @".to_string(),
             };
-            let py_err = parser_error_to_py(coded_error);
-            let msg = py_err.to_string();
+            let msg = format_parser_error_message(&coded_error);
 
             // The message should start with the code, not "Parse error: "
             assert!(
@@ -615,8 +631,7 @@ mod tests {
         fn test_parser_error_to_py_non_coded_error_with_prefix() {
             // Test that non-coded errors still get the "Parse error: " prefix
             let non_coded_error = parser::ParserError::UnexpectedToken("foo".to_string());
-            let py_err = parser_error_to_py(non_coded_error);
-            let msg = py_err.to_string();
+            let msg = format_parser_error_message(&non_coded_error);
 
             // The message should have the "Parse error: " prefix
             assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! - `value` - JValue type (the runtime value representation)
 
 pub mod ast;
+pub mod ast_transform;
 mod compiler;
 mod datetime;
 pub mod evaluator;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -35,6 +35,13 @@ pub enum ParserError {
 
     #[error("Expected {expected}, found {found}")]
     Expected { expected: String, found: String },
+
+    /// A JSONata-spec-coded parse error (S0214-S0217 for the %/@ operators).
+    /// Code is at the start of the message (matching the DateTimeError::Coded
+    /// convention from the datetime picture-string engine) so
+    /// test_reference_suite.py's extract_error_code() finds it.
+    #[error("{code}: {message}")]
+    Coded { code: &'static str, message: String },
 }
 
 /// Token types for the lexer
@@ -95,6 +102,7 @@ pub enum Token {
 
     // Special
     Hash, // # index binding operator
+    At,   // @ focus binding operator
     Eof,
 }
 
@@ -611,6 +619,10 @@ impl Lexer {
                     self.advance();
                     return Ok(Token::Hash);
                 }
+                Some('@') => {
+                    self.advance();
+                    return Ok(Token::At);
+                }
                 Some('=') => {
                     self.advance();
                     return Ok(Token::Equal);
@@ -716,6 +728,7 @@ impl Parser {
             Token::LeftBrace => Some((80, 81)), // Object constructor as postfix
             Token::Caret => Some((80, 81)),     // Sort operator as postfix
             Token::Hash => Some((80, 81)),      // Index binding operator as postfix
+            Token::At => Some((80, 81)),        // Focus binding operator as postfix
             Token::Question => Some((20, 21)),
             Token::QuestionQuestion => Some((15, 16)), // Coalescing operator
             Token::QuestionColon => Some((15, 16)),    // Default operator
@@ -978,6 +991,12 @@ impl Parser {
                 // Descendant operator in primary position
                 self.advance()?;
                 Ok(AstNode::Descendant)
+            }
+            Token::Percent => {
+                // Parent operator in primary position. Bare at parse time --
+                // ast_transform assigns the actual ancestor slot (label/level).
+                self.advance()?;
+                Ok(AstNode::Parent)
             }
             Token::Function => {
                 // Parse lambda: function($param1, $param2, ...) { body }
@@ -1487,6 +1506,31 @@ impl Parser {
                     lhs = AstNode::IndexBind {
                         input: Box::new(lhs),
                         variable: var_name,
+                    };
+                }
+                Token::At => {
+                    // Focus binding operator: @$var
+                    // Produces a generic Binary(FocusBind) marker -- ast_transform
+                    // resolves this into a PathStep.focus flag, matching
+                    // jsonata-js's parser.js:834-847 (which does the same S0214
+                    // check inline, deferring all other semantics to processAST).
+                    self.advance()?; // skip '@'
+
+                    let var_name = match &self.current_token {
+                        Token::Variable(name) => name.clone(),
+                        _ => {
+                            return Err(ParserError::Coded {
+                                code: "S0214",
+                                message: "Expected a variable reference after @".to_string(),
+                            });
+                        }
+                    };
+                    self.advance()?; // skip variable
+
+                    lhs = AstNode::Binary {
+                        op: BinaryOp::FocusBind,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(AstNode::Variable(var_name)),
                     };
                 }
                 Token::Caret => {
@@ -2207,5 +2251,61 @@ mod tests {
             "expected parse to succeed, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn test_parent_operator_parses_as_prefix() {
+        let ast = parse("%.OrderID").unwrap();
+        // %.OrderID should parse as a path with two steps: Parent, then Name("OrderID")
+        match ast {
+            AstNode::Path { steps } => {
+                assert_eq!(steps.len(), 2);
+                assert!(matches!(steps[0].node, AstNode::Parent));
+                assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "OrderID"));
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_percent_still_parses_as_modulo_infix() {
+        // Regression: % must still work as binary modulo when NOT in prefix position
+        let ast = parse("10 % 3").unwrap();
+        assert!(matches!(
+            ast,
+            AstNode::Binary {
+                op: BinaryOp::Modulo,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_focus_bind_parses_as_binary_marker() {
+        let ast = parse("Order@$o").unwrap();
+        match ast {
+            AstNode::Binary {
+                op: BinaryOp::FocusBind,
+                lhs,
+                rhs,
+            } => {
+                // Order is parsed as a Path with a Name step
+                if let AstNode::Path { steps } = *lhs {
+                    assert_eq!(steps.len(), 1);
+                    assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "Order"));
+                } else {
+                    panic!("expected lhs to be Path, got {:?}", lhs);
+                }
+                assert!(matches!(*rhs, AstNode::Variable(ref n) if n == "o"));
+            }
+            other => panic!("expected Binary{{FocusBind}}, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_focus_bind_requires_variable_rhs() {
+        // S0214: @'s RHS must be a bare variable reference
+        let err = parse("Order@foo").unwrap_err();
+        assert!(err.to_string().starts_with("S0214"));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1126,6 +1126,24 @@ impl Parser {
                         // Check for .(expr) syntax (function application)
                         self.advance()?;
 
+                        // Empty block `.()`: a parenthesised step with no
+                        // expression (e.g. `Account.Order.().%`). jsonata-js
+                        // treats `()` as an empty block that evaluates to
+                        // undefined; keep it as a `FunctionApplication` of an
+                        // empty `Block` so the ancestry pass can walk past it.
+                        if self.current_token == Token::RightParen {
+                            self.advance()?;
+                            let mut steps = match lhs {
+                                AstNode::Path { steps } => steps,
+                                _ => vec![PathStep::new(lhs)],
+                            };
+                            steps.push(PathStep::new(AstNode::FunctionApplication(Box::new(
+                                AstNode::Block(Vec::new()),
+                            ))));
+                            lhs = AstNode::Path { steps };
+                            continue;
+                        }
+
                         // Parse the expression(s) to apply - may be block with semicolons
                         let mut expressions = vec![self.parse_expression(0)?];
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -993,10 +993,12 @@ impl Parser {
                 Ok(AstNode::Descendant)
             }
             Token::Percent => {
-                // Parent operator in primary position. Bare at parse time --
-                // ast_transform assigns the actual ancestor slot (label/level).
+                // Parent operator in primary position. Label is resolved by
+                // ast_transform -- this empty string is never observed by
+                // the evaluator (ast_transform fills every AstNode::Parent
+                // ("") with a real label or errors S0217).
                 self.advance()?;
-                Ok(AstNode::Parent)
+                Ok(AstNode::Parent(String::new()))
             }
             Token::Function => {
                 // Parse lambda: function($param1, $param2, ...) { body }
@@ -1503,9 +1505,16 @@ impl Parser {
                     };
                     self.advance()?; // skip variable
 
-                    lhs = AstNode::IndexBind {
-                        input: Box::new(lhs),
-                        variable: var_name,
+                    // Produces a generic Binary(IndexBind) marker -- ast_transform
+                    // resolves this into a PathStep.index_var flag, mirroring how
+                    // @$var/FocusBind is represented (see Token::At below). Using
+                    // the same generic Binary shape (rather than a dedicated
+                    // AstNode::IndexBind variant) lets that variant be retired
+                    // from ast.rs entirely.
+                    lhs = AstNode::Binary {
+                        op: BinaryOp::IndexBind,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(AstNode::Variable(var_name)),
                     };
                 }
                 Token::At => {
@@ -1693,10 +1702,18 @@ impl Parser {
 
 /// Parse a JSONata expression string into an AST
 ///
-/// This is the main entry point for parsing.
+/// This is the main entry point for parsing. Runs the post-parse
+/// ast_transform pass (ancestor-slot resolution, @/#/% unification)
+/// unconditionally, matching jsonata-js's processAST always running
+/// immediately after the raw Pratt parse.
 pub fn parse(expression: &str) -> Result<AstNode, ParserError> {
     let mut parser = Parser::new(expression.to_string())?;
-    parser.parse()
+    let raw_ast = parser.parse()?;
+    crate::ast_transform::resolve_ancestry(raw_ast).map_err(|e| match e {
+        crate::ast_transform::AstTransformError::Coded { code, message } => {
+            ParserError::Coded { code, message }
+        }
+    })
 }
 
 #[cfg(test)]
@@ -2255,12 +2272,20 @@ mod tests {
 
     #[test]
     fn test_parent_operator_parses_as_prefix() {
-        let ast = parse("%.OrderID").unwrap();
+        // Tests the RAW grammar rule (bare `%` in primary position) in
+        // isolation from ast_transform's ancestor resolution -- uses
+        // Parser::new(...).parse() directly rather than the free `parse()`
+        // function, since the free function now runs ast_transform
+        // unconditionally (Step 8), and `%.OrderID` alone has no preceding
+        // step for `%` to resolve against (that's covered by
+        // ast_transform's own S0217 tests).
+        let mut parser = Parser::new("%.OrderID".to_string()).unwrap();
+        let ast = parser.parse().unwrap();
         // %.OrderID should parse as a path with two steps: Parent, then Name("OrderID")
         match ast {
             AstNode::Path { steps } => {
                 assert_eq!(steps.len(), 2);
-                assert!(matches!(steps[0].node, AstNode::Parent));
+                assert!(matches!(steps[0].node, AstNode::Parent(_)));
                 assert!(matches!(steps[1].node, AstNode::Name(ref n) if n == "OrderID"));
             }
             other => panic!("expected Path, got {:?}", other),
@@ -2282,7 +2307,12 @@ mod tests {
 
     #[test]
     fn test_focus_bind_parses_as_binary_marker() {
-        let ast = parse("Order@$o").unwrap();
+        // Tests the RAW grammar rule in isolation from ast_transform (which
+        // now runs unconditionally in the free `parse()` and would rewrite
+        // this into a Path with a `focus` flag instead -- see
+        // ast_transform.rs's own real-parser-based tests for that).
+        let mut parser = Parser::new("Order@$o".to_string()).unwrap();
+        let ast = parser.parse().unwrap();
         match ast {
             AstNode::Binary {
                 op: BinaryOp::FocusBind,
@@ -2299,6 +2329,30 @@ mod tests {
                 assert!(matches!(*rhs, AstNode::Variable(ref n) if n == "o"));
             }
             other => panic!("expected Binary{{FocusBind}}, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_index_bind_parses_as_binary_marker() {
+        // #$var now reuses the same generic Binary marker shape as @$var
+        // (Task 4 retires the dedicated AstNode::IndexBind struct variant).
+        let mut parser = Parser::new("arr#$i".to_string()).unwrap();
+        let ast = parser.parse().unwrap();
+        match ast {
+            AstNode::Binary {
+                op: BinaryOp::IndexBind,
+                lhs,
+                rhs,
+            } => {
+                if let AstNode::Path { steps } = *lhs {
+                    assert_eq!(steps.len(), 1);
+                    assert!(matches!(steps[0].node, AstNode::Name(ref n) if n == "arr"));
+                } else {
+                    panic!("expected lhs to be Path, got {:?}", lhs);
+                }
+                assert!(matches!(*rhs, AstNode::Variable(ref n) if n == "i"));
+            }
+            other => panic!("expected Binary{{IndexBind}}, got {:?}", other),
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1512,13 +1512,16 @@ impl Parser {
                     // Binds the current array index to the specified variable
                     self.advance()?; // skip '#'
 
-                    // Expect a variable name
+                    // Expect a variable name. A bare `#` without a `$var` (e.g.
+                    // `Account.Order@$o#i.Product`) is S0214, mirroring jsonata-js's
+                    // inline check for `@`/`#` (parser.js ~L834-847).
                     let var_name = match &self.current_token {
                         Token::Variable(name) => name.clone(),
                         _ => {
-                            return Err(ParserError::InvalidSyntax(
-                                "Expected variable name after #".to_string(),
-                            ));
+                            return Err(ParserError::Coded {
+                                code: "S0214",
+                                message: "Expected a variable reference after #".to_string(),
+                            });
                         }
                     };
                     self.advance()?; // skip variable

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -613,3 +613,75 @@ fn test_recursive_lambda_ids_do_not_collide() {
         assert_eq!(result, JValue::from(json!(720.0)), "iteration {i}");
     }
 }
+
+// --- Task 6: `%` inside filter predicates and sort terms (runtime) ---
+//
+// Regression guard for the runtime half of Task 6. The `ast_transform` unit
+// tests only assert AST *tagging*; these assert the resolved VALUES end-to-end,
+// so the fragile runtime pieces (create_tuple_stream's deferred incoming-unbind
+// for `%.%` chains, the step's own-label bind before apply_stages, and routing
+// a `%` path-step over a tuple stream) fail loudly if broken. Expected values
+// are from tests/jsonata-js/.../parent-operator/parent.json (dataset5).
+//
+// The result is still a tuple stream (final output-unwrap is Task 7), so we
+// extract the `@` values recursively before comparing.
+fn tuple_at_values(v: &JValue) -> Vec<JValue> {
+    match v {
+        JValue::Array(arr) => arr.iter().flat_map(tuple_at_values).collect(),
+        JValue::Object(o) if o.get("__tuple__").and_then(|b| b.as_bool()) == Some(true) => {
+            match o.get("@") {
+                Some(inner) => tuple_at_values(inner),
+                None => vec![],
+            }
+        }
+        other => vec![other.clone()],
+    }
+}
+
+fn dataset5() -> JValue {
+    let s = include_str!("jsonata-js/test/test-suite/datasets/dataset5.json");
+    serde_json::from_str::<serde_json::Value>(s).unwrap().into()
+}
+
+fn eval_tuple_at(expr: &str) -> Vec<JValue> {
+    let ast = parse(expr).unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &dataset5()).unwrap();
+    tuple_at_values(&result)
+}
+
+#[test]
+fn test_percent_in_predicate_on_parent_step() {
+    // parent.json: "...Price.%[%.OrderID='order103'].SKU" -> the % step over a
+    // tuple stream, with a predicate whose own % resolves to Product.
+    let got = eval_tuple_at("Account.Order.Product.Price.%[%.OrderID='order103'].SKU");
+    let want: Vec<JValue> = ["0406654608", "0406634348"]
+        .iter()
+        .map(|s| JValue::from(json!(s)))
+        .collect();
+    assert_eq!(got, want);
+}
+
+#[test]
+fn test_percent_chain_in_predicate() {
+    // "...Product[%.%.`Account Name`='Firefly'].SKU" exercises the %.% chain
+    // inside a predicate (first % -> Product, second % -> Order/Account name).
+    let got = eval_tuple_at("Account.Order.Product[%.%.`Account Name`='Firefly'].SKU");
+    let want: Vec<JValue> = ["0406654608", "0406634348", "040657863", "0406654603"]
+        .iter()
+        .map(|s| JValue::from(json!(s)))
+        .collect();
+    assert_eq!(got, want);
+}
+
+#[test]
+fn test_percent_in_two_sort_terms() {
+    // "...SKU^(%.Price, >%.%.OrderID)" -- both sort terms use %; ordering must
+    // match parent.json (primary %.Price asc, secondary %.%.OrderID desc).
+    let got = eval_tuple_at("Account.Order.Product.SKU^(%.Price, >%.%.OrderID)");
+    let want: Vec<JValue> = ["0406634348", "040657863", "0406654608", "0406654603"]
+        .iter()
+        .map(|s| JValue::from(json!(s)))
+        .collect();
+    assert_eq!(got, want);
+}

--- a/tests/parent_and_focus_binding_suite.rs
+++ b/tests/parent_and_focus_binding_suite.rs
@@ -1,0 +1,186 @@
+// Fast-iteration mirror of the parent-operator/joins reference-suite cases
+// for the %/@ operators, mirroring tests/datetime_picture_suite.rs's
+// structure (see that file for the run_case/run_group_file helpers this
+// duplicates -- kept as a separate file since this isn't datetime-related).
+//
+// This is NOT a replacement for `pytest tests/python/test_reference_suite.py`
+// (the real gate); it exists so the %/@ ancestry + tuple-stream machinery can
+// be iterated on with `cargo test` (seconds) instead of a maturin rebuild +
+// pytest cycle per fix. See
+// docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md.
+
+use jsonata_core::{
+    evaluator::{Evaluator, EvaluatorError},
+    parser::parse,
+    value::JValue,
+};
+use serde_json::Value as JsonValue;
+use std::fs;
+use std::path::Path;
+
+/// Mirrors `evaluator_error_to_py` in src/lib.rs: the Python-visible exception
+/// message is the raw inner string of the error variant (which carries the
+/// leading JSONata error code, e.g. "S0217: ..."), NOT its `Display` impl.
+fn error_message(e: &EvaluatorError) -> &str {
+    match e {
+        EvaluatorError::TypeError(m) => m,
+        EvaluatorError::ReferenceError(m) => m,
+        EvaluatorError::EvaluationError(m) => m,
+    }
+}
+
+fn resolve_expr(case: &JsonValue, group_dir: &Path) -> Option<String> {
+    if let Some(expr) = case.get("expr").and_then(|e| e.as_str()) {
+        return Some(expr.to_string());
+    }
+    let expr_file = case.get("expr-file").and_then(|e| e.as_str())?;
+    fs::read_to_string(group_dir.join(expr_file)).ok()
+}
+
+fn resolve_data(case: &JsonValue, dataset_dir: &Path) -> JsonValue {
+    if let Some(data) = case.get("data") {
+        return data.clone();
+    }
+    if let Some(dataset) = case.get("dataset").and_then(|d| d.as_str()) {
+        let path = dataset_dir.join(format!("{dataset}.json"));
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(parsed) = serde_json::from_str(&content) {
+                return parsed;
+            }
+        }
+    }
+    JsonValue::Null
+}
+
+fn run_case(case: &JsonValue, group_dir: &Path, dataset_dir: &Path) -> Result<(), String> {
+    let expr = resolve_expr(case, group_dir).ok_or("missing expr/expr-file")?;
+    let data: JValue = resolve_data(case, dataset_dir).into();
+
+    let ast = match parse(&expr) {
+        Ok(ast) => ast,
+        Err(e) => {
+            // A parse error may itself be the expected outcome (code check below).
+            if let Some(code) = case.get("code").and_then(|c| c.as_str()) {
+                let msg = format!("{e}");
+                if msg.contains(code) {
+                    return Ok(());
+                }
+                return Err(format!("expected code {code}, got parse error: {msg}"));
+            }
+            return Err(format!("parse error: {e}"));
+        }
+    };
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data);
+
+    if let Some(code) = case.get("code").and_then(|c| c.as_str()) {
+        return match &result {
+            Err(e) => {
+                let msg = error_message(e);
+                if msg.starts_with(code) {
+                    Ok(())
+                } else {
+                    Err(format!("expected code {code}, got error: {msg}"))
+                }
+            }
+            Ok(v) => Err(format!("expected error {code}, got result {v:?}")),
+        };
+    }
+
+    if case.get("undefinedResult").and_then(|b| b.as_bool()) == Some(true) {
+        return match result {
+            Ok(JValue::Undefined) | Ok(JValue::Null) => Ok(()),
+            Ok(other) => Err(format!("expected undefined, got {other:?}")),
+            Err(e) => Err(format!("expected undefined, got error: {e}")),
+        };
+    }
+
+    if let Some(expected) = case.get("result") {
+        return match result {
+            Ok(v) => {
+                let actual = serde_json::to_value(&v)
+                    .map_err(|e| format!("failed to serialize result: {e}"))?;
+                if &actual == expected {
+                    Ok(())
+                } else {
+                    Err(format!("expected {expected}, got {actual}"))
+                }
+            }
+            Err(e) => Err(format!("expected result {expected}, got error: {e}")),
+        };
+    }
+
+    Err("test spec has no expected outcome (result, undefinedResult, or code)".to_string())
+}
+
+fn run_group_file(path: &Path, group_dir: &Path, dataset_dir: &Path) -> (usize, Vec<String>) {
+    let content = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading {path:?}: {e}"));
+    let json: JsonValue =
+        serde_json::from_str(&content).unwrap_or_else(|e| panic!("parsing {path:?}: {e}"));
+    let cases: Vec<&JsonValue> = match &json {
+        JsonValue::Array(arr) => arr.iter().collect(),
+        obj => vec![obj],
+    };
+
+    let mut failures = Vec::new();
+    for (i, case) in cases.iter().enumerate() {
+        if let Err(msg) = run_case(case, group_dir, dataset_dir) {
+            let desc = case
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("");
+            failures.push(format!(
+                "{}[{i}] ({desc}): {msg}",
+                path.file_stem().unwrap().to_string_lossy()
+            ));
+        }
+    }
+    (cases.len(), failures)
+}
+
+fn groups_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/jsonata-js/test/test-suite/groups")
+}
+
+fn dataset_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/jsonata-js/test/test-suite/datasets")
+}
+
+#[test]
+fn parent_operator() {
+    let group_dir = groups_root().join("parent-operator");
+    let (total, failures) =
+        run_group_file(&group_dir.join("parent.json"), &group_dir, &dataset_dir());
+    assert!(
+        failures.is_empty(),
+        "{}/{} failed:\n{}",
+        failures.len(),
+        total,
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn joins() {
+    let group_dir = groups_root().join("joins");
+    let mut all_failures = Vec::new();
+    let mut all_total = 0;
+    let mut files: Vec<_> = fs::read_dir(&group_dir)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("json"))
+        .collect();
+    files.sort();
+    for path in files {
+        let (total, failures) = run_group_file(&path, &group_dir, &dataset_dir());
+        all_total += total;
+        all_failures.extend(failures);
+    }
+    assert!(
+        all_failures.is_empty(),
+        "{}/{} failed:\n{}",
+        all_failures.len(),
+        all_total,
+        all_failures.join("\n")
+    );
+}

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -21,6 +21,39 @@ class TestCompile:
         #     jsonatapy.compile("invalid [[[ syntax")
         pass
 
+    def test_compile_coded_error_s0214_no_prefix(self):
+        """Test that S0214 coded errors appear without 'Parse error:' prefix.
+
+        This test verifies that parser errors with JSONata spec codes (like S0214,
+        which is raised when @ is not followed by a variable) appear at the start
+        of the error message without an added 'Parse error:' prefix. The test suite
+        extracts error codes using a regex that expects the code at the very start.
+        """
+        with pytest.raises(ValueError) as exc_info:
+            jsonatapy.compile("Order@foo")
+
+        error_msg = str(exc_info.value)
+        # The error should start with S0214:, not "Parse error: S0214:"
+        assert error_msg.startswith("S0214:"), (
+            f"Expected error to start with 'S0214:', got: {error_msg}"
+        )
+        # Sanity check: should NOT have Parse error prefix
+        assert not error_msg.startswith("Parse error: S0214:"), (
+            f"Error should not have 'Parse error:' prefix, got: {error_msg}"
+        )
+
+    def test_compile_non_coded_error_with_prefix(self):
+        """Test that non-coded parse errors still get 'Parse error:' prefix."""
+        with pytest.raises(ValueError) as exc_info:
+            # An unclosed string is a non-coded error
+            jsonatapy.compile('"unclosed string')
+
+        error_msg = str(exc_info.value)
+        # Non-coded errors should have the "Parse error: " prefix
+        assert error_msg.startswith("Parse error:"), (
+            f"Expected error to start with 'Parse error:', got: {error_msg}"
+        )
+
 
 class TestEvaluate:
     """Tests for evaluate() function"""

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -2,9 +2,12 @@
 Test adapter for the JSONata reference test suite.
 
 This module loads and runs all 1682 test cases from the reference JavaScript JSONata
-implementation. 1610 currently pass (2 more xpass); the remaining 70 are xfailed pending
-fixes tracked by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md
+implementation. 1613 currently pass; the remaining 69 are marked xfail pending fixes
+tracked by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md
 and docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md.
+Of those, 24 already xpass: parent-and-focus-binding-operators Task 5 wired up the
+tuple-stream runtime for %/@/# and incidentally enabled many parent-operator/joins
+cases, but their markers stay until their owning tasks (6/7) land and can claim them.
 """
 
 import json
@@ -100,18 +103,6 @@ _XFAIL_PHASE_BY_GROUP = {
     "array-constructor": "Phase 5: untriaged straggler",
     "function-distinct": "Phase 5: untriaged straggler",
     "flattening": "Phase 5: untriaged straggler",
-    # parent-and-focus-binding-operators Task 4 (2026-07): retiring the
-    # dedicated AstNode::IndexBind variant (folded into the same PathStep
-    # flags @/# now share) also retired the narrow evaluator-side runtime
-    # wrapping it used to do for SOME #$var cases. ast_transform now always
-    # migrates #$var into PathStep.index_var, but the evaluator doesn't act
-    # on that flag yet (that's Task 5's tuple-stream runtime wiring, see
-    # docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md
-    # Section 3) -- so these previously-passing cases regress until Task 5
-    # lands. sorting/case020 and performance/case001 aren't otherwise in the
-    # "joins" group above, hence the separate entries.
-    "sorting": "Task 5: #$var tuple-stream runtime wiring not yet implemented",
-    "performance": "Task 5: #$var tuple-stream runtime wiring not yet implemented",
 }
 
 _XFAIL_TEST_IDS = {
@@ -135,7 +126,6 @@ _XFAIL_TEST_IDS = {
     "joins/index[10]",
     "joins/index[11]",
     "joins/index[12]",
-    "joins/index[13]",
     "joins/index[15]",
     "joins/index[1]",
     "joins/index[2]",
@@ -185,8 +175,6 @@ _XFAIL_TEST_IDS = {
     "parent-operator/parent[7]",
     "parent-operator/parent[8]",
     "parent-operator/parent[9]",
-    "performance/case001",
-    "sorting/case020",
 }
 
 

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -2,8 +2,9 @@
 Test adapter for the JSONata reference test suite.
 
 This module loads and runs all 1682 test cases from the reference JavaScript JSONata
-implementation. 1613 currently pass; the remaining 69 are xfailed pending fixes tracked
-by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md.
+implementation. 1610 currently pass (2 more xpass); the remaining 70 are xfailed pending
+fixes tracked by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md
+and docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md.
 """
 
 import json
@@ -99,6 +100,18 @@ _XFAIL_PHASE_BY_GROUP = {
     "array-constructor": "Phase 5: untriaged straggler",
     "function-distinct": "Phase 5: untriaged straggler",
     "flattening": "Phase 5: untriaged straggler",
+    # parent-and-focus-binding-operators Task 4 (2026-07): retiring the
+    # dedicated AstNode::IndexBind variant (folded into the same PathStep
+    # flags @/# now share) also retired the narrow evaluator-side runtime
+    # wrapping it used to do for SOME #$var cases. ast_transform now always
+    # migrates #$var into PathStep.index_var, but the evaluator doesn't act
+    # on that flag yet (that's Task 5's tuple-stream runtime wiring, see
+    # docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md
+    # Section 3) -- so these previously-passing cases regress until Task 5
+    # lands. sorting/case020 and performance/case001 aren't otherwise in the
+    # "joins" group above, hence the separate entries.
+    "sorting": "Task 5: #$var tuple-stream runtime wiring not yet implemented",
+    "performance": "Task 5: #$var tuple-stream runtime wiring not yet implemented",
 }
 
 _XFAIL_TEST_IDS = {
@@ -122,6 +135,7 @@ _XFAIL_TEST_IDS = {
     "joins/index[10]",
     "joins/index[11]",
     "joins/index[12]",
+    "joins/index[13]",
     "joins/index[15]",
     "joins/index[1]",
     "joins/index[2]",
@@ -171,6 +185,8 @@ _XFAIL_TEST_IDS = {
     "parent-operator/parent[7]",
     "parent-operator/parent[8]",
     "parent-operator/parent[9]",
+    "performance/case001",
+    "sorting/case020",
 }
 
 

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -2,12 +2,12 @@
 Test adapter for the JSONata reference test suite.
 
 This module loads and runs all 1682 test cases from the reference JavaScript JSONata
-implementation. 1613 currently pass; the remaining 69 are marked xfail pending fixes
-tracked by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md
-and docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md.
-Of those, 24 already xpass: parent-and-focus-binding-operators Task 5 wired up the
-tuple-stream runtime for %/@/# and incidentally enabled many parent-operator/joins
-cases, but their markers stay until their owning tasks (6/7) land and can claim them.
+implementation. 1678 currently pass; the remaining 4 are marked xfail pending fixes
+tracked by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md.
+Those 4 are Phase 5's untriaged stragglers (array-constructor, function-distinct,
+flattening). The full parent-operator and joins groups (the %/@/# parent-reference,
+focus-binding, and index-binding operators) now pass; see
+docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md.
 """
 
 import json
@@ -98,8 +98,6 @@ def extract_error_code(error_msg: str) -> str | None:
 # that will fix it, so the suite stays green while the gap is tracked explicitly
 # instead of silently hidden again.
 _XFAIL_PHASE_BY_GROUP = {
-    "parent-operator": "Phase 3: % parent-reference operator not parsed",
-    "joins": "Phase 4: @ tuple-stream binding parse gaps / tuple-wrapper leak",
     "array-constructor": "Phase 5: untriaged straggler",
     "function-distinct": "Phase 5: untriaged straggler",
     "flattening": "Phase 5: untriaged straggler",
@@ -110,71 +108,6 @@ _XFAIL_TEST_IDS = {
     "array-constructor/array-sequences[4]",
     "flattening/sequence-of-arrays[1]",
     "function-distinct/distinct[4]",
-    "joins/employee-map-reduce[0]",
-    "joins/employee-map-reduce[10]",
-    "joins/employee-map-reduce[11]",
-    "joins/employee-map-reduce[1]",
-    "joins/employee-map-reduce[2]",
-    "joins/employee-map-reduce[3]",
-    "joins/employee-map-reduce[4]",
-    "joins/employee-map-reduce[5]",
-    "joins/employee-map-reduce[6]",
-    "joins/employee-map-reduce[7]",
-    "joins/employee-map-reduce[8]",
-    "joins/employee-map-reduce[9]",
-    "joins/index[0]",
-    "joins/index[10]",
-    "joins/index[11]",
-    "joins/index[12]",
-    "joins/index[15]",
-    "joins/index[1]",
-    "joins/index[2]",
-    "joins/index[3]",
-    "joins/index[4]",
-    "joins/index[5]",
-    "joins/index[6]",
-    "joins/index[7]",
-    "joins/index[8]",
-    "joins/index[9]",
-    "joins/library-joins[0]",
-    "joins/library-joins[10]",
-    "joins/library-joins[1]",
-    "joins/library-joins[2]",
-    "joins/library-joins[3]",
-    "joins/library-joins[4]",
-    "joins/library-joins[5]",
-    "joins/library-joins[6]",
-    "joins/library-joins[7]",
-    "joins/library-joins[8]",
-    "joins/library-joins[9]",
-    "parent-operator/parent[0]",
-    "parent-operator/parent[10]",
-    "parent-operator/parent[11]",
-    "parent-operator/parent[12]",
-    "parent-operator/parent[13]",
-    "parent-operator/parent[14]",
-    "parent-operator/parent[15]",
-    "parent-operator/parent[16]",
-    "parent-operator/parent[17]",
-    "parent-operator/parent[18]",
-    "parent-operator/parent[19]",
-    "parent-operator/parent[1]",
-    "parent-operator/parent[20]",
-    "parent-operator/parent[21]",
-    "parent-operator/parent[22]",
-    "parent-operator/parent[23]",
-    "parent-operator/parent[24]",
-    "parent-operator/parent[25]",
-    "parent-operator/parent[26]",
-    "parent-operator/parent[27]",
-    "parent-operator/parent[2]",
-    "parent-operator/parent[3]",
-    "parent-operator/parent[4]",
-    "parent-operator/parent[5]",
-    "parent-operator/parent[6]",
-    "parent-operator/parent[7]",
-    "parent-operator/parent[8]",
-    "parent-operator/parent[9]",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,7 @@ wheels = [
 
 [[package]]
 name = "jsonatapy"
-version = "2.1.4"
+version = "2.1.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Completes Phase 3+4 of the reference-suite-coverage-gap effort (see `docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md`). Implements JSONata's `%` (parent-reference) and `@$var`/`#$var` (focus/index binding) operators, which were completely unimplemented at the lexer/AST level before this branch (`@` caused an immediate lexer error, `%` only ever tokenized as binary modulo).

- New post-parse `ast_transform` module: a faithful port of jsonata-js's `processAST`/`seekParent`/`pushAncestry`/`resolveAncestry`, resolving `%`/`%.%` ancestor chains through plain paths, parenthesized blocks, object-constructor values, predicates, and sort terms — validated throughout against jsonata-js's own `.ast()` output rather than hand-derived expectations.
- Retires the old `AstNode::IndexBind` wrapping-node representation of `#$var` in favor of a unified step-level-flag scheme shared by `%`/`@`/`#`, fixing a pre-existing tuple-context propagation gap in the process.
- Unified tuple-stream runtime in the evaluator: creation, consumption, predicate/sort-term-aware binding, group-by handling, and a fix for a "tuple wrapper leaks into user-visible output" bug class that was latent even for the pre-existing `#$var` feature.
- ~10 additional root-cause fixes surfaced only once the full `parent-operator`+`joins` reference-suite groups were run end-to-end (contiguous-focus-skip ancestor resolution, empty `.()` steps, `#`/`@` variable-first index-vs-focus semantics, tuple-stream handling for array-constructors/sort/group-by, a general null-vs-undefined semantic completion for empty path results).

**Result:** all 65 `parent-operator`+`joins` reference-suite xfail entries removed — both groups now pass 100% for real. `1678/1682` reference-suite tests passing (up from `1613/1682`); the remaining 4 are Phase 5's untriaged, out-of-scope stragglers (`array-constructor`/`function-distinct`/`flattening`).

This was implemented via subagent-driven-development against a written plan (`docs/superpowers/plans/2026-07-06-parent-and-focus-binding-operators.md`), with a task-level review after each of 8 tasks plus a final whole-branch review. Several review rounds caught real, verified bugs — mostly in the plan's own reference code, caught only by validating against real jsonata-js behavior rather than trusting hand-derived expectations. The final whole-branch review caught one genuine correctness bug (a tuple-key bind/unbind that could silently clobber an outer `:=`-bound variable sharing a name with a binding variable), fixed and re-verified before this PR.

## Test plan
- [x] `cargo test` (207+ tests: unit + `ast_transform` + `tests/parent_and_focus_binding_suite.rs` new integration harness + existing integration tests) — all pass
- [x] `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `uv run pytest tests/python/test_reference_suite.py` — 1678 passed, 4 xfailed (Phase 5 only), 0 failed
- [x] `uv run pytest tests/python/` (full suite) — 1772 passed, 4 skipped, 4 xfailed, 0 failed, no regressions
- [ ] CI green on all platforms (Linux/Windows/macOS) and Python 3.10-3.14 — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)