### PR TITLE
fix(release): fail loudly on a fresh dispatch when v$VERSION already exists at a different commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,38 @@ jobs:
             git push origin HEAD:${{ github.ref_name }}
           fi
 
-          # Create tag only if it doesn't already exist
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
-            echo "Tag v$VERSION already exists, skipping"
-          else
+          # Create the tag if it doesn't exist yet. If it already exists, verify it points at
+          # the commit this run is actually releasing before treating that as a no-op --
+          # silently reusing a tag that predates this run's commit is exactly how three
+          # separate release-benchmark runs ended up measuring stale code in the past: the
+          # workflow's job graph and matrix come from whatever ref triggered this dispatch, but
+          # every build/test/benchmark job checks out `refs/tags/v$VERSION` explicitly, so a
+          # stale tag silently overrides the intent of the dispatch.
+          CURRENT_SHA=$(git rev-parse HEAD)
+          REMOTE_REFS=$(git ls-remote origin "refs/tags/v$VERSION" "refs/tags/v$VERSION^{}" || true)
+
+          if [ -z "$REMOTE_REFS" ]; then
+            echo "Tag v$VERSION does not exist yet on origin - creating it"
             git tag -a "v$VERSION" -m "Release v$VERSION"
             git push origin "v$VERSION"
+          else
+            # Prefer the peeled (^{}) line for annotated tags -- it's the actual commit the tag
+            # points at, not the tag object's own SHA.
+            REMOTE_TAG_SHA=$(echo "$REMOTE_REFS" | awk '$2 ~ /\^\{\}$/ {print $1}')
+            if [ -z "$REMOTE_TAG_SHA" ]; then
+              REMOTE_TAG_SHA=$(echo "$REMOTE_REFS" | awk '{print $1}' | head -1)
+            fi
+
+            if [ "$REMOTE_TAG_SHA" = "$CURRENT_SHA" ]; then
+              echo "Tag v$VERSION already exists and already points at the current commit ($CURRENT_SHA) - nothing to do"
+            else
+              echo "::error::Tag v$VERSION already exists but points at $REMOTE_TAG_SHA, not the commit this run is releasing ($CURRENT_SHA)."
+              echo "::error::Building, testing, publishing, or benchmarking would silently use the stale commit instead of $CURRENT_SHA -- this has happened before."
+              echo "::error::If you deliberately want to re-point v$VERSION at $CURRENT_SHA (e.g. re-running a release-time job after merging a fix on the same version), delete and recreate the tag yourself first, then re-dispatch this workflow:"
+              echo "::error::  git tag -d v$VERSION && git push origin :refs/tags/v$VERSION && git tag -a v$VERSION -m 'Release v$VERSION' $CURRENT_SHA && git push origin v$VERSION"
+              echo "::error::Otherwise, use a new version number for this release."
+              exit 1
+            fi
           fi
 
           echo "tag=v$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
`release.yml`'s "Commit version bump" step silently skipped creating the release tag whenever it already existed, with no check on what commit it actually pointed at. Every downstream job (`build-wheels`, `build-sdist`, `test-wheels`, `publish-pypi`, `publish-crates`, the release-benchmark job) checks out `refs/tags/v$VERSION` explicitly, so a stale tag silently overrides the intent of a fresh dispatch. This happened three separate times this session with `v2.1.6`, each requiring a manual `git tag -d` / `git push origin :refs/tags/...` / re-tag / re-push dance to recover.

Now compares the existing tag's target commit (correctly handling the peeled `^{}` form for annotated tags) against the commit the current run is actually releasing:
- Tags match → no-op, same as before.
- No tag exists yet → create it, same as before.
- Tags **don't** match → fail loudly with both commit SHAs and the exact recovery commands, instead of silently building from the wrong ref.

## Scope note
This only changes behavior on a **fresh** `workflow_dispatch`. It does **not** protect `gh run rerun` of an already-completed run — that replays the job graph frozen at the run's original dispatch time and never re-evaluates this step. (Same reason this session's Python 3.14 bump didn't take effect when a benchmark job was rerun instead of freshly dispatched.) All three incidents this fix addresses were fresh dispatches, which is the path this guards.

## Test plan
- [x] YAML validated
- [x] Manually tested the shell logic against the real repo for all three cases: tag exists and matches HEAD (no-op), tag exists and mismatches (fails with correct message), tag doesn't exist (creates it)
- [x] Verified `awk` correctly picks the peeled `^{}` line for annotated tags rather than the tag object's own SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf67vyo9v6Rta9VG3K6Zvx