### PR TITLE
fix(benchmarks): use jsonata-python's Context for fair repeated-eval timing; bump to Python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -624,7 +624,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -127,21 +127,22 @@ cargo bench --no-default-features --features simd
 `jsonatapy` is the fastest Python JSONata implementation by a large margin, and faster than
 the JavaScript reference implementation for most pure expression workloads:
 
-| Category | vs JavaScript (V8) | vs jsonata-python |
-|----------|--------------------|-------------------|
-| Simple paths | **2.6–9.7x faster** | ~10,000–50,000x faster |
-| Complex transformations | **6.7–17.6x faster** | ~11,000–59,000x faster |
-| String operations | **10.5–17.0x faster** | ~23,000–50,000x faster |
-| Higher-order functions | **13.0–18.7x faster** | ~2,900–4,000x faster |
-| Deep nesting | 3.6x faster – 1.6x slower | ~1,300–8,100x faster |
-| Array operations | **1.5–7.0x faster**, mapping ~2–2.4x slower | ~180–10,500x faster |
-| Realistic workloads (raw dict) | Mixed: 2.0x slower – 2.4x faster | ~170–380x faster |
+| Category | vs JavaScript (V8) |
+|----------|--------------------|
+| Simple paths | **2.6–9.7x faster** |
+| Complex transformations | **6.7–17.6x faster** |
+| String operations | **10.5–17.0x faster** |
+| Higher-order functions | **13.0–18.7x faster** |
+| Deep nesting | 3.6x faster – 1.6x slower |
+| Array operations | **1.5–7.0x faster**, mapping ~2–2.4x slower |
+| Realistic workloads (raw dict) | Mixed: 2.0x slower – 2.4x faster |
 
-`jsonata-python` (the `jsonata` PyPI package) wraps the real `jsonata.js` library in an embedded
-Duktape engine and offers no pre-compilation API; the consistent ~12–18ms floor per call
-regardless of expression complexity suggests it effectively re-parses and recompiles the
-library from scratch on every call, with no caching between calls — which would explain the
-multiple-orders-of-magnitude gap.
+`jsonatapy` is also dramatically faster than `jsonata-python` (the `jsonata` PyPI package) across
+every category — by multiple orders of magnitude for one-off calls via its `transform()`
+convenience function, since that re-bootstraps an embedded Duktape JS engine (and re-loads the
+`jsonata.js` library into it) on every call with no caching. Reusing its documented `Context`
+object instead substantially narrows the gap, though jsonatapy still wins clearly. See
+[Performance docs](docs/performance.md) for measured numbers.
 
 ### The Python boundary
 

--- a/benchmarks/python/benchmark.py
+++ b/benchmarks/python/benchmark.py
@@ -247,19 +247,31 @@ class BenchmarkSuite:
     def _run_jsonata_python_benchmark(self, expression: str, data: Any, iterations: int) -> float:
         """Run benchmark using jsonata-python (rayokota) implementation.
 
-        jsonata-python doesn't support pre-compilation - jsonata.transform()
-        parses and evaluates in one call each time, so this includes parsing
-        overhead on every iteration (unlike jsonatapy's compile-once,
-        evaluate-many path).
+        jsonata-python doesn't support pre-compiling an *expression*, but its
+        `Context` class explicitly documents itself as a "reusable JSONata
+        context for more efficient repeated transforms" - reusing one avoids
+        re-bootstrapping the underlying Duktape engine (and re-loading the
+        jsonata.js library into it) on every call, which the module-level
+        `transform()` convenience function does each time. Measured locally:
+        reusing a Context is ~50x faster than transform() for a trivial path
+        expression, and still ~1.6x faster even for a 100-element array
+        filter (where JSON-string marshalling dominates instead). Using
+        Context here matches every other implementation in this suite, which
+        all compile/warm once and evaluate many times in the timed loop.
         """
         if not JSONATA_PYTHON_AVAILABLE:
             return -1.0
+
+        if hasattr(jsonata_python, "Context"):
+            call = jsonata_python.Context()
+        else:
+            call = jsonata_python.transform
 
         # Warm up
         warmup_iters = min(100, max(10, iterations // 10))
         for _ in range(warmup_iters):
             try:
-                jsonata_python.transform(expression, data)
+                call(expression, data)
             except Exception as e:
                 print(f"⚠ jsonata-python warmup failed: {e}")
                 return -1.0
@@ -268,7 +280,7 @@ class BenchmarkSuite:
         start = time.perf_counter()
         for _ in range(iterations):
             try:
-                jsonata_python.transform(expression, data)
+                call(expression, data)
             except Exception as e:
                 print(f"⚠ jsonata-python evaluation failed: {e}")
                 return -1.0

--- a/benchmarks/update_docs.py
+++ b/benchmarks/update_docs.py
@@ -166,6 +166,18 @@ def generate_markdown(data, versions):
         )
     md.append("")
 
+    if implementations.get("jsonata_python"):
+        md.append(
+            "> **Note on jsonata-python:** the `jsonata-python` column below reflects its "
+            "`Context`-reused call path, not its one-off `transform()` convenience function. "
+            "`transform()` re-bootstraps an embedded Duktape engine (and reloads the "
+            "`jsonata.js` library into it) on every call, which is dramatically slower and not "
+            "representative of how a real caller would use it repeatedly; reusing a `Context` "
+            "is the library's own documented path for repeated evaluation and is the fair "
+            "comparison to jsonatapy's and jsonata-js's own compile-once-evaluate-many "
+            "measurement.\n"
+        )
+
     md.append(f"Benchmarks run on {date}.\n")
 
     # Summary table

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,8 +57,9 @@ let result = Evaluator::new().evaluate(&ast, &data)?;
 - **1682/1682** JSONata reference tests passing
 - **up to 19x faster** than the JavaScript reference implementation for pure expression workloads
 - **~40x faster** than jsonata-rs on pure-Rust Criterion benchmarks (no Python overhead)
-- **thousands of times faster** than jsonata-python across all categories — it re-parses and
-  bytecode-compiles the entire `jsonata.js` library from scratch on every call
+- **dramatically faster** than jsonata-python across all categories — its one-off `transform()`
+  call re-bootstraps an embedded Duktape engine every time; reusing its `Context` object narrows
+  the gap substantially but jsonatapy still wins clearly
 
 See [Performance](performance.md) for full benchmark results.
 


### PR DESCRIPTION
## Summary
- The jsonata-python (rayokota) benchmark used `transform()`, a one-off convenience function that re-bootstraps the embedded Duktape engine (reloading `jsonata.js`) on every call. Every other implementation in this suite is measured compile/warm-once, evaluate-many; jsonata-python was being measured worst-case-every-time instead.
- The package documents `Context` as a "reusable JSONata context for more efficient repeated transforms" for exactly this. Switching to it (with a fallback to `transform()` for older package versions) measured **~50x faster** for a trivial path expression, and **~1.6x faster** even for a 100-element array filter, locally.
- This doesn't touch jsonatapy's own numbers, but it means the jsonata-python figures published in docs after PR #49 (`~10,000-50,000x slower`) reflect the unfair path, not jsonata-python's real best case. Softened the affected prose in `README.md`/`docs/index.md` to be qualitative rather than hand-editing precise numbers from noisy local timings — see the decision needed below.
- Bumped the release benchmark job's Python version from 3.11 to 3.14 (latest stable) — confirmed locally that `jsonata`'s sdist builds successfully from source there (its last prebuilt wheel is cp311).

## Decision needed before docs show precise numbers
Getting the real corrected numbers into the docs requires another clean release-benchmark CI run — this would be the **third** time touching the `v2.1.6` tag. Two options:
- **(a)** Force-move `v2.1.6` again and re-run the benchmark job now.
- **(b)** Wait for the next real version bump (2.1.7) — this is genuinely clean, since the "skip tag creation if it already exists" issue only bites on same-version re-releases, not a new tag.

Not doing either in this PR; the code fix and softened prose stand on their own regardless of which path is chosen.

## Test plan
- [x] Verified `jsonata.Context()` produces identical results to `transform()` for several expressions
- [x] `ruff check` / `ruff format --check` pass
- [x] Verified `jsonata` 0.2.5 builds from sdist successfully on a local Python 3.14 venv and functions correctly (including `Context`)
- [x] YAML validated after the `release.yml` python-version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf67vyo9v6Rta9VG3K6Zvx