### PR TITLE
fix(benchmarks): await jsonata-js calls; substantiate pre-converted-data speedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/benchmarks/javascript/benchmark.js
+++ b/benchmarks/javascript/benchmark.js
@@ -21,7 +21,7 @@ process.stdin.on('data', (chunk) => {
     inputData += chunk;
 });
 
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
     try {
         const params = JSON.parse(inputData);
         const { expression, data, iterations } = params;
@@ -32,13 +32,18 @@ process.stdin.on('end', () => {
         // Warm up (10% of iterations, min 10, max 100)
         const warmupIterations = Math.min(100, Math.max(10, Math.floor(iterations / 10)));
         for (let i = 0; i < warmupIterations; i++) {
-            compiled.evaluate(data);
+            await compiled.evaluate(data);
         }
 
         // Measure
+        // NOTE: evaluate() is async (jsonata-js recurses via real `await` internally,
+        // including once per array element) — it MUST be awaited here, or the loop
+        // only runs each call up to its first internal suspension point and defers
+        // the rest of the real work to microtasks that drain after `end` is captured,
+        // making the measured time meaningless for anything but trivial expressions.
         const start = process.hrtime.bigint();
         for (let i = 0; i < iterations; i++) {
-            compiled.evaluate(data);
+            await compiled.evaluate(data);
         }
         const end = process.hrtime.bigint();
 

--- a/benchmarks/python/benchmark.py
+++ b/benchmarks/python/benchmark.py
@@ -939,7 +939,9 @@ def _run_path_comparison(ecommerce_data: dict, suite: BenchmarkSuite):
         json_speedup = (js_per_iter / (t4 / iterations)) if js_per_iter else None
         if js_per_iter:
             js_equiv_ms = js_per_iter * iterations
-            print(f"  JavaScript (equivalent):    {js_equiv_ms:8.2f} ms ({js_per_iter:.4f} ms/iter)")
+            print(
+                f"  JavaScript (equivalent):    {js_equiv_ms:8.2f} ms ({js_per_iter:.4f} ms/iter)"
+            )
             print(f"    → evaluate_with_data is {handle_speedup:6.2f}x vs JS")
             print(f"    → evaluate_data_to_json is {json_speedup:6.2f}x vs JS")
 

--- a/benchmarks/python/benchmark.py
+++ b/benchmarks/python/benchmark.py
@@ -874,6 +874,17 @@ def _run_path_comparison(ecommerce_data: dict, suite: BenchmarkSuite):
     data_handle = jsonatapy.JsonataData(ecommerce_data)
     data_handle_json = jsonatapy.JsonataData.from_json(json_str)
 
+    # Reuse the JS timing already measured for the identical expression in the
+    # "Realistic Workload" category (same expression text, same 100-product
+    # data) so the pre-converted-data paths get a real "vs JS" speedup instead
+    # of leaving it unsubstantiated. Iteration counts differ between the two
+    # categories, so compare per-iteration rates, not raw totals.
+    js_ms_per_iter_by_expr = {
+        r.expression: r.js_ms / r.iterations
+        for r in suite.results
+        if r.category == "Realistic Workload" and r.js_ms
+    }
+
     for name, expression in expressions:
         compiled = jsonatapy.compile(expression)
 
@@ -923,6 +934,15 @@ def _run_path_comparison(ecommerce_data: dict, suite: BenchmarkSuite):
             f"  evaluate_data_to_json():    {t4:8.2f} ms ({t4 / iterations:.4f} ms/iter)  [{t1 / t4:.1f}x vs dict]"
         )
 
+        js_per_iter = js_ms_per_iter_by_expr.get(expression)
+        handle_speedup = (js_per_iter / (t3 / iterations)) if js_per_iter else None
+        json_speedup = (js_per_iter / (t4 / iterations)) if js_per_iter else None
+        if js_per_iter:
+            js_equiv_ms = js_per_iter * iterations
+            print(f"  JavaScript (equivalent):    {js_equiv_ms:8.2f} ms ({js_per_iter:.4f} ms/iter)")
+            print(f"    → evaluate_with_data is {handle_speedup:6.2f}x vs JS")
+            print(f"    → evaluate_data_to_json is {json_speedup:6.2f}x vs JS")
+
         # Record as benchmark results for the summary
         suite.results.append(
             BenchmarkResult(
@@ -932,6 +952,8 @@ def _run_path_comparison(ecommerce_data: dict, suite: BenchmarkSuite):
                 data_size="100 products",
                 iterations=iterations,
                 jsonatapy_ms=t3,
+                js_ms=(js_per_iter * iterations) if js_per_iter else None,
+                jsonatapy_speedup=handle_speedup,
             )
         )
         suite.results.append(
@@ -942,6 +964,8 @@ def _run_path_comparison(ecommerce_data: dict, suite: BenchmarkSuite):
                 data_size="100 products",
                 iterations=iterations,
                 jsonatapy_ms=t4,
+                js_ms=(js_per_iter * iterations) if js_per_iter else None,
+                jsonatapy_speedup=json_speedup,
             )
         )
 


### PR DESCRIPTION
## Summary

- `benchmarks/javascript/benchmark.js`'s timed loop called jsonata-js's `evaluate()` (which is `async`, with a real `await` per recursion step) without awaiting it, so JS measurements only captured the synchronous prefix of each call. This made JS look implausibly fast on anything iterating arrays, and is the root cause of the published perf-claims mismatch across README.md / docs/performance.md / the live CI benchmark comment.
- `benchmarks/python/benchmark.py`'s Path Comparison section now computes a real "vs JS" speedup for the pre-converted-data paths (`evaluate_with_data`/`evaluate_data_to_json`) instead of leaving it unsubstantiated, by reusing the JS timing already measured for the identical expression in the Realistic Workload category.

Draft PR opened to get CI's "Performance Benchmarks" job to run against this fix so I can gauge run-to-run variance before updating the published numbers in README.md/docs/performance.md/benchmarks/README.md/docs/index.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf67vyo9v6Rta9VG3K6Zvx