### PR TITLE
fix(release): temporarily drop macOS from release matrix (#45)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,8 +175,15 @@ jobs:
           - { os: 'Linux', runner: ubuntu-latest, target: aarch64-unknown-linux-gnu }
           # Windows
           - { os: 'Windows', runner: windows-latest, target: x86_64-pc-windows-msvc }
-          # macOS (self-hosted Mac Mini, native ARM64 build)
-          - { os: 'macOS', runner: [self-hosted, macOS, ARM64], target: aarch64-apple-darwin }
+          # macOS temporarily removed from the main release matrix: the
+          # self-hosted Mac Mini runner's Test-wheels step has been failing
+          # deterministically (not flaky) with a stale-environment symptom
+          # despite the built wheel itself verified correct -- see issue #45.
+          # Once fixed, add macOS back here. Until then, ship Linux/Windows
+          # from this workflow and backfill macOS separately with
+          # release-macos-backfill.yml (`gh workflow run
+          # release-macos-backfill.yml -f version=X.Y.Z` after this release
+          # publishes).
 
     steps:
       - name: Checkout
@@ -290,7 +297,7 @@ jobs:
         platform:
           - { os: 'ubuntu-latest', runner: ubuntu-latest }
           - { os: 'windows-latest', runner: windows-latest }
-          - { os: 'macOS', runner: [self-hosted, macOS, ARM64] }
+          # macOS removed -- see the matching comment in build-wheels above (issue #45).
         python: ['3.10', '3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
## Summary

- The self-hosted Mac Mini's "Test wheels" step has failed 3/3 identically on the 2.1.6 release (workflow run [28827118144](https://github.com/txjmb/jsonata-core/actions/runs/28827118144)) with a stale-environment symptom -- `strings` on the actual compiled `.so` from that run's own wheel artifact confirms the `%`/`@`-operator fix (`S0214`, `Expected a variable reference after @`) genuinely is present, so this is not a code bug. It's also not flaky: fully reproducible, 3 for 3.
- Root cause tracked in #45 (suspected concurrent-job race on the shared self-hosted runner's `_work` directory across the 4 Python-version matrix entries) -- needs hands-on access to the runner to resolve properly.
- This removes macOS from `release.yml`'s build-wheels/test-wheels matrix so 2.1.6 can ship with Linux/Windows wheels now. `release-macos-backfill.yml` already exists for exactly this scenario (building + publishing a macOS wheel for an *already-released* version separately) and will be used once #45 is fixed.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed no other hardcoded macOS references remain in the matrix-dependent steps (`grep macOS release.yml`)
- [ ] After merge: trigger a fresh `release.yml` run for 2.1.6 and confirm Linux/Windows wheels build, test, and publish successfully without macOS blocking it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf67vyo9v6Rta9VG3K6Zvx