### PR TITLE
fix: Phase 5 reference-suite stragglers (array-constructor, distinct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,8 @@ See [official JSONata docs](https://docs.jsonata.org/) for the full language ref
 
 ## Performance
 
-`jsonata-core` passes **1678/1682** JSONata reference tests (4 xfailed pending known
-Phase 5 stragglers in `array-constructor`, `function-distinct`, and `flattening`) and
-is the fastest JSONata implementation available in either Rust or Python.
+`jsonata-core` passes **1682/1682** JSONata reference tests and is the fastest JSONata
+implementation available in either Rust or Python.
 
 ### Pure Rust (Criterion benchmarks, no Python overhead)
 
@@ -161,8 +160,7 @@ See [Performance docs](docs/performance.md) for full benchmark results and metho
 
 ## Features
 
-- **1678/1682 JSONata reference tests passing** — 4 xfailed pending Phase 5 stragglers
-  (`array-constructor`, `function-distinct`, `flattening`)
+- **1682/1682 JSONata reference tests passing**
 - **Pure Rust core** — no JavaScript runtime, no Node.js dependency
 - **Optional Python bindings** — PyO3/maturin, zero-copy where possible
 - **Cross-platform** — Linux, macOS (Intel & ARM), Windows; Python 3.10–3.13

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,7 @@ let result = Evaluator::new().evaluate(&ast, &data)?;
 
 ## Performance highlights
 
-- **1678/1682** JSONata reference tests passing (4 xfailed pending Phase 5 stragglers
-  in `array-constructor`, `function-distinct`, and `flattening`)
+- **1682/1682** JSONata reference tests passing
 - **up to 18x faster** than the JavaScript reference implementation for pure expression workloads
 - **~40x faster** than jsonata-rs (the next pure-Rust JSONata implementation)
 - **~10–65x faster** than jsonata-python across all categories

--- a/docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md
+++ b/docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md
@@ -152,7 +152,21 @@ new session shouldn't need to re-derive it, just verify and build on it.
   large phase. Phases 0-2 ship now as their own release; Phases 3+4 (combined) and 5 remain
   open follow-up work with no landing date attached.
 - **Phase 5 — remaining stragglers.** `array-constructor` (2), `function-distinct` (1),
-  `flattening` (1) — not yet triaged; likely quick once looked at individually.
+  `flattening` (1) — **DONE (2026-07-06)**. Three distinct root causes, all in
+  `src/evaluator.rs`: (1) the array-constructor step (`.[a,b]`) didn't implement
+  jsonata-js's `evaluateStep` special case where, when it's the path's last step and
+  maps over exactly one input item, the constructed sub-array becomes the whole path
+  result directly rather than being wrapped in an extra outer array (fixed by tracking
+  `is_last_step` in the path-step loop); (2) the compiled/VM fast path
+  (`try_compile_path`) folded the explicit `[]` keep-array marker
+  (`Predicate(Boolean(true))`) into an ordinary boolean filter, discarding its
+  keep-singleton semantics that the tree-walker's `evaluate_predicate` already handled
+  correctly — fixed by bailing out to the tree-walker for that marker, matching the
+  existing numeric-predicate bailout; (3) `$distinct` threw on non-array input instead
+  of jsonata-js's `functions.js` behavior of returning non-array (and length-<=1 array)
+  input unchanged. All three verified against real jsonata-js and fixed at both
+  builtin-dispatch call sites (compiled and tree-walker). 1682/1682 passing, zero
+  xfails remain in the suite.
 
 Out of scope: the jsonata-js 2.2.1 signature-engine spec's Phase 2
 (`docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md`) — porting jsonata-js's new

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1411,9 +1411,13 @@ fn try_compile_path(
     };
 
     // Compile a boolean filter predicate, rejecting numeric predicates (`[0]`, `[1]`)
-    // which represent index access in JSONata, not boolean filtering.
+    // which represent index access in JSONata, not boolean filtering, and the
+    // explicit `[]` keep-array marker (`Boolean(true)`), which forces the result
+    // to stay an array rather than filtering — the tree-walker's
+    // `evaluate_predicate` special-cases it and the compiled path has no
+    // equivalent, so bail out rather than silently treating it as `filter(true)`.
     let compile_filter = |node: &AstNode| -> Option<CompiledExpr> {
-        if matches!(node, AstNode::Number(_)) {
+        if matches!(node, AstNode::Number(_) | AstNode::Boolean(true)) {
             return None;
         }
         try_compile_expr_inner(node, allowed_vars)
@@ -2055,10 +2059,10 @@ fn call_pure_builtin(name: &str, args: &[JValue], data: &JValue) -> Result<JValu
         },
         "distinct" => match effective_args.first() {
             Some(JValue::Null | JValue::Undefined) | None => Ok(JValue::Null),
-            Some(JValue::Array(arr)) => Ok(functions::array::distinct(arr)?),
-            _ => Err(EvaluatorError::TypeError(
-                "distinct() requires an array argument".to_string(),
-            )),
+            Some(JValue::Array(arr)) if arr.len() > 1 => Ok(functions::array::distinct(arr)?),
+            // Non-array input, and arrays of length <= 1, pass through unchanged
+            // (jsonata-js functions.js: `if(!Array.isArray(arr) || arr.length <= 1) return arr;`)
+            Some(other) => Ok(other.clone()),
         },
 
         // ── Object functions ────────────────────────────────────────────
@@ -4268,7 +4272,8 @@ impl Evaluator {
         };
 
         // Process remaining steps
-        for step in steps[1..].iter() {
+        for (step_idx, step) in steps[1..].iter().enumerate() {
+            let is_last_step = step_idx == steps.len() - 2;
             // Early return if current is null/undefined - no point continuing
             // This handles cases like `blah.{}` where blah doesn't exist
             if current.is_null() {
@@ -4843,7 +4848,17 @@ impl Evaluator {
                                 // Each array element gets its own sub-array with all values
                                 result.push(JValue::array(group_values));
                             }
-                            JValue::array(result)
+                            // jsonata-js's evaluateStep: when this is the path's last
+                            // step and mapping produced exactly one constructed
+                            // sub-array, that sub-array IS the path result directly
+                            // (not wrapped in an outer singleton array) — e.g.
+                            // `$.[value,epochSeconds]` over a 1-element array yields
+                            // `[3, 1578381600]`, not `[[3, 1578381600]]`.
+                            if is_last_step && result.len() == 1 {
+                                result.into_iter().next().unwrap()
+                            } else {
+                                JValue::array(result)
+                            }
                         }
                         _ => {
                             // For non-arrays, just evaluate the array constructor normally
@@ -7642,10 +7657,11 @@ impl Evaluator {
                     ));
                 }
                 match &evaluated_args[0] {
-                    JValue::Array(arr) => Ok(functions::array::distinct(arr)?),
-                    _ => Err(EvaluatorError::TypeError(
-                        "distinct() requires an array argument".to_string(),
-                    )),
+                    JValue::Array(arr) if arr.len() > 1 => Ok(functions::array::distinct(arr)?),
+                    // Non-array input, and arrays of length <= 1, pass through
+                    // unchanged (jsonata-js functions.js:
+                    // `if(!Array.isArray(arr) || arr.length <= 1) return arr;`)
+                    other => Ok(other.clone()),
                 }
             }
             "exists" => {

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -2,12 +2,12 @@
 Test adapter for the JSONata reference test suite.
 
 This module loads and runs all 1682 test cases from the reference JavaScript JSONata
-implementation. 1678 currently pass; the remaining 4 are marked xfail pending fixes
-tracked by phase in docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md.
-Those 4 are Phase 5's untriaged stragglers (array-constructor, function-distinct,
-flattening). The full parent-operator and joins groups (the %/@/# parent-reference,
-focus-binding, and index-binding operators) now pass; see
-docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md.
+implementation. All 1682 pass. See
+docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md and
+docs/superpowers/specs/2026-07-06-parent-and-focus-binding-operators-design.md for the
+history of how the gap (widened test discovery, datetime picture-strings,
+formatInteger/parseInteger, the %/@/# parent-reference/focus-binding/index-binding
+operators, and the array-constructor/distinct stragglers) was closed.
 """
 
 import json
@@ -88,42 +88,13 @@ def extract_error_code(error_msg: str) -> str | None:
     return match.group(1) if match else None
 
 
-# Coverage gap remediation tracking (see
-# docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md).
-#
-# load_test_cases() used to only glob "case*.json", silently skipping 20 files / 408
-# cases under other naming conventions. Phase 0 widened the glob to pick up all of
-# them; of the 408, 325 fail against the current implementation for reasons owned by
-# later phases of that spec. Each entry below is xfailed with a pointer to the phase
-# that will fix it, so the suite stays green while the gap is tracked explicitly
-# instead of silently hidden again.
-_XFAIL_PHASE_BY_GROUP = {
-    "array-constructor": "Phase 5: untriaged straggler",
-    "function-distinct": "Phase 5: untriaged straggler",
-    "flattening": "Phase 5: untriaged straggler",
-}
-
-_XFAIL_TEST_IDS = {
-    "array-constructor/array-sequences[2]",
-    "array-constructor/array-sequences[4]",
-    "flattening/sequence-of-arrays[1]",
-    "function-distinct/distinct[4]",
-}
-
-
 def _build_pytest_params(
     cases: list[tuple[str, str, dict[str, Any]]],
 ) -> list["pytest.mark.structures.ParameterSet"]:
-    params = []
-    for test_id, group_name, spec in cases:
-        marks = []
-        if test_id in _XFAIL_TEST_IDS:
-            reason = _XFAIL_PHASE_BY_GROUP.get(
-                group_name, "unresolved reference-suite coverage gap"
-            )
-            marks.append(pytest.mark.xfail(reason=reason, strict=False))
-        params.append(pytest.param(test_id, group_name, spec, marks=marks, id=test_id))
-    return params
+    return [
+        pytest.param(test_id, group_name, spec, id=test_id)
+        for test_id, group_name, spec in cases
+    ]
 
 
 # Load all test cases
@@ -134,7 +105,7 @@ print(f"\n{'=' * 70}")
 print("JSONata Reference Suite Test Loader")
 print(f"{'=' * 70}")
 print(f"Loaded {len(DATASETS)} datasets from {DATASET_DIR}")
-print(f"Loaded {len(test_cases)} test cases ({len(_XFAIL_TEST_IDS)} xfailed pending later phases)")
+print(f"Loaded {len(test_cases)} test cases")
 print(f"{'=' * 70}\n")
 
 

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -92,8 +92,7 @@ def _build_pytest_params(
     cases: list[tuple[str, str, dict[str, Any]]],
 ) -> list["pytest.mark.structures.ParameterSet"]:
     return [
-        pytest.param(test_id, group_name, spec, id=test_id)
-        for test_id, group_name, spec in cases
+        pytest.param(test_id, group_name, spec, id=test_id) for test_id, group_name, spec in cases
     ]
 
 


### PR DESCRIPTION
## Summary

Closes the final 4 xfails from the reference-suite coverage gap effort (`docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md`), bringing the suite to **1682/1682 passing**.

Three distinct root causes, all diagnosed against real jsonata-js behavior before fixing:

1. **Array-constructor last-step unwrap** (`array-constructor/array-sequences[2]`, `flattening/sequence-of-arrays[1]`): jsonata-js's `evaluateStep` has a special case — when an array-constructor step (`.[a,b]`) is the path's *last* step and maps over exactly *one* input item, the constructed sub-array becomes the whole path result directly, rather than being wrapped in an extra outer array. `src/evaluator.rs`'s `ArrayGroup` handling didn't implement this, producing `[[3, 1578381600]]` instead of `[3, 1578381600]`.

2. **Compiled-path keep-array bug** (`array-constructor/array-sequences[4]`): the VM/compiled fast path (`try_compile_path`) folded the explicit `[]` keep-array marker (`Predicate(Boolean(true))`) into an ordinary boolean filter, silently discarding the keep-singleton semantics the tree-walker already handled correctly in `evaluate_predicate`. Now bails to the tree-walker for that marker, mirroring the existing numeric-predicate (`[0]`) bailout.

3. **`$distinct()` non-array passthrough** (`function-distinct/distinct[4]`): threw `"distinct() requires an array argument"` instead of jsonata-js's actual behavior (`functions.js`: `if(!Array.isArray(arr) || arr.length <= 1) return arr;`) of returning non-array (and length<=1 array) input unchanged.

## Test plan

- [x] `uv run pytest tests/python/test_reference_suite.py` — 1682/1682 passing (was 1678 passed + 4 xfailed)
- [x] `cargo test --release` — 213 tests passing across all 4 test binaries
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Manually verified all fixes against live `node` execution of jsonata-js (reference implementation) before and after
- [x] Verified the dot-attached keep-array form (`a.b[]`, not just standalone `field[]`) against jsonata-js too, since fix #2 touches both encodings
- [x] Removed the now-empty xfail-tracking machinery from `test_reference_suite.py`; updated README/docs pass-count claims to 1682/1682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf67vyo9v6Rta9VG3K6Zvx