### PR TITLE
fix(release): tag-reuse guard, benchmark noise fix, and macOS uv cache staleness (#45)

### DIFF
--- a/.github/workflows/release-macos-backfill.yml
+++ b/.github/workflows/release-macos-backfill.yml
@@ -97,7 +97,13 @@ jobs:
       - name: Create venv and install wheel
         run: |
           uv venv --python ${{ matrix.python }} .venv
-          uv pip install --python .venv/bin/python --find-links dist jsonatapy pytest pytest-xdist
+          # --reinstall (implies --refresh): this runner's uv cache persists
+          # across jobs and is keyed by filename only for --find-links
+          # sources, so without this flag a wheel rebuilt under the same
+          # version/interpreter/platform can silently lose to a stale cache
+          # entry from an earlier run -- see the matching comment in
+          # release.yml (issue #45).
+          uv pip install --python .venv/bin/python --reinstall --find-links dist jsonatapy pytest pytest-xdist
           .venv/bin/python -c "import jsonatapy; print(f'jsonatapy {jsonatapy.__version__} installed successfully')"
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,38 @@ jobs:
             git push origin HEAD:${{ github.ref_name }}
           fi
 
-          # Create tag only if it doesn't already exist
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q "v$VERSION"; then
-            echo "Tag v$VERSION already exists, skipping"
-          else
+          # Create the tag if it doesn't exist yet. If it already exists, verify it points at
+          # the commit this run is actually releasing before treating that as a no-op --
+          # silently reusing a tag that predates this run's commit is exactly how three
+          # separate release-benchmark runs ended up measuring stale code in the past: the
+          # workflow's job graph and matrix come from whatever ref triggered this dispatch, but
+          # every build/test/benchmark job checks out `refs/tags/v$VERSION` explicitly, so a
+          # stale tag silently overrides the intent of the dispatch.
+          CURRENT_SHA=$(git rev-parse HEAD)
+          REMOTE_REFS=$(git ls-remote origin "refs/tags/v$VERSION" "refs/tags/v$VERSION^{}" || true)
+
+          if [ -z "$REMOTE_REFS" ]; then
+            echo "Tag v$VERSION does not exist yet on origin - creating it"
             git tag -a "v$VERSION" -m "Release v$VERSION"
             git push origin "v$VERSION"
+          else
+            # Prefer the peeled (^{}) line for annotated tags -- it's the actual commit the tag
+            # points at, not the tag object's own SHA.
+            REMOTE_TAG_SHA=$(echo "$REMOTE_REFS" | awk '$2 ~ /\^\{\}$/ {print $1}')
+            if [ -z "$REMOTE_TAG_SHA" ]; then
+              REMOTE_TAG_SHA=$(echo "$REMOTE_REFS" | awk '{print $1}' | head -1)
+            fi
+
+            if [ "$REMOTE_TAG_SHA" = "$CURRENT_SHA" ]; then
+              echo "Tag v$VERSION already exists and already points at the current commit ($CURRENT_SHA) - nothing to do"
+            else
+              echo "::error::Tag v$VERSION already exists but points at $REMOTE_TAG_SHA, not the commit this run is releasing ($CURRENT_SHA)."
+              echo "::error::Building, testing, publishing, or benchmarking would silently use the stale commit instead of $CURRENT_SHA -- this has happened before."
+              echo "::error::If you deliberately want to re-point v$VERSION at $CURRENT_SHA (e.g. re-running a release-time job after merging a fix on the same version), delete and recreate the tag yourself first, then re-dispatch this workflow:"
+              echo "::error::  git tag -d v$VERSION && git push origin :refs/tags/v$VERSION && git tag -a v$VERSION -m 'Release v$VERSION' $CURRENT_SHA && git push origin v$VERSION"
+              echo "::error::Otherwise, use a new version number for this release."
+              exit 1
+            fi
           fi
 
           echo "tag=v$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,14 +361,31 @@ jobs:
         if: matrix.platform.os != 'macOS'
         shell: bash
         run: |
-          uv pip install --system --find-links dist jsonatapy
+          # --reinstall (implies --refresh) forces uv to re-read this exact
+          # file instead of trusting its cache, which is keyed by filename
+          # only for --find-links sources -- see the macOS comment below,
+          # which is where this actually bit us (issue #45).
+          uv pip install --system --reinstall --find-links dist jsonatapy
           python -c "import jsonatapy; print(f'jsonatapy {jsonatapy.__version__} installed successfully')"
 
       - name: Install wheel (macOS)
         if: matrix.platform.os == 'macOS'
         shell: bash
         run: |
-          uv pip install --find-links dist jsonatapy
+          # --reinstall is required here, not just belt-and-suspenders: uv's
+          # cache for --find-links (flat index) sources is keyed by filename
+          # alone, not content. jsonatapy-<version>-<abi>-<platform>.whl is
+          # the same filename every time this version/interpreter/platform
+          # combo is built. GitHub-hosted Linux/Windows runners get a fresh
+          # uv cache every job so this never bit them, but this self-hosted
+          # Mac Mini's ~/.cache/uv persists across every job (and any local
+          # dev/testing on the same machine) forever. Without --reinstall, a
+          # wheel rebuilt with new code silently loses to a stale
+          # same-version cache entry from an earlier build/dev session --
+          # this is exactly what caused issue #45 (verified: the built wheel
+          # was correct, `uv pip install` resolved and "installed" it in
+          # ~1ms, but the parser behaved like the pre-%/@-operator code).
+          uv pip install --reinstall --find-links dist jsonatapy
           python -c "import jsonatapy; print(f'jsonatapy {jsonatapy.__version__} installed successfully')"
 
       - name: Install test dependencies (Linux/Windows)
@@ -686,7 +703,7 @@ jobs:
       - name: Build jsonatapy (optimized)
         run: |
           maturin build --release --out dist
-          uv pip install --system --find-links dist jsonatapy
+          uv pip install --system --reinstall --find-links dist jsonatapy
 
       - name: Verify installation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -714,7 +714,25 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p benchmarks/baseline
+          VERSION="${{ needs.validate-version.outputs.version }}"
           git fetch origin benchmark-data
+
+          # If results/v$VERSION.json already exists on benchmark-data, this
+          # version was already benchmarked and recorded by an earlier run -
+          # i.e. this run is a `gh run rerun` (or similar retry) of a release
+          # that already completed, not a genuinely new release. latest.json
+          # at this point holds that earlier run's numbers for the SAME
+          # version/commit, so comparing against it would be v$VERSION vs
+          # v$VERSION on a shared runner: pure noise, not a real signal. This
+          # happened 3 times for v2.1.6 in one session and produced two bogus
+          # "regression" issues (txjmb/jsonata-core#48, #51) before this guard
+          # existed.
+          if git show FETCH_HEAD:results/v${VERSION}.json > /dev/null 2>&1; then
+            echo "already_recorded=true" >> $GITHUB_OUTPUT
+            echo "v${VERSION} was already recorded to benchmark-data by an earlier run - skipping comparison to avoid comparing this version against itself"
+          else
+            echo "already_recorded=false" >> $GITHUB_OUTPUT
+          fi
 
           if git show FETCH_HEAD:results/latest.json > benchmarks/baseline/baseline.json.tmp; then
             mv benchmarks/baseline/baseline.json.tmp benchmarks/baseline/baseline.json
@@ -728,7 +746,7 @@ jobs:
 
       - name: Compare with previous release
         id: compare
-        if: steps.baseline.outputs.has_baseline == 'true'
+        if: steps.baseline.outputs.has_baseline == 'true' && steps.baseline.outputs.already_recorded != 'true'
         run: |
           cd benchmarks
           python python/compare.py baseline/baseline.json "${{ steps.run_benchmark.outputs.results_file }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,15 +201,8 @@ jobs:
           - { os: 'Linux', runner: ubuntu-latest, target: aarch64-unknown-linux-gnu }
           # Windows
           - { os: 'Windows', runner: windows-latest, target: x86_64-pc-windows-msvc }
-          # macOS temporarily removed from the main release matrix: the
-          # self-hosted Mac Mini runner's Test-wheels step has been failing
-          # deterministically (not flaky) with a stale-environment symptom
-          # despite the built wheel itself verified correct -- see issue #45.
-          # Once fixed, add macOS back here. Until then, ship Linux/Windows
-          # from this workflow and backfill macOS separately with
-          # release-macos-backfill.yml (`gh workflow run
-          # release-macos-backfill.yml -f version=X.Y.Z` after this release
-          # publishes).
+          # macOS (self-hosted Mac Mini, native ARM64 build)
+          - { os: 'macOS', runner: [self-hosted, macOS, ARM64], target: aarch64-apple-darwin }
 
     steps:
       - name: Checkout
@@ -323,7 +316,7 @@ jobs:
         platform:
           - { os: 'ubuntu-latest', runner: ubuntu-latest }
           - { os: 'windows-latest', runner: windows-latest }
-          # macOS removed -- see the matching comment in build-wheels above (issue #45).
+          - { os: 'macOS', runner: [self-hosted, macOS, ARM64] }
         python: ['3.10', '3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
## Summary

Four related release-pipeline hardening fixes, all discovered while investigating repeated 2.1.6 release-dispatch issues:

- **Tag-reuse guard**: fail loudly on a fresh `workflow_dispatch` if `v$VERSION` already exists at a different commit, instead of silently reusing the stale tag (this is what let 2.1.6 get released 3 times against different commits in one session).
- **Benchmark noise fix**: skip the regression-comparison step when results for that version were already recorded on `benchmark-data`, instead of diffing a version's benchmarks against themselves and reporting CI-runner jitter as 10-60% regressions (txjmb/jsonata-core#48, #51 — both false positives).
- **macOS `uv` cache staleness (closes #45)**: root-caused and fixed why the self-hosted Mac Mini's `test-wheels` jobs were failing with pre-`%`/`@`-operator parser behavior despite a verified-correct built wheel. `uv`'s `--find-links` cache keys by **filename only, not content** — this runner's `~/.cache/uv` persists across every CI job (unlike GitHub-hosted runners' throwaway cache), so a stale same-named `jsonatapy` wheel from an earlier build/dev session was silently served instead of the freshly built one. Fixed with `--reinstall` (implies `--refresh`) on every step that installs a just-built wheel from `dist/`.
- **Re-enable macOS** in the main `release.yml` matrix now that the fix above is verified — see test plan.

## Test plan

- [x] Dispatched `release-macos-backfill.yml -f version=2.1.6` against this branch as a live end-to-end test of the `--reinstall` fix: build, all 4 `test-macos-wheel` Python legs (3.10-3.13), and the PyPI/GitHub-release publish step all succeeded (run [28880675664](https://github.com/txjmb/jsonata-core/actions/runs/28880675664)).
- [x] Confirmed independently via `pypi.org/pypi/jsonatapy/2.1.6/json` and `gh release view v2.1.6` that all 4 macOS wheels are now live on both PyPI and the GitHub release.
- [ ] Next real `release.yml` dispatch will exercise the restored macOS matrix entries end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6DcXWcQsw2oQfZEw5fYDm