### PR TITLE
jsonata-js 2.2.1 Phase 2: resource guardrails (timeout/stack/sequence)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md
+++ b/docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md
@@ -1,0 +1,2713 @@
+# jsonata-js 2.2.1 Phase 2: Guardrails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port jsonata-js 2.2.1's resource-guardrails feature (`timeout`, `stack`, `sequence` options → errors D1012, D1011, D2015) to `jsonata-core` (Rust) and `jsonatapy` (Python), with parity across all three execution surfaces this port has grown since jsonata-js's single-engine model: the tree-walker, the bytecode VM, and the "compiled expression" fast-path interpreter used by HOF/lambda calls.
+
+**Architecture:** A new `EvaluatorOptions { timeout_ms, max_stack_depth, max_sequence_length: Option<_> }` struct threads through all three execution surfaces. Stack depth extends the existing `recursion_depth` mechanism in `evaluate_internal` (never replacing the hardcoded native-stack safety net). Timeout piggybacks on that same per-node checkpoint, plus per-iteration checks in the loop-based HOF paths (map/filter, VM's `FilterByBytecode`) since those bypass the checkpoint entirely on the compiled path. Sequence length gets a single `check_sequence_length()` helper called at every site a *query-result* sequence is constructed (map/filter/wildcard/descendants/keys/lookup/append/spread/each/range/path-mapping) — verified against literal `createSequence()` call sites in the vendored jsonata-js source, not just the design spec's summary of them (which had two inaccuracies, corrected below).
+
+**Tech Stack:** Rust (`jsonata-core`), PyO3 (`jsonatapy`), pytest.
+
+## Global Constraints
+
+- All `EvaluatorOptions` fields are `Option<_>`, default `None` = unlimited/current behavior. No behavior change for any caller that doesn't pass options.
+- `Evaluator::new()` and `Evaluator::with_context()` keep their exact current signatures — existing Rust callers (tests, benches, examples) must not need changes.
+- The hardcoded native-stack safety net (`max_recursion_depth = 302`, U1001) is an always-on backstop regardless of user options (GitHub issue #34) — never relaxed by a user-supplied `max_stack_depth` higher than 302.
+- D2015 applies only to *query-result* sequences, never to literal array construction (`[1,2,3]`) — this exclusion is load-bearing; verify it holds at every site.
+- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` must stay clean throughout. `uv run pytest tests/python/test_reference_suite.py` must stay at 1682/1682 (no reference-suite case exercises guardrails, so this is a pure regression check).
+- Error message format matches existing convention: the code is embedded in the `EvaluatorError::EvaluationError(String)` payload as `"CODE: message"` — there is no structured error-code field to add (see Task 1 note).
+
+## Corrections to the design spec (verified against `tests/jsonata-js/src/*.js`, v2.2.1)
+
+The design spec's Phase 2 section lists the D2015-guarded constructs as "map/filter/group/wildcard/descendants/append/spread/keys/each/sift/range". Grepping every `createSequence(` call site in the vendored `tests/jsonata-js/src/{jsonata,functions}.js` and reading each enclosing function shows two corrections:
+
+1. **`$sift` is NOT guarded upstream.** `sift()` in `functions.js` returns a plain filtered object (like group-by) — no `createSequence()` call. It's excluded from D2015 below, despite being named in the spec.
+2. **`$lookup` IS guarded upstream** (`functions.js`'s `lookup()`, array-fanout branch: `result = this.createSequence()`), but wasn't named in the spec's list. It's included below.
+3. **Group-by (`ObjectTransform`) is NOT guarded.** `evaluateGroupExpression`'s one `createSequence()` call wraps its *input* (defensive normalization, unreachable in practice since it only fires when wrapping a single non-array item — `sequence.push(item)` never exceeds any positive cap), not its object-shaped *output*. Excluded.
+4. **`$match` (regex) IS guarded upstream** but isn't in the spec's list or in scope per the user's task description. Left out — flagged here as a known, deliberate gap for a future patch, not implemented in this plan.
+
+Everything else in the spec's list is confirmed correct against the source.
+
+---
+
+## Task 1: `EvaluatorOptions` struct and `Evaluator` plumbing
+
+**Files:**
+- Modify: `src/evaluator.rs:9` (imports), `src/evaluator.rs:2543-2595` (struct + constructors)
+- Test: `tests/integration_test.rs` (new tests appended near `test_deep_recursion_does_not_overflow_native_stack`, line ~551)
+
+**Interfaces:**
+- Produces: `pub struct EvaluatorOptions { pub timeout_ms: Option<u64>, pub max_stack_depth: Option<usize>, pub max_sequence_length: Option<usize> }` (derives `Default, Clone, Debug`), `Evaluator::with_options(context: Context, options: EvaluatorOptions) -> Self`, new private fields `Evaluator.options: EvaluatorOptions` and `Evaluator.start_time: Option<std::time::Instant>`.
+
+- [ ] **Step 1: Add the `use` import**
+
+In `src/evaluator.rs`, the imports block currently reads (line 9-16):
+```rust
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+```
+Add a new line directly after `use std::cmp::Ordering;`:
+```rust
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+```
+
+- [ ] **Step 2: Add the `EvaluatorOptions` struct**
+
+Immediately before `pub struct Evaluator {` (currently line 2543), insert:
+```rust
+/// Resource-limit guardrails, mirroring jsonata-js 2.2.1's `timeout`/`stack`/`sequence`
+/// evaluator options. All fields default to `None` = unlimited (current behavior).
+#[derive(Default, Clone, Debug)]
+pub struct EvaluatorOptions {
+    /// Maximum wall-clock evaluation time in milliseconds. Exceeding it raises D1012.
+    pub timeout_ms: Option<u64>,
+    /// Maximum AST-recursion stack depth. Exceeding it raises D1011 if this is the
+    /// tighter of this value and the hardcoded native-stack safety ceiling (302);
+    /// otherwise the hardcoded ceiling still raises U1001 (see GitHub issue #34).
+    pub max_stack_depth: Option<usize>,
+    /// Maximum length of a query-result sequence (map/filter/wildcard/descendants/
+    /// keys/lookup/append/spread/each/range/path-mapping). Exceeding it raises D2015.
+    /// Does NOT apply to literal array construction.
+    pub max_sequence_length: Option<usize>,
+}
+
+/// Checks a constructed query-result sequence's length against the configured
+/// `max_sequence_length` guardrail. Call this ONLY at sites that build a
+/// query-result sequence (map/filter/wildcard/descendants/keys/lookup/append/
+/// spread/each/range/path-mapping) — never at literal array construction
+/// (`[1,2,3]`), matching jsonata-js's `createSequence()` scoping.
+pub(crate) fn check_sequence_length(
+    len: usize,
+    options: &EvaluatorOptions,
+) -> Result<(), EvaluatorError> {
+    if let Some(max) = options.max_sequence_length {
+        if len > max {
+            return Err(EvaluatorError::EvaluationError(format!(
+                "D2015: The maximum sequence length of {} was exceeded.",
+                max
+            )));
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Add fields to `Evaluator` and update both constructors, add `with_options`**
+
+Current (`src/evaluator.rs:2543-2595`):
+```rust
+pub struct Evaluator {
+    context: Context,
+    recursion_depth: usize,
+    max_recursion_depth: usize,
+    next_lambda_id: u64,
+    tuple_stream_created: bool,
+    keep_tuple_stream: bool,
+}
+
+impl Evaluator {
+    pub fn new() -> Self {
+        Evaluator {
+            context: Context::new(),
+            recursion_depth: 0,
+            max_recursion_depth: 302,
+            next_lambda_id: 0,
+            tuple_stream_created: false,
+            keep_tuple_stream: false,
+        }
+    }
+
+    pub fn with_context(context: Context) -> Self {
+        Evaluator {
+            context,
+            recursion_depth: 0,
+            max_recursion_depth: 302,
+            next_lambda_id: 0,
+            tuple_stream_created: false,
+            keep_tuple_stream: false,
+        }
+    }
+```
+Replace with:
+```rust
+pub struct Evaluator {
+    context: Context,
+    recursion_depth: usize,
+    max_recursion_depth: usize,
+    next_lambda_id: u64,
+    tuple_stream_created: bool,
+    keep_tuple_stream: bool,
+    options: EvaluatorOptions,
+    /// Set in `evaluate()` (only when `options.timeout_ms` is configured) and
+    /// checked in `evaluate_internal`'s per-node checkpoint for D1012.
+    start_time: Option<Instant>,
+}
+
+impl Evaluator {
+    pub fn new() -> Self {
+        Evaluator {
+            context: Context::new(),
+            recursion_depth: 0,
+            max_recursion_depth: 302,
+            next_lambda_id: 0,
+            tuple_stream_created: false,
+            keep_tuple_stream: false,
+            options: EvaluatorOptions::default(),
+            start_time: None,
+        }
+    }
+
+    pub fn with_context(context: Context) -> Self {
+        Evaluator {
+            context,
+            recursion_depth: 0,
+            max_recursion_depth: 302,
+            next_lambda_id: 0,
+            tuple_stream_created: false,
+            keep_tuple_stream: false,
+            options: EvaluatorOptions::default(),
+            start_time: None,
+        }
+    }
+
+    /// Construct an `Evaluator` with guardrail options. `Evaluator::new()`/
+    /// `with_context()` remain unchanged (unlimited options) for existing callers.
+    pub fn with_options(context: Context, options: EvaluatorOptions) -> Self {
+        Evaluator {
+            context,
+            recursion_depth: 0,
+            max_recursion_depth: 302,
+            next_lambda_id: 0,
+            tuple_stream_created: false,
+            keep_tuple_stream: false,
+            options,
+            start_time: None,
+        }
+    }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo build --lib 2>&1 | tail -40`
+Expected: clean build (no errors — this task adds fields/constructors but no behavior change, so nothing else should break).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluator.rs
+git commit -m "feat(guardrails): add EvaluatorOptions struct and Evaluator::with_options"
+```
+
+---
+
+## Task 2: D1011 stack-depth guardrail (TDD)
+
+**Files:**
+- Modify: `src/evaluator.rs:2916-2951` (`evaluate_internal`)
+- Test: `tests/integration_test.rs`
+
+**Interfaces:**
+- Consumes: `Evaluator.options.max_stack_depth: Option<usize>` (Task 1), `Evaluator.max_recursion_depth: usize` (existing, always 302).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration_test.rs` (same file/pattern as `test_deep_recursion_does_not_overflow_native_stack` at line 525):
+```rust
+/// A user-configured `max_stack_depth` tighter than the hardcoded native-stack
+/// ceiling (302) must trip D1011, not U1001 — the tree-walker's own guardrail,
+/// not the Rust-specific native-stack safety net.
+#[test]
+fn test_max_stack_depth_raises_d1011_not_u1001() {
+    let data = JValue::Null;
+    let ast = parse("($inf := function($n){$n+$inf($n-1)}; $inf(5))").unwrap();
+    let context = Context::new();
+    let options = evaluator::EvaluatorOptions {
+        max_stack_depth: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(context, options);
+    let result = evaluator.evaluate(&ast, &data);
+    let err = result.expect_err("expected a D1011 stack-overflow error");
+    assert!(
+        err.to_string().contains("D1011"),
+        "expected D1011, got: {err}"
+    );
+}
+
+/// A `max_stack_depth` at or above the hardcoded ceiling changes nothing — the
+/// hardcoded 302 ceiling (and its U1001 error) remains the effective, always-on
+/// backstop (GitHub issue #34).
+#[test]
+fn test_max_stack_depth_above_hardcoded_ceiling_still_raises_u1001() {
+    let handle = std::thread::Builder::new()
+        .stack_size(1024 * 1024)
+        .spawn(|| {
+            let data = JValue::Null;
+            let ast = parse("($inf := function($n){$n+$inf($n-1)}; $inf(5))").unwrap();
+            let options = evaluator::EvaluatorOptions {
+                max_stack_depth: Some(100_000),
+                ..Default::default()
+            };
+            let mut evaluator = Evaluator::with_options(Context::new(), options);
+            match evaluator.evaluate(&ast, &data) {
+                Ok(v) => format!("Ok({v:?})"),
+                Err(e) => format!("Err({e})"),
+            }
+        })
+        .unwrap();
+    let outcome = handle.join().unwrap();
+    assert!(outcome.contains("U1001"), "expected U1001, got: {outcome}");
+}
+```
+Check the top of `tests/integration_test.rs` already imports `evaluator::{Context, Evaluator}` and `parser::parse` (or equivalent) — if `evaluator::EvaluatorOptions` isn't in scope, use the fully-qualified path as shown (`evaluator::EvaluatorOptions`) rather than adding a new `use`, to match how `evaluator::Context`/`Evaluator` are likely already referenced elsewhere in that file (check the existing `use` block at the top of the file and follow its style).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test integration_test test_max_stack_depth -- --nocapture`
+Expected: compile error (`EvaluatorOptions` has no effect yet / `with_options` exists from Task 1 but the depth check doesn't look at `options.max_stack_depth` yet) — first test FAILs with the assertion (`err.to_string()` will contain `U1001`, not `D1011`, since the check doesn't exist yet).
+
+- [ ] **Step 3: Implement the D1011 check**
+
+Current (`src/evaluator.rs:2916-2951`):
+```rust
+    fn evaluate_internal(
+        &mut self,
+        node: &AstNode,
+        data: &JValue,
+    ) -> Result<JValue, EvaluatorError> {
+        // Fast path for leaf nodes — skip recursion tracking overhead
+        if let Some(result) = self.evaluate_leaf(node, data) {
+            return result;
+        }
+
+        // Check recursion depth to prevent stack overflow
+        self.recursion_depth += 1;
+        if self.recursion_depth > self.max_recursion_depth {
+            self.recursion_depth -= 1;
+            return Err(EvaluatorError::EvaluationError(format!(
+                "U1001: Stack overflow - maximum recursion depth ({}) exceeded",
+                self.max_recursion_depth
+            )));
+        }
+
+        const RED_ZONE: usize = 128 * 1024;
+        const GROW_STACK_SIZE: usize = 8 * 1024 * 1024;
+        let result = stacker::maybe_grow(RED_ZONE, GROW_STACK_SIZE, || {
+            self.evaluate_internal_impl(node, data)
+        });
+
+        self.recursion_depth -= 1;
+        result
+    }
+```
+Replace the recursion-depth-check block with:
+```rust
+    fn evaluate_internal(
+        &mut self,
+        node: &AstNode,
+        data: &JValue,
+    ) -> Result<JValue, EvaluatorError> {
+        // Fast path for leaf nodes — skip recursion tracking overhead
+        if let Some(result) = self.evaluate_leaf(node, data) {
+            return result;
+        }
+
+        // Check recursion depth to prevent stack overflow. `effective_limit` is
+        // whichever is tighter: the user's `max_stack_depth` guardrail or the
+        // hardcoded native-stack-safety ceiling (`max_recursion_depth`, always
+        // 302, GitHub issue #34). The hardcoded ceiling is an always-on backstop
+        // regardless of user options — only a user limit BELOW it can produce
+        // D1011; hitting the hardcoded ceiling itself (no option set, or an
+        // option set at/above 302) still produces U1001.
+        self.recursion_depth += 1;
+        let effective_limit = match self.options.max_stack_depth {
+            Some(limit) => limit.min(self.max_recursion_depth),
+            None => self.max_recursion_depth,
+        };
+        if self.recursion_depth > effective_limit {
+            self.recursion_depth -= 1;
+            return Err(EvaluatorError::EvaluationError(
+                if effective_limit < self.max_recursion_depth {
+                    "D1011: Stack overflow. Check for non-terminating recursive function. Consider rewriting as tail-recursive".to_string()
+                } else {
+                    format!(
+                        "U1001: Stack overflow - maximum recursion depth ({}) exceeded",
+                        effective_limit
+                    )
+                },
+            ));
+        }
+
+        const RED_ZONE: usize = 128 * 1024;
+        const GROW_STACK_SIZE: usize = 8 * 1024 * 1024;
+        let result = stacker::maybe_grow(RED_ZONE, GROW_STACK_SIZE, || {
+            self.evaluate_internal_impl(node, data)
+        });
+
+        self.recursion_depth -= 1;
+        result
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test integration_test test_max_stack_depth -- --nocapture`
+Expected: both PASS. Also run `cargo test --test integration_test test_deep_recursion_does_not_overflow_native_stack` to confirm the pre-existing U1001 test is unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluator.rs tests/integration_test.rs
+git commit -m "feat(guardrails): D1011 stack-depth guardrail in evaluate_internal"
+```
+
+---
+
+## Task 3: D1012 timeout guardrail (TDD)
+
+**Files:**
+- Modify: `src/evaluator.rs:2857-2870` (`pub fn evaluate`), `src/evaluator.rs:2916-2951` (`evaluate_internal`, continuing from Task 2)
+- Test: `tests/integration_test.rs`
+
+**Interfaces:**
+- Consumes: `Evaluator.options.timeout_ms: Option<u64>` (Task 1).
+- Produces: `Evaluator.start_time` gets set at the start of every top-level `evaluate()` call when a timeout is configured.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration_test.rs`:
+```rust
+/// A configured timeout must trip D1012 on a pathologically slow (but
+/// terminating) expression — a large nested-arithmetic chain is cheap to
+/// construct as a source string but expensive to evaluate node-by-node.
+#[test]
+fn test_timeout_raises_d1012() {
+    let data = JValue::Null;
+    // 200,000 additions chained: "1+1+1+...+1"
+    let expr_str = format!("({})", vec!["1"; 200_000].join("+"));
+    let ast = parse(&expr_str).unwrap();
+    let options = evaluator::EvaluatorOptions {
+        timeout_ms: Some(1), // 1ms — must expire before 200k node evaluations finish
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let result = evaluator.evaluate(&ast, &data);
+    let err = result.expect_err("expected a D1012 timeout error");
+    assert!(
+        err.to_string().contains("D1012"),
+        "expected D1012, got: {err}"
+    );
+}
+
+/// No timeout configured (the default) must never raise D1012, however long
+/// evaluation takes.
+#[test]
+fn test_no_timeout_configured_never_raises_d1012() {
+    let data = JValue::Null;
+    let expr_str = format!("({})", vec!["1"; 200_000].join("+"));
+    let ast = parse(&expr_str).unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data);
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+}
+```
+Note: a deeply nested `1+1+1+...` expression may itself trip D1011/U1001 depending on parser associativity (left-associative chains are usually *iterative* in the parser's AST shape, not recursive-per-term, so this should evaluate as a flat sequence of `Add` nodes rather than 200,000 levels of stack depth — but if `test_timeout_raises_d1012` unexpectedly fails with a stack-depth error instead of D1012, reduce the chain to a width that evaluates without tripping D1011 (e.g. wrap in a `$map` over a large literal array with cheap per-element work instead: `$map([1..200000], function($x){$x*2})` — adjust based on actual parser AST shape observed when Step 2 is run).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test integration_test test_timeout -- --nocapture`
+Expected: `test_timeout_raises_d1012` FAILs (no D1012 check exists yet, so it returns `Ok`); `test_no_timeout_configured_never_raises_d1012` passes already (nothing changed yet). If the first test fails for a different reason (unexpected error code, e.g. a stack-depth error instead of running-out-the-clock), apply the adjustment noted in Step 1 before proceeding.
+
+- [ ] **Step 3: Implement the D1012 check**
+
+In `pub fn evaluate` (`src/evaluator.rs:2857-2870`), current:
+```rust
+    pub fn evaluate(&mut self, node: &AstNode, data: &JValue) -> Result<JValue, EvaluatorError> {
+        // Set parent context to root data if not already set
+        if self.context.get_parent().is_none() {
+            self.context.set_parent(data.clone());
+        }
+
+        self.tuple_stream_created = false;
+        let result = self.evaluate_internal(node, data)?;
+        Ok(if self.tuple_stream_created {
+            unwrap_tuple_output(result)
+        } else {
+            result
+        })
+    }
+```
+Replace with:
+```rust
+    pub fn evaluate(&mut self, node: &AstNode, data: &JValue) -> Result<JValue, EvaluatorError> {
+        // Set parent context to root data if not already set
+        if self.context.get_parent().is_none() {
+            self.context.set_parent(data.clone());
+        }
+
+        if self.options.timeout_ms.is_some() {
+            self.start_time = Some(Instant::now());
+        }
+
+        self.tuple_stream_created = false;
+        let result = self.evaluate_internal(node, data)?;
+        Ok(if self.tuple_stream_created {
+            unwrap_tuple_output(result)
+        } else {
+            result
+        })
+    }
+```
+
+Then in `evaluate_internal` (as left by Task 2), insert the timeout check directly after the D1011 block and before the `stacker::maybe_grow` call:
+```rust
+        // Check evaluation timeout (D1012). `start_time` is only set (in
+        // `evaluate()`) when `options.timeout_ms` is configured, so this is a
+        // single `is_none()` branch of overhead when no timeout is set.
+        if let Some(timeout_ms) = self.options.timeout_ms {
+            if let Some(start) = self.start_time {
+                if start.elapsed().as_millis() as u64 > timeout_ms {
+                    self.recursion_depth -= 1;
+                    return Err(EvaluatorError::EvaluationError(format!(
+                        "D1012: Evaluation timeout after {} milliseconds. Check for infinite loop",
+                        timeout_ms
+                    )));
+                }
+            }
+        }
+
+        const RED_ZONE: usize = 128 * 1024;
+```
+(i.e. the `const RED_ZONE` line that already exists right after the D1011 block now follows this new block instead.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test integration_test test_timeout -- --nocapture`
+Expected: both PASS.
+Run the full suite to check nothing else broke: `cargo test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluator.rs tests/integration_test.rs
+git commit -m "feat(guardrails): D1012 timeout guardrail in evaluate_internal"
+```
+
+---
+
+## Task 4: D2015 in the range operator (establishes the pattern)
+
+**Files:**
+- Modify: `src/evaluator.rs:11121-11193` (`fn range`)
+- Test: `tests/integration_test.rs`
+
+**Interfaces:**
+- Consumes: `check_sequence_length` (Task 1), `Evaluator.options` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration_test.rs`:
+```rust
+/// The range operator must respect `max_sequence_length` (D2015) in addition
+/// to its existing hardcoded 10-million-element cap (D2014) — mirrors
+/// jsonata-js's `evaluateRangeExpression`, which checks D2014 then D2015.
+#[test]
+fn test_range_operator_raises_d2015_when_configured() {
+    let data = JValue::Null;
+    let ast = parse("[1..1000]").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator
+        .evaluate(&ast, &data)
+        .expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// Without `max_sequence_length` set, ranges up to the existing 10M hardcoded
+/// cap are unaffected.
+#[test]
+fn test_range_operator_unaffected_without_max_sequence_length() {
+    let data = JValue::Null;
+    let ast = parse("[1..1000]").unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data).unwrap();
+    match result {
+        JValue::Array(arr) => assert_eq!(arr.len(), 1000),
+        other => panic!("expected array, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify the first fails**
+
+Run: `cargo test --test integration_test test_range_operator -- --nocapture`
+Expected: `test_range_operator_raises_d2015_when_configured` FAILs (no D2015 check exists yet); the second already passes.
+
+- [ ] **Step 3: Implement the check**
+
+Current (`src/evaluator.rs:11170-11180`):
+```rust
+        if size > 10_000_000 {
+            return Err(EvaluatorError::EvaluationError(
+                "D2014: Range operator results in too many elements (> 10,000,000)".to_string(),
+            ));
+        }
+```
+Replace with:
+```rust
+        if size > 10_000_000 {
+            return Err(EvaluatorError::EvaluationError(
+                "D2014: Range operator results in too many elements (> 10,000,000)".to_string(),
+            ));
+        }
+        check_sequence_length(size, &self.options)?;
+```
+(`fn range(&self, ...)` already has `&self` in scope — no threading needed.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test integration_test test_range_operator -- --nocapture`
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluator.rs tests/integration_test.rs
+git commit -m "feat(guardrails): D2015 sequence-length check in range operator"
+```
+
+---
+
+## Task 5: D2015 at the tree-walker's shared path-evaluation chokepoints + top-level Wildcard/Descendant
+
+This is the highest-leverage task: `evaluate_path` and `compiled_eval_field_path` are *shared exit points* that every path expression funnels through (plain field mapping, wildcard-in-path, descendant-in-path, predicate/filter-in-path) — one check at each covers the entire path-evaluation surface, rather than needing a check at every individual step type.
+
+**Files:**
+- Modify: `src/evaluator.rs:5038-5049` (`evaluate_path`'s final return), `src/evaluator.rs:1505-1543` (`compiled_eval_field_path`'s final return — plumbing note: this function doesn't have `options` yet, added in Task 7; for THIS task, only instrument `evaluate_path` and the two top-level arms, which are both `Evaluator` methods with direct `self.options` access)
+- Modify: `src/evaluator.rs:3497-3526` (top-level `AstNode::Wildcard` / `AstNode::Descendant` arms)
+- Test: `tests/integration_test.rs`
+
+**Interfaces:**
+- Consumes: `check_sequence_length` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration_test.rs`:
+```rust
+/// Plain field-path mapping over an array (e.g. `items.name`) is a
+/// query-result sequence per jsonata-js's `evaluatePath`/`evaluateStep` and
+/// must respect `max_sequence_length`.
+#[test]
+fn test_path_mapping_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"name": format!("item{i}")})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("items.name").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// Top-level wildcard `*` over a large object must respect max_sequence_length.
+#[test]
+fn test_wildcard_raises_d2015() {
+    let mut obj = serde_json::Map::new();
+    for i in 0..1000 {
+        obj.insert(format!("k{i}"), serde_json::json!(i));
+    }
+    let data: JValue = serde_json::Value::Object(obj).into();
+    let ast = parse("*").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// Top-level descendant `**` over a deeply-nested structure must respect
+/// max_sequence_length.
+#[test]
+fn test_descendant_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"v": i})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("**").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test integration_test test_path_mapping_raises_d2015 test_wildcard_raises_d2015 test_descendant_raises_d2015 -- --nocapture`
+Expected: all three FAIL (no D2015 checks exist yet at these sites).
+
+- [ ] **Step 3: Instrument `evaluate_path`'s shared exit point**
+
+Current (`src/evaluator.rs:5038-5049`):
+```rust
+        // An explicit `[]` keep-array forces the result to remain an array even
+        // after a later singleton index collapses it to a scalar (jsonata's
+        // keepSingleton), e.g. `$#$pos[][$pos<3]^($)[-1]` must yield `[4]`.
+        let result = if has_explicit_array_keep
+            && !matches!(result, JValue::Array(_) | JValue::Null | JValue::Undefined)
+        {
+            JValue::array(vec![result])
+        } else {
+            result
+        };
+
+        Ok(result)
+```
+Replace with:
+```rust
+        // An explicit `[]` keep-array forces the result to remain an array even
+        // after a later singleton index collapses it to a scalar (jsonata's
+        // keepSingleton), e.g. `$#$pos[][$pos<3]^($)[-1]` must yield `[4]`.
+        let result = if has_explicit_array_keep
+            && !matches!(result, JValue::Array(_) | JValue::Null | JValue::Undefined)
+        {
+            JValue::array(vec![result])
+        } else {
+            result
+        };
+
+        if let JValue::Array(arr) = &result {
+            check_sequence_length(arr.len(), &self.options)?;
+        }
+
+        Ok(result)
+```
+
+- [ ] **Step 4: Instrument the top-level `Wildcard`/`Descendant` arms**
+
+Current (`src/evaluator.rs:3497-3526`):
+```rust
+            AstNode::Wildcard => {
+                match data {
+                    JValue::Object(obj) => {
+                        let mut result = Vec::new();
+                        for value in obj.values() {
+                            // Flatten arrays into the result
+                            match value {
+                                JValue::Array(arr) => result.extend(arr.iter().cloned()),
+                                _ => result.push(value.clone()),
+                            }
+                        }
+                        Ok(JValue::array(result))
+                    }
+                    JValue::Array(arr) => {
+                        // For arrays, wildcard returns all elements
+                        Ok(JValue::Array(arr.clone()))
+                    }
+                    _ => Ok(JValue::Null),
+                }
+            }
+
+            // Descendant: recursively traverse all nested values
+            AstNode::Descendant => {
+                let descendants = self.collect_descendants(data);
+                if descendants.is_empty() {
+                    Ok(JValue::Null) // No descendants means undefined
+                } else {
+                    Ok(JValue::array(descendants))
+                }
+            }
+```
+Replace with:
+```rust
+            AstNode::Wildcard => {
+                match data {
+                    JValue::Object(obj) => {
+                        let mut result = Vec::new();
+                        for value in obj.values() {
+                            // Flatten arrays into the result
+                            match value {
+                                JValue::Array(arr) => result.extend(arr.iter().cloned()),
+                                _ => result.push(value.clone()),
+                            }
+                        }
+                        check_sequence_length(result.len(), &self.options)?;
+                        Ok(JValue::array(result))
+                    }
+                    JValue::Array(arr) => {
+                        // For arrays, wildcard returns all elements
+                        Ok(JValue::Array(arr.clone()))
+                    }
+                    _ => Ok(JValue::Null),
+                }
+            }
+
+            // Descendant: recursively traverse all nested values
+            AstNode::Descendant => {
+                let descendants = self.collect_descendants(data);
+                if descendants.is_empty() {
+                    Ok(JValue::Null) // No descendants means undefined
+                } else {
+                    check_sequence_length(descendants.len(), &self.options)?;
+                    Ok(JValue::array(descendants))
+                }
+            }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --test integration_test test_path_mapping_raises_d2015 test_wildcard_raises_d2015 test_descendant_raises_d2015 -- --nocapture`
+Expected: all three PASS.
+Run the full reference suite to confirm no regressions: `uv run pytest tests/python/test_reference_suite.py -q` (requires `maturin develop --release` first if the extension hasn't been rebuilt since Task 1-4's changes) — expect 1682/1682 still.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/evaluator.rs tests/integration_test.rs
+git commit -m "feat(guardrails): D2015 at tree-walker path evaluation, wildcard, descendant"
+```
+
+---
+
+## Task 6: D2015 in tree-walker HOF/object builtins (map, filter, keys, lookup, append, spread, each)
+
+**Files:**
+- Modify: `src/evaluator.rs:7848-7964` (`"map"` arm, 3 return points), `src/evaluator.rs:7966-8110` (`"filter"` arm, 3 return points), `src/evaluator.rs:7675-7729` (`"keys"` arm), `src/evaluator.rs:7730-7782` (`"lookup"` arm), `src/evaluator.rs:7414-7441` (`"append"` arm), `src/evaluator.rs:7783-7821` (`"spread"` arm), `src/evaluator.rs:8324-8368` (`"each"` arm)
+- Test: `tests/python/test_guardrails.py` (new file — see Task 12; a minimal Rust-level smoke test for one construct is enough here since the full per-construct/per-surface matrix lives in Task 12's Python suite once all engines are done)
+
+**Interfaces:**
+- Consumes: `check_sequence_length` (Task 1). All 7 sites are `&mut self` methods on `Evaluator` — direct `self.options` access, no signature changes needed.
+
+- [ ] **Step 1: Write one Rust-level smoke test (full matrix comes later)**
+
+Append to `tests/integration_test.rs`:
+```rust
+/// $map's generic (non-compiled-fast-path) construction must respect
+/// max_sequence_length. Using `$x.*` as the lambda body (not compilable, per
+/// try_compile_expr_with_allowed_vars's lack of a Wildcard arm) forces this
+/// through the generic per-element loop at evaluator.rs:7936-7956, not the
+/// CompiledExpr fast path.
+#[test]
+fn test_map_generic_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"a": i})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("$map(items, function($x){$x.*})").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --test integration_test test_map_generic_path_raises_d2015 -- --nocapture`
+Expected: FAILs (no check exists yet).
+
+- [ ] **Step 3: Instrument `"map"` (3 return points)**
+
+Current (`src/evaluator.rs:7887`, `:7922`, `:7956` — the three `Ok(JValue::array(result))`/`return Ok(JValue::array(result))` points inside the `"map" =>` arm):
+```rust
+                                    return Ok(JValue::array(result));
+```
+(first occurrence, inside the CompiledExpr-lambda fast path)
+```rust
+                                            return Ok(JValue::array(result));
+```
+(second occurrence, inside the stored-lambda-variable fast path)
+```rust
+                        Ok(JValue::array(result))
+```
+(third occurrence, the generic per-element loop, at the end of the `JValue::Array(arr) => { ... }` match arm)
+
+Prefix each of these 3 lines with a `check_sequence_length` call, e.g. the third one becomes:
+```rust
+                        check_sequence_length(result.len(), &self.options)?;
+                        Ok(JValue::array(result))
+```
+and the first/second (which use `return Ok(...)`) become:
+```rust
+                                    check_sequence_length(result.len(), &self.options)?;
+                                    return Ok(JValue::array(result));
+```
+Apply the equivalent one-line-before-each-return pattern at all 3 sites — the exact surrounding indentation is shown in the code already read at `src/evaluator.rs:7848-7964` (fetch it again with `sed -n '7848,7964p' src/evaluator.rs` if the file has shifted from earlier task edits, and match indentation exactly).
+
+- [ ] **Step 4: Instrument `"filter"` (3 return points)**
+
+Same pattern at `src/evaluator.rs:7966-8110`'s three sites: line with `return Ok(JValue::array(result));` (compiled-lambda fast path, ~8030), `return Ok(JValue::array(result));` (stored-lambda fast path, ~8065), and `Ok(JValue::array(result))` (generic loop, ~8109). Insert `check_sequence_length(result.len(), &self.options)?;` immediately before each.
+
+- [ ] **Step 5: Instrument `"keys"`, `"lookup"`, `"spread"`, `"each"` (single return point each)**
+
+- `"keys"` (`src/evaluator.rs:7675-7729`): the array-fanout branch builds `all_keys: Vec<JValue>` then calls `Ok(unwrap_single(all_keys))` (~line 7723). Insert `check_sequence_length(all_keys.len(), &self.options)?;` immediately before that line. (The single-object branch, `keys: Vec<JValue>` from one object's keys, is NOT capped upstream in this arm's shape — but see Step 6 note below on whether to include it; the object-branch's `keys.len()` is bounded by the object's own key count which is not what jsonata-js's `createSequence` push-based cap targets for a *single* object's key-list either, since `keys()` on a single object still routes through `this.createSequence()` in JS per the grep evidence — for full parity, ALSO insert `check_sequence_length(keys.len(), &self.options)?;` before `Ok(unwrap_single(keys))` at the single-object branch, line ~7701.)
+- `"lookup"` (`src/evaluator.rs:7730-7782`): the array-fanout branch (`results: Vec<JValue>` from `lookup_recursive`) has `Ok(JValue::array(results))` (~line 7780). Insert `check_sequence_length(results.len(), &self.options)?;` immediately before it.
+- `"spread"` (`src/evaluator.rs:7783-7821`): the array branch builds `result: Vec<JValue>` then `Ok(JValue::array(result))` (~line 7816). Insert the check immediately before.
+- `"each"` (`src/evaluator.rs:8324-8368`): builds `result: Vec<JValue>` then `Ok(JValue::array(result))` (~line 8362). Insert the check immediately before.
+
+- [ ] **Step 6: Instrument `"append"` (pre-check pattern, matching upstream exactly)**
+
+jsonata-js's `append()` checks `arg1.length + arg2.length > options.sequence` BEFORE concatenating (a manual pre-check, not a push-based incremental one) — mirror this exactly rather than checking after. Current (`src/evaluator.rs:7414-7441`):
+```rust
+                // Convert both to arrays if needed, then append
+                let arr = match first {
+                    JValue::Array(a) => a.to_vec(),
+                    other => vec![other.clone()], // Wrap non-array in array
+                };
+
+                Ok(functions::array::append(&arr, second)?)
+```
+Replace with:
+```rust
+                // Convert both to arrays if needed, then append
+                let arr = match first {
+                    JValue::Array(a) => a.to_vec(),
+                    other => vec![other.clone()], // Wrap non-array in array
+                };
+
+                // Pre-check combined size before concatenating, mirroring
+                // jsonata-js's append() (`arg1.length + arg2.length > options.sequence`).
+                let second_len = match second {
+                    JValue::Array(a) => a.len(),
+                    _ => 1,
+                };
+                check_sequence_length(arr.len() + second_len, &self.options)?;
+
+                Ok(functions::array::append(&arr, second)?)
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test --test integration_test test_map_generic_path_raises_d2015 -- --nocapture`
+Expected: PASS.
+Run: `cargo test` (full suite) and `uv run pytest tests/python/test_reference_suite.py -q` (rebuild first: `maturin develop --release`) — expect 1682/1682, no regressions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/evaluator.rs tests/integration_test.rs
+git commit -m "feat(guardrails): D2015 in tree-walker map/filter/keys/lookup/append/spread/each"
+```
+
+---
+
+## Task 7: Thread `options`/`start_time` through the `eval_compiled` call graph (mechanical plumbing)
+
+This is the largest mechanical task. `eval_compiled_inner` (the free-function "compiled expression" interpreter used by VM `EvalFallback`, by the tree-walker's `$map`/`$filter`/`$reduce`/lambda-invocation fast paths, and recursively by itself) currently takes no guardrail state at all. This task threads it through WITHOUT adding any new checks yet (checks come in Task 8) — pure plumbing, verified by the compiler.
+
+**Files:**
+- Modify: `src/evaluator.rs:736-1616` (`eval_compiled`, `eval_compiled_shaped`, `eval_compiled_inner`, `compiled_eval_field_path`, `compiled_apply_filter`, `call_pure_builtin`, `call_pure_builtin_by_name`)
+- Modify: `src/evaluator.rs` — every external call site of these functions (18 in the tree-walker's own methods, per the list below; each already has `&self`/`&mut self` so passes `&self.options, self.start_time`)
+- Modify: `src/evaluator.rs:9902-...` (`call_builtin_with_values` — a third builtin dispatcher, `&mut self` method, direct access, no threading needed — only add the D2015 check in Task 9)
+
+**Interfaces:**
+- Produces: `eval_compiled(expr, data, vars, options: &EvaluatorOptions, start_time: Option<Instant>)`, `eval_compiled_shaped(expr, data, vars, shape, options, start_time)`, `eval_compiled_inner(expr, data, vars, ctx, shape, options, start_time)`, `compiled_eval_field_path(steps, data, vars, ctx, shape, options, start_time)`, `compiled_apply_filter(filter, value, vars, ctx, shape, options, start_time)`, `call_pure_builtin(name, args, data, options)`, `call_pure_builtin_by_name(name, args, data, options)`.
+
+- [ ] **Step 1: Update the public/wrapper function signatures**
+
+Current (`src/evaluator.rs:736-755`):
+```rust
+pub(crate) fn eval_compiled(
+    expr: &CompiledExpr,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+) -> Result<JValue, EvaluatorError> {
+    eval_compiled_inner(expr, data, vars, None, None)
+}
+
+/// Like `eval_compiled` but with an optional shape cache for O(1) positional
+/// field access. The shape cache maps field names to their index in the object's
+/// internal Vec, enabling `get_index()` instead of hash lookups.
+#[inline(always)]
+fn eval_compiled_shaped(
+    expr: &CompiledExpr,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    shape: &ShapeCache,
+) -> Result<JValue, EvaluatorError> {
+    eval_compiled_inner(expr, data, vars, None, Some(shape))
+}
+```
+Replace with:
+```rust
+pub(crate) fn eval_compiled(
+    expr: &CompiledExpr,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<JValue, EvaluatorError> {
+    eval_compiled_inner(expr, data, vars, None, None, options, start_time)
+}
+
+/// Like `eval_compiled` but with an optional shape cache for O(1) positional
+/// field access. The shape cache maps field names to their index in the object's
+/// internal Vec, enabling `get_index()` instead of hash lookups.
+#[inline(always)]
+fn eval_compiled_shaped(
+    expr: &CompiledExpr,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    shape: &ShapeCache,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<JValue, EvaluatorError> {
+    eval_compiled_inner(expr, data, vars, None, Some(shape), options, start_time)
+}
+```
+
+- [ ] **Step 2: Update `eval_compiled_inner`'s signature and every internal recursive call**
+
+Current signature (`src/evaluator.rs:769-775`):
+```rust
+fn eval_compiled_inner(
+    expr: &CompiledExpr,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+) -> Result<JValue, EvaluatorError> {
+```
+Replace with:
+```rust
+fn eval_compiled_inner(
+    expr: &CompiledExpr,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<JValue, EvaluatorError> {
+```
+Then, within this function's body (`src/evaluator.rs:769-1197`), every recursive self-call currently ends its argument list with `, ctx, shape)` — 31 such call sites (confirmed by `grep -n "eval_compiled_inner(" src/evaluator.rs` before this edit — every hit between lines 842 and 1194 belongs to this function). Append `, options, start_time` before the closing paren of each. Since the trailing arguments are uniformly `ctx, shape` (verbatim) across every one of these 31 sites, do this as a scoped substitution rather than 31 manual edits — restrict to this function's line range so no unrelated code is touched:
+```bash
+sed -i '769,1197s/, ctx, shape)/, ctx, shape, options, start_time)/g' src/evaluator.rs
+```
+Also update the two `eval_compiled_inner(expr, data, vars, None, None)` / `(expr, data, vars, None, Some(shape))` calls from Step 1 if the sed didn't already reach them (they're outside the 769-1197 range, at lines 741/754 — verify those two were updated correctly by Step 1's manual edit, not by this sed).
+
+Run `grep -n "eval_compiled_inner(" src/evaluator.rs` afterward and manually inspect: every call within lines 769-1197 should now end `, options, start_time)`; the function's own signature line (769-775) should NOT have been altered by the sed (it doesn't match the `, ctx, shape)` pattern since it's a multi-line signature, not a call).
+
+- [ ] **Step 3: Update `compiled_eval_field_path` and `compiled_apply_filter`**
+
+Current `compiled_eval_field_path` signature (`src/evaluator.rs:1505-1511`):
+```rust
+fn compiled_eval_field_path(
+    steps: &[CompiledStep],
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+) -> Result<JValue, EvaluatorError> {
+```
+Replace with:
+```rust
+fn compiled_eval_field_path(
+    steps: &[CompiledStep],
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<JValue, EvaluatorError> {
+```
+Inside its body, the one call `current = compiled_apply_filter(filter, &current, vars, ctx, shape)?;` (line 1529) becomes:
+```rust
+            current = compiled_apply_filter(filter, &current, vars, ctx, shape, options, start_time)?;
+```
+And update its one external call site — `CompiledExpr::FieldPath(steps) => compiled_eval_field_path(steps, data, vars, ctx, shape)` (line 1011, inside `eval_compiled_inner`, which after Step 2 already has `options`/`start_time` in scope) — becomes:
+```rust
+        CompiledExpr::FieldPath(steps) => {
+            compiled_eval_field_path(steps, data, vars, ctx, shape, options, start_time)
+        }
+```
+
+Current `compiled_apply_filter` signature (`src/evaluator.rs:1616-1621`):
+```rust
+fn compiled_apply_filter(
+    filter: &CompiledExpr,
+    value: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+) -> Result<JValue, EvaluatorError> {
+```
+Replace with:
+```rust
+fn compiled_apply_filter(
+    filter: &CompiledExpr,
+    value: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<JValue, EvaluatorError> {
+```
+Its two internal calls to `eval_compiled_inner` (lines ~1635, ~1650) need `, options, start_time` appended the same way as Step 2 (these are OUTSIDE the 769-1197 sed range, so they weren't touched — update them by hand, same substitution: `, ctx, effective_shape)` → `, ctx, effective_shape, options, start_time)` and `, ctx, shape)` → `, ctx, shape, options, start_time)`).
+
+- [ ] **Step 4: Update `call_pure_builtin`/`call_pure_builtin_by_name`**
+
+Current (`src/evaluator.rs:1376-1381` and `:1665`):
+```rust
+pub(crate) fn call_pure_builtin_by_name(
+    name: &str,
+    args: &[JValue],
+    data: &JValue,
+) -> Result<JValue, EvaluatorError> {
+    call_pure_builtin(name, args, data)
+}
+```
+```rust
+fn call_pure_builtin(name: &str, args: &[JValue], data: &JValue) -> Result<JValue, EvaluatorError> {
+```
+Replace with:
+```rust
+pub(crate) fn call_pure_builtin_by_name(
+    name: &str,
+    args: &[JValue],
+    data: &JValue,
+    options: &EvaluatorOptions,
+) -> Result<JValue, EvaluatorError> {
+    call_pure_builtin(name, args, data, options)
+}
+```
+```rust
+fn call_pure_builtin(
+    name: &str,
+    args: &[JValue],
+    data: &JValue,
+    options: &EvaluatorOptions,
+) -> Result<JValue, EvaluatorError> {
+```
+Its one external call site is `CompiledExpr::BuiltinCall { name, args } => { ... call_pure_builtin(name, &evaled_args, data) }` inside `eval_compiled_inner` (line ~1019, already has `options` in scope after Step 2) — becomes `call_pure_builtin(name, &evaled_args, data, options)`.
+
+- [ ] **Step 5: Fix every external call site by following compiler errors**
+
+Run `cargo build --lib 2>&1 | head -100` now — this WILL fail with many "this function takes N arguments but M were supplied" errors, one per external call site that hasn't been updated. This is the exhaustiveness check: fix each reported call site by appending the two new trailing arguments, using `&self.options, self.start_time` when the call site is inside an `Evaluator` method (the majority — e.g. the `$map`/`$filter`/`$reduce` fast paths at lines ~7882, 7913, 8018, 8053, 8185, 8215; `invoke_stored_lambda`'s fast path at ~2632; and the 6 pairs of `eval_compiled_shaped`/`eval_compiled` fast-path calls used in path-mapping at ~3733/3735, ~4899/4901, ~5402/5404, ~6212/6214, ~10197/10199, ~10287/10289). Repeat `cargo build --lib` after each fix until it succeeds — do not stop at the first clean compile of one file section; keep going until the WHOLE crate builds with zero errors. This compiler-driven loop is the actual completeness guarantee for this task (more reliable than any hand-maintained list, since a missed call site cannot silently compile).
+
+- [ ] **Step 6: Verify no behavior change**
+
+Run: `cargo test` (full suite — must be 100% green, since this task adds no new checks, only plumbing)
+Run: `cargo clippy --lib -- -D warnings` (watch for unused-variable warnings on `options`/`start_time` in call sites where they're threaded but not yet read anywhere except inside `eval_compiled_inner`'s own signature — these should NOT be unused since `eval_compiled_inner`'s body will start referencing `options`/`start_time` in Task 8; if clippy complains before Task 8 lands, that's expected and will resolve once Task 8 adds the checks — do not silence with `#[allow(unused)]`, just proceed to Task 8 in the same work session)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/evaluator.rs
+git commit -m "refactor(guardrails): thread EvaluatorOptions/start_time through eval_compiled call graph"
+```
+
+---
+
+## Task 8: D2015 + D1012 in `eval_compiled_inner`'s MapCall/FilterCall/ReduceCall and `compiled_apply_filter`
+
+Now that Task 7 threaded `options`/`start_time` everywhere, add the actual checks. D1012 (timeout) must be checked *inside* the per-element loops here, not just once — these loops can run for a long time on a large array while never passing through `evaluate_internal`'s checkpoint (this is a deliberate extension beyond the design spec's literal text, which only mentions checking timeout "at evaluate_internal" — see the plan's cover note to the user about this). D2015 is checked once, after each loop, matching jsonata-js's semantics of capping the final sequence length (`$reduce` is NOT included — jsonata-js's `reduce()` has no `createSequence()` call, so its accumulator is uncapped upstream too; only the D1012 timeout-in-loop applies to `ReduceCall`, not D2015).
+
+**Files:**
+- Modify: `src/evaluator.rs:1048-1195` (`MapCall`, `FilterCall`, `ReduceCall` arms of `eval_compiled_inner`)
+- Modify: `src/evaluator.rs:1616-1656` (`compiled_apply_filter`)
+- Test: `tests/python/test_guardrails.py` (Task 12 covers the full matrix; this task's own verification is via the compiled-lambda-fast-path route being reachable — see Step 1)
+
+**Interfaces:**
+- Consumes: `check_sequence_length`, `options: &EvaluatorOptions`, `start_time: Option<Instant>` (both now in scope per Task 7).
+
+- [ ] **Step 1: Write a Rust-level test forcing the CompiledExpr fast path**
+
+Append to `tests/integration_test.rs`:
+```rust
+/// $map with a directly-compilable lambda body (e.g. `$x*2`, no wildcards/
+/// wildcards/HOFs inside) takes the CompiledExpr::MapCall fast path through
+/// eval_compiled_inner, NOT the generic tree-walker loop. Confirms D2015
+/// applies there too.
+#[test]
+fn test_map_compiled_fast_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).collect::<Vec<i32>>()
+    }).into();
+    let ast = parse("$map(items, function($x){$x*2})").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// A timeout must trip inside a large compiled-fast-path $map loop, even
+/// though the loop never passes through evaluate_internal's per-node checkpoint.
+#[test]
+fn test_map_compiled_fast_path_raises_d1012_timeout() {
+    let data: JValue = serde_json::json!({
+        "items": (0..500_000).collect::<Vec<i32>>()
+    }).into();
+    let ast = parse("$map(items, function($x){$x*2})").unwrap();
+    let options = evaluator::EvaluatorOptions {
+        timeout_ms: Some(1),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
+    assert!(err.to_string().contains("D1012"), "got: {err}");
+}
+```
+
+- [ ] **Step 2: Run to verify both fail**
+
+Run: `cargo test --test integration_test test_map_compiled_fast_path -- --nocapture`
+Expected: both FAIL (no checks in `MapCall` yet).
+
+- [ ] **Step 3: Instrument `MapCall`**
+
+Current (`src/evaluator.rs:1048-1097`, as left by Task 7's plumbing — signatures now carry `options, start_time`):
+```rust
+        CompiledExpr::MapCall {
+            array,
+            params,
+            body,
+        } => {
+            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape, options, start_time)?;
+            let single_holder;
+            let items: &[JValue] = match &arr_val {
+                JValue::Array(a) => a.as_slice(),
+                JValue::Undefined => return Ok(JValue::Undefined),
+                other => {
+                    single_holder = [other.clone()];
+                    &single_holder[..]
+                }
+            };
+            let mut result = Vec::with_capacity(items.len());
+            let p0 = params.first().map(|s| s.as_str());
+
+            if let Some(p1) = params.get(1).map(|s| s.as_str()) {
+                for (idx, item) in items.iter().enumerate() {
+                    let idx_val = JValue::Number(idx as f64);
+                    let mut call_vars = clone_outer_vars(vars, 2);
+                    if let Some(p) = p0 {
+                        call_vars.insert(p, item);
+                    }
+                    call_vars.insert(p1, &idx_val);
+                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    if !mapped.is_undefined() {
+                        result.push(mapped);
+                    }
+                }
+            } else if let Some(p0) = p0 {
+                let mut call_vars = clone_outer_vars(vars, 1);
+                for item in items.iter() {
+                    call_vars.insert(p0, item);
+                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    if !mapped.is_undefined() {
+                        result.push(mapped);
+                    }
+                }
+            }
+            Ok(if result.is_empty() {
+                JValue::Undefined
+            } else {
+                JValue::array(result)
+            })
+        }
+```
+Replace with (adds a `check_timeout` closure call at the top of each per-element loop body, and a `check_sequence_length` after both loops):
+```rust
+        CompiledExpr::MapCall {
+            array,
+            params,
+            body,
+        } => {
+            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape, options, start_time)?;
+            let single_holder;
+            let items: &[JValue] = match &arr_val {
+                JValue::Array(a) => a.as_slice(),
+                JValue::Undefined => return Ok(JValue::Undefined),
+                other => {
+                    single_holder = [other.clone()];
+                    &single_holder[..]
+                }
+            };
+            let mut result = Vec::with_capacity(items.len());
+            let p0 = params.first().map(|s| s.as_str());
+
+            if let Some(p1) = params.get(1).map(|s| s.as_str()) {
+                for (idx, item) in items.iter().enumerate() {
+                    check_loop_timeout(options, start_time)?;
+                    let idx_val = JValue::Number(idx as f64);
+                    let mut call_vars = clone_outer_vars(vars, 2);
+                    if let Some(p) = p0 {
+                        call_vars.insert(p, item);
+                    }
+                    call_vars.insert(p1, &idx_val);
+                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    if !mapped.is_undefined() {
+                        result.push(mapped);
+                    }
+                }
+            } else if let Some(p0) = p0 {
+                let mut call_vars = clone_outer_vars(vars, 1);
+                for item in items.iter() {
+                    check_loop_timeout(options, start_time)?;
+                    call_vars.insert(p0, item);
+                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    if !mapped.is_undefined() {
+                        result.push(mapped);
+                    }
+                }
+            }
+            check_sequence_length(result.len(), options)?;
+            Ok(if result.is_empty() {
+                JValue::Undefined
+            } else {
+                JValue::array(result)
+            })
+        }
+```
+Add the new `check_loop_timeout` helper right next to `check_sequence_length` (Task 1's location, `src/evaluator.rs` near the `EvaluatorOptions` struct):
+```rust
+/// Per-iteration D1012 check for loop-based compiled/VM constructs (map/filter/
+/// reduce element loops, FilterByBytecode) that don't pass through
+/// `evaluate_internal`'s per-node checkpoint and would otherwise run untimed.
+#[inline]
+pub(crate) fn check_loop_timeout(
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<(), EvaluatorError> {
+    if let Some(timeout_ms) = options.timeout_ms {
+        if let Some(start) = start_time {
+            if start.elapsed().as_millis() as u64 > timeout_ms {
+                return Err(EvaluatorError::EvaluationError(format!(
+                    "D1012: Evaluation timeout after {} milliseconds. Check for infinite loop",
+                    timeout_ms
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Instrument `FilterCall` (D2015 + D1012-in-loop) and `ReduceCall` (D1012-in-loop only)**
+
+Apply the same `check_loop_timeout(options, start_time)?;` at the top of each per-element loop body in `FilterCall` (`src/evaluator.rs:1099-1151`, both the 2-param and 1-param loops) and in `ReduceCall`'s single loop (`src/evaluator.rs:1153-1195`). Add `check_sequence_length(result.len(), options)?;` in `FilterCall` before each of its two `Ok(...)` branches that can return `JValue::array(result)` (the `was_single` match and the plain `Ok(JValue::array(result))` — check length only in the branches where `result.len() > 1`, i.e. right before constructing the array; for the `was_single` match arm, add the check inside the `_ => JValue::array(result)` arm specifically). Do NOT add `check_sequence_length` to `ReduceCall` — its accumulator is uncapped upstream (see task intro).
+
+- [ ] **Step 5: Instrument `compiled_apply_filter`**
+
+Current (`src/evaluator.rs:1616-1656`, as left by Task 7):
+```rust
+fn compiled_apply_filter(
+    filter: &CompiledExpr,
+    value: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    ctx: Option<&Context>,
+    shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<JValue, EvaluatorError> {
+    match value {
+        JValue::Array(arr) => {
+            let mut result = Vec::new();
+            let local_shape: Option<ShapeCache> = if shape.is_none() {
+                arr.first().and_then(build_shape_cache)
+            } else {
+                None
+            };
+            let effective_shape = shape.or(local_shape.as_ref());
+            for item in arr.iter() {
+                let pred = eval_compiled_inner(filter, item, vars, ctx, effective_shape, options, start_time)?;
+                if compiled_is_truthy(&pred) {
+                    result.push(item.clone());
+                }
+            }
+            if result.is_empty() {
+                Ok(JValue::Undefined)
+            } else if result.len() == 1 {
+                Ok(result.remove(0))
+            } else {
+                Ok(JValue::array(result))
+            }
+        }
+        JValue::Undefined => Ok(JValue::Undefined),
+        _ => {
+            let pred = eval_compiled_inner(filter, value, vars, ctx, shape, options, start_time)?;
+            if compiled_is_truthy(&pred) {
+                Ok(value.clone())
+            } else {
+                Ok(JValue::Undefined)
+            }
+        }
+    }
+}
+```
+Replace the array branch's loop and tail with:
+```rust
+            for item in arr.iter() {
+                check_loop_timeout(options, start_time)?;
+                let pred = eval_compiled_inner(filter, item, vars, ctx, effective_shape, options, start_time)?;
+                if compiled_is_truthy(&pred) {
+                    result.push(item.clone());
+                }
+            }
+            if result.is_empty() {
+                Ok(JValue::Undefined)
+            } else if result.len() == 1 {
+                Ok(result.remove(0))
+            } else {
+                check_sequence_length(result.len(), options)?;
+                Ok(JValue::array(result))
+            }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --test integration_test test_map_compiled_fast_path -- --nocapture`
+Expected: both PASS.
+Run: `cargo test` (full suite), `cargo clippy --lib -- -D warnings`, and rebuild + rerun the reference suite: `maturin develop --release && uv run pytest tests/python/test_reference_suite.py -q` — expect 1682/1682.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/evaluator.rs tests/integration_test.rs
+git commit -m "feat(guardrails): D2015+D1012 in eval_compiled_inner's MapCall/FilterCall/ReduceCall"
+```
+
+---
+
+## Task 9: Thread `EvaluatorOptions` through `vm.rs`; D2015+D1012 in `FilterByBytecode`; D2015 in the two remaining pure-builtin dispatchers' append/keys arms
+
+**Files:**
+- Modify: `src/vm.rs:166-189` (`Vm` struct + `run`), `src/vm.rs:195-211` (`run_inner` signature), `src/vm.rs:487-503` (`MakeArray` — verify NOT touched, literal-only), `src/vm.rs:532-542` (`CallBuiltin`), `src/vm.rs:545-578` (`FilterByBytecode`), `src/vm.rs:581-585` (`EvalFallback`)
+- Modify: `src/evaluator.rs:1665-...` (`call_pure_builtin`'s `"append"`/`"keys"` arms, ~lines 2033-2105 — reachable from `vm.rs`'s `CallBuiltin` and `eval_compiled_inner`'s `BuiltinCall`; missing this site would let a fully-compiled expression silently bypass D2015)
+- Modify: `src/evaluator.rs:9902-...` (`call_builtin_with_values`'s `"append"`/`"keys"` arms, ~lines 10071-10115 — a third, separate dispatcher)
+- Test: `tests/integration_test.rs` (a Rust-level VM-path smoke test using the bench facade, or defer full verification to Task 12's Python parity suite if the Rust-level VM isn't easily reachable from `tests/integration_test.rs` — check whether `#[cfg(feature = "bench")]`'s `_bench` module in `src/lib.rs` exposes a way to run the VM directly from a Rust test; if not, this task's correctness is verified via Task 12's Python-level "pure VM path" test instead, and this task's own Step 1 becomes a compile-and-existing-test-suite check only)
+
+**Interfaces:**
+- Produces: `Vm::with_options(prog: &BytecodeProgram, options: EvaluatorOptions) -> Self` (new; `Vm::new` unchanged, delegates to it with `EvaluatorOptions::default()`), `run_inner(prog, data, vars, stack, options: &EvaluatorOptions, start_time: Option<Instant>)`.
+
+- [ ] **Step 1: Update `Vm` struct and constructors**
+
+Current (`src/vm.rs:166-189`):
+```rust
+pub(crate) struct Vm<'prog> {
+    prog: &'prog BytecodeProgram,
+    /// Operand stack.
+    stack: Vec<JValue>,
+}
+
+impl<'prog> Vm<'prog> {
+    pub(crate) fn new(prog: &'prog BytecodeProgram) -> Self {
+        Vm {
+            prog,
+            stack: Vec::with_capacity(16),
+        }
+    }
+
+    /// Run the program against `data` with optional variable bindings.
+    #[inline]
+    pub(crate) fn run(
+        &mut self,
+        data: &JValue,
+        vars: Option<&HashMap<&str, &JValue>>,
+    ) -> Result<JValue, EvaluatorError> {
+        run_inner(self.prog, data, vars, &mut self.stack)
+    }
+}
+```
+Replace with:
+```rust
+pub(crate) struct Vm<'prog> {
+    prog: &'prog BytecodeProgram,
+    /// Operand stack.
+    stack: Vec<JValue>,
+    options: EvaluatorOptions,
+}
+
+impl<'prog> Vm<'prog> {
+    pub(crate) fn new(prog: &'prog BytecodeProgram) -> Self {
+        Self::with_options(prog, EvaluatorOptions::default())
+    }
+
+    /// Construct a `Vm` with guardrail options (timeout/sequence-length; stack
+    /// depth is not meaningful here — the VM is an iterative flat-instruction
+    /// loop, not native recursion, and self-recursive user lambdas can't
+    /// compile to bytecode in the first place, see design-spec Phase 2 notes).
+    pub(crate) fn with_options(prog: &'prog BytecodeProgram, options: EvaluatorOptions) -> Self {
+        Vm {
+            prog,
+            stack: Vec::with_capacity(16),
+            options,
+        }
+    }
+
+    /// Run the program against `data` with optional variable bindings.
+    #[inline]
+    pub(crate) fn run(
+        &mut self,
+        data: &JValue,
+        vars: Option<&HashMap<&str, &JValue>>,
+    ) -> Result<JValue, EvaluatorError> {
+        let start_time = if self.options.timeout_ms.is_some() {
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+        run_inner(self.prog, data, vars, &mut self.stack, &self.options, start_time)
+    }
+}
+```
+Add the import at the top of `src/vm.rs` (currently line 17):
+```rust
+use crate::evaluator::{
+    check_loop_timeout, check_sequence_length, eval_compiled, CompiledExpr, EvaluatorError,
+    EvaluatorOptions,
+};
+```
+
+- [ ] **Step 2: Update `run_inner`'s signature and its 2 recursive self-calls**
+
+Current (`src/vm.rs:195-200`):
+```rust
+fn run_inner(
+    prog: &BytecodeProgram,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    stack: &mut Vec<JValue>,
+) -> Result<JValue, EvaluatorError> {
+```
+Replace with:
+```rust
+fn run_inner(
+    prog: &BytecodeProgram,
+    data: &JValue,
+    vars: Option<&HashMap<&str, &JValue>>,
+    stack: &mut Vec<JValue>,
+    options: &EvaluatorOptions,
+    start_time: Option<std::time::Instant>,
+) -> Result<JValue, EvaluatorError> {
+```
+Its 2 internal recursive calls are both inside `FilterByBytecode` (Step 3 below rewrites that arm to pass `options, start_time` through).
+
+- [ ] **Step 3: Instrument `FilterByBytecode` (D2015 + D1012-in-loop)**
+
+Current (`src/vm.rs:545-578`):
+```rust
+            Instr::FilterByBytecode(idx) => {
+                let sub_prog = &sub_programs[*idx as usize];
+                let src = stack.pop().unwrap_or(JValue::Undefined);
+                // Allocate one reusable sub-stack for all element evaluations.
+                let mut sub_stack: Vec<JValue> = Vec::with_capacity(8);
+                let result = match src {
+                    JValue::Array(arr) => {
+                        let mut kept: Vec<JValue> = Vec::with_capacity(arr.len());
+                        for item in arr.iter() {
+                            let test = run_inner(sub_prog, item, vars, &mut sub_stack)?;
+                            if compiled_is_truthy(&test) {
+                                kept.push(item.clone());
+                            }
+                        }
+                        match kept.len() {
+                            0 => JValue::Undefined,
+                            1 => kept.pop().unwrap(),
+                            _ => JValue::array(kept),
+                        }
+                    }
+                    JValue::Undefined => JValue::Undefined,
+                    other => {
+                        // Single value: apply predicate directly
+                        let test = run_inner(sub_prog, &other, vars, &mut sub_stack)?;
+                        if compiled_is_truthy(&test) {
+                            other
+                        } else {
+                            JValue::Undefined
+                        }
+                    }
+                };
+                stack.push(result);
+                ip += 1;
+            }
+```
+Replace with:
+```rust
+            Instr::FilterByBytecode(idx) => {
+                let sub_prog = &sub_programs[*idx as usize];
+                let src = stack.pop().unwrap_or(JValue::Undefined);
+                // Allocate one reusable sub-stack for all element evaluations.
+                let mut sub_stack: Vec<JValue> = Vec::with_capacity(8);
+                let result = match src {
+                    JValue::Array(arr) => {
+                        let mut kept: Vec<JValue> = Vec::with_capacity(arr.len());
+                        for item in arr.iter() {
+                            check_loop_timeout(options, start_time)?;
+                            let test =
+                                run_inner(sub_prog, item, vars, &mut sub_stack, options, start_time)?;
+                            if compiled_is_truthy(&test) {
+                                kept.push(item.clone());
+                            }
+                        }
+                        match kept.len() {
+                            0 => JValue::Undefined,
+                            1 => kept.pop().unwrap(),
+                            _ => {
+                                check_sequence_length(kept.len(), options)?;
+                                JValue::array(kept)
+                            }
+                        }
+                    }
+                    JValue::Undefined => JValue::Undefined,
+                    other => {
+                        // Single value: apply predicate directly
+                        let test =
+                            run_inner(sub_prog, &other, vars, &mut sub_stack, options, start_time)?;
+                        if compiled_is_truthy(&test) {
+                            other
+                        } else {
+                            JValue::Undefined
+                        }
+                    }
+                };
+                stack.push(result);
+                ip += 1;
+            }
+```
+
+- [ ] **Step 4: Thread `options` into `CallBuiltin` and `EvalFallback`**
+
+Current (`src/vm.rs:532-542` and `:581-585`):
+```rust
+            Instr::CallBuiltin {
+                name_idx,
+                arg_count,
+            } => {
+                let name = &string_pool[*name_idx as usize];
+                let n = *arg_count as usize;
+                let start = stack.len().saturating_sub(n);
+                let args: Vec<JValue> = stack.drain(start..).collect();
+                stack.push(call_pure_builtin_by_name(name, &args, data)?);
+                ip += 1;
+            }
+```
+```rust
+            Instr::EvalFallback(idx) => {
+                let expr = &fallback_exprs[*idx as usize];
+                stack.push(eval_compiled(expr, data, vars)?);
+                ip += 1;
+            }
+```
+Replace with:
+```rust
+            Instr::CallBuiltin {
+                name_idx,
+                arg_count,
+            } => {
+                let name = &string_pool[*name_idx as usize];
+                let n = *arg_count as usize;
+                let start = stack.len().saturating_sub(n);
+                let args: Vec<JValue> = stack.drain(start..).collect();
+                stack.push(call_pure_builtin_by_name(name, &args, data, options)?);
+                ip += 1;
+            }
+```
+```rust
+            Instr::EvalFallback(idx) => {
+                let expr = &fallback_exprs[*idx as usize];
+                stack.push(eval_compiled(expr, data, vars, options, start_time)?);
+                ip += 1;
+            }
+```
+(`call_pure_builtin_by_name`'s signature was already updated in Task 7, Step 4 — this just supplies the new argument at its one remaining call site.)
+
+- [ ] **Step 5: Update `Vm::run`/`Vm::new` call sites in `lib.rs` (compile-only for now — full kwarg threading is Task 10)**
+
+Run `cargo build --lib 2>&1 | head -60` — this will report the 2 call sites in `src/lib.rs` (bench facade `:73`, Python `run_eval` `:174-175`) as needing an updated call. For THIS task, just make them compile with unlimited options (`Vm::new(bc)` already delegates to `with_options` with `EvaluatorOptions::default()`, so no call-site change is needed there — `Vm::new` keeps its 1-arg signature). Confirm with `cargo build --lib` that it's clean without touching `lib.rs` at all; if it IS clean, skip to Step 6 (this should be the case, since `Vm::new` was kept source-compatible).
+
+- [ ] **Step 6: D2015 in `call_pure_builtin`'s own `"append"`/`"keys"` arms**
+
+`call_pure_builtin` (`src/evaluator.rs:1665-...`, threaded with `options` in Task 7) has ITS OWN separate `"append"`/`"keys"` match arms (distinct from the tree-walker method's arms instrumented in Task 6, and distinct from `call_builtin_with_values` instrumented in Step 7 below) — this is the dispatcher reachable from `vm.rs`'s `Instr::CallBuiltin` (via `call_pure_builtin_by_name`) and from `eval_compiled_inner`'s `CompiledExpr::BuiltinCall` arm. Missing this site would let `$append`/`$keys` silently bypass D2015 whenever they're called from a fully-compiled expression or from inside a compiled HOF lambda body — exactly the failure mode this plan exists to prevent. Current (~lines 2033-2052 and ~2069-2105, re-locate via `grep -n '"append" =>\|"keys" =>' src/evaluator.rs` and pick the occurrences inside `call_pure_builtin`, not the tree-walker method or `call_builtin_with_values`):
+```rust
+        "append" => {
+            if effective_args.len() != 2 {
+                return Err(EvaluatorError::EvaluationError(
+                    "append() requires exactly 2 arguments".to_string(),
+                ));
+            }
+            let first = &effective_args[0];
+            let second = &effective_args[1];
+            if matches!(second, JValue::Null | JValue::Undefined) {
+                return Ok(first.clone());
+            }
+            if matches!(first, JValue::Null | JValue::Undefined) {
+                return Ok(second.clone());
+            }
+            let arr = match first {
+                JValue::Array(a) => a.to_vec(),
+                other => vec![other.clone()],
+            };
+            Ok(functions::array::append(&arr, second)?)
+        }
+```
+Replace with:
+```rust
+        "append" => {
+            if effective_args.len() != 2 {
+                return Err(EvaluatorError::EvaluationError(
+                    "append() requires exactly 2 arguments".to_string(),
+                ));
+            }
+            let first = &effective_args[0];
+            let second = &effective_args[1];
+            if matches!(second, JValue::Null | JValue::Undefined) {
+                return Ok(first.clone());
+            }
+            if matches!(first, JValue::Null | JValue::Undefined) {
+                return Ok(second.clone());
+            }
+            let arr = match first {
+                JValue::Array(a) => a.to_vec(),
+                other => vec![other.clone()],
+            };
+            let second_len = match second {
+                JValue::Array(a) => a.len(),
+                _ => 1,
+            };
+            check_sequence_length(arr.len() + second_len, options)?;
+            Ok(functions::array::append(&arr, second)?)
+        }
+```
+And its `"keys"` arm:
+```rust
+        "keys" => match effective_args.first() {
+            Some(JValue::Null | JValue::Undefined) | None => Ok(JValue::Null),
+            Some(JValue::Lambda { .. } | JValue::Builtin { .. }) => Ok(JValue::Null),
+            Some(JValue::Object(obj)) => {
+                if obj.is_empty() {
+                    Ok(JValue::Null)
+                } else {
+                    let keys: Vec<JValue> = obj.keys().map(|k| JValue::string(k.clone())).collect();
+                    if keys.len() == 1 {
+                        Ok(keys.into_iter().next().unwrap())
+                    } else {
+                        Ok(JValue::array(keys))
+                    }
+                }
+            }
+            Some(JValue::Array(arr)) => {
+                let mut all_keys: Vec<JValue> = Vec::new();
+                for item in arr.iter() {
+                    if let JValue::Object(obj) = item {
+                        for key in obj.keys() {
+                            let k = JValue::string(key.clone());
+                            if !all_keys.contains(&k) {
+                                all_keys.push(k);
+                            }
+                        }
+                    }
+                }
+                if all_keys.is_empty() {
+                    Ok(JValue::Null)
+                } else if all_keys.len() == 1 {
+                    Ok(all_keys.into_iter().next().unwrap())
+                } else {
+                    Ok(JValue::array(all_keys))
+                }
+            }
+            _ => Ok(JValue::Null),
+        },
+```
+Insert `check_sequence_length(keys.len(), options)?;` before the `if keys.len() == 1 { ... } else { Ok(JValue::array(keys)) }` block's else-branch return (or simply before the whole `if/else`, since the check is a no-op when `keys.len() == 1`), and `check_sequence_length(all_keys.len(), options)?;` before the equivalent `all_keys.len() == 1` check in the array branch. Concretely, replace the `Some(JValue::Object(obj))` arm's body with:
+```rust
+            Some(JValue::Object(obj)) => {
+                if obj.is_empty() {
+                    Ok(JValue::Null)
+                } else {
+                    let keys: Vec<JValue> = obj.keys().map(|k| JValue::string(k.clone())).collect();
+                    check_sequence_length(keys.len(), options)?;
+                    if keys.len() == 1 {
+                        Ok(keys.into_iter().next().unwrap())
+                    } else {
+                        Ok(JValue::array(keys))
+                    }
+                }
+            }
+```
+and the `Some(JValue::Array(arr))` arm's tail with:
+```rust
+                if all_keys.is_empty() {
+                    Ok(JValue::Null)
+                } else if all_keys.len() == 1 {
+                    Ok(all_keys.into_iter().next().unwrap())
+                } else {
+                    check_sequence_length(all_keys.len(), options)?;
+                    Ok(JValue::array(all_keys))
+                }
+```
+
+- [ ] **Step 7: D2015 in `call_builtin_with_values`'s `"append"`/`"keys"` arms**
+
+This is a third builtin dispatcher (`&mut self` method on `Evaluator`, direct `self.options` access — found via `grep -n "fn call_builtin_with_values" src/evaluator.rs`, currently at line 9902). Current (~lines 10071-10115, exact lines depend on earlier tasks' edits — re-locate via `grep -n '"append" =>\|"keys" =>' src/evaluator.rs` and find the occurrence inside `call_builtin_with_values`):
+```rust
+            "append" => {
+                // append(array1, array2) - append second array to first
+                if values.len() < 2 {
+                    return Err(EvaluatorError::EvaluationError(
+                        "append() requires 2 arguments".to_string(),
+                    ));
+                }
+                let first = &values[0];
+                let second = &values[1];
+
+                // Convert first to array if needed
+                let mut result = match first {
+                    JValue::Array(arr) => arr.to_vec(),
+                    JValue::Null => vec![],
+                    other => vec![other.clone()],
+                };
+
+                // Append second (flatten if array)
+                match second {
+                    JValue::Array(arr) => result.extend(arr.iter().cloned()),
+                    JValue::Null => {}
+                    other => result.push(other.clone()),
+                }
+
+                Ok(JValue::array(result))
+            }
+```
+Replace with:
+```rust
+            "append" => {
+                // append(array1, array2) - append second array to first
+                if values.len() < 2 {
+                    return Err(EvaluatorError::EvaluationError(
+                        "append() requires 2 arguments".to_string(),
+                    ));
+                }
+                let first = &values[0];
+                let second = &values[1];
+
+                // Convert first to array if needed
+                let mut result = match first {
+                    JValue::Array(arr) => arr.to_vec(),
+                    JValue::Null => vec![],
+                    other => vec![other.clone()],
+                };
+
+                // Append second (flatten if array)
+                match second {
+                    JValue::Array(arr) => result.extend(arr.iter().cloned()),
+                    JValue::Null => {}
+                    other => result.push(other.clone()),
+                }
+
+                check_sequence_length(result.len(), &self.options)?;
+                Ok(JValue::array(result))
+            }
+```
+And its `"keys"` arm:
+```rust
+            "keys" => match arg {
+                JValue::Object(obj) => {
+                    let keys: Vec<JValue> = obj.keys().map(|k| JValue::string(k.clone())).collect();
+                    Ok(JValue::array(keys))
+                }
+                JValue::Null => Ok(JValue::Null),
+                _ => Err(EvaluatorError::TypeError(
+                    "keys() requires an object".to_string(),
+```
+Replace the array-construction line with:
+```rust
+            "keys" => match arg {
+                JValue::Object(obj) => {
+                    let keys: Vec<JValue> = obj.keys().map(|k| JValue::string(k.clone())).collect();
+                    check_sequence_length(keys.len(), &self.options)?;
+                    Ok(JValue::array(keys))
+                }
+                JValue::Null => Ok(JValue::Null),
+                _ => Err(EvaluatorError::TypeError(
+                    "keys() requires an object".to_string(),
+```
+
+- [ ] **Step 8: Verify everything compiles and passes**
+
+Run: `cargo build --lib 2>&1 | tail -60` — fix any remaining call-site errors the same compiler-driven way as Task 7 Step 5.
+Run: `cargo test`, `cargo clippy --lib -- -D warnings`, `cargo fmt --check`.
+Run: `maturin develop --release && uv run pytest tests/python/test_reference_suite.py -q` — expect 1682/1682.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/vm.rs src/evaluator.rs
+git commit -m "feat(guardrails): thread EvaluatorOptions through vm.rs; D2015+D1012 in FilterByBytecode"
+```
+
+---
+
+## Task 10: `lib.rs` — thread `EvaluatorOptions` through the PyO3 boundary
+
+**Files:**
+- Modify: `src/lib.rs:154-349` (`JsonataExpression` struct/impl, `compile`, `evaluate`), `src/lib.rs:519-535` (`create_evaluator`)
+
+**Interfaces:**
+- Produces: `compile(expression, timeout=None, max_stack_depth=None, max_sequence_length=None)`, `evaluate(expression, data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None)`, and the same three new kwargs on all 4 `JsonataExpression` `#[pymethods]` (`evaluate`, `evaluate_with_data`, `evaluate_data_to_json`, `evaluate_json`).
+
+- [ ] **Step 1: Add a shared kwargs-to-`EvaluatorOptions` helper**
+
+Add near `create_evaluator` (`src/lib.rs`, just before its current definition at line 519):
+```rust
+#[cfg(feature = "python")]
+fn build_evaluator_options(
+    timeout: Option<u64>,
+    max_stack_depth: Option<usize>,
+    max_sequence_length: Option<usize>,
+) -> evaluator::EvaluatorOptions {
+    evaluator::EvaluatorOptions {
+        timeout_ms: timeout,
+        max_stack_depth,
+        max_sequence_length,
+    }
+}
+```
+
+- [ ] **Step 2: Thread options through `create_evaluator`**
+
+Current (`src/lib.rs:519-535`):
+```rust
+fn create_evaluator(py: Python, bindings: Option<Py<PyAny>>) -> PyResult<evaluator::Evaluator> {
+    if let Some(bindings_obj) = bindings {
+        let bindings_json = python_to_json(py, &bindings_obj)?;
+
+        let mut context = evaluator::Context::new();
+        if let JValue::Object(map) = bindings_json {
+            for (key, value) in map.iter() {
+                context.bind(key.clone(), value.clone());
+            }
+        } else {
+            return Err(PyTypeError::new_err("bindings must be a dictionary"));
+        }
+        Ok(evaluator::Evaluator::with_context(context))
+    } else {
+        Ok(evaluator::Evaluator::new())
+    }
+}
+```
+Replace with:
+```rust
+fn create_evaluator(
+    py: Python,
+    bindings: Option<Py<PyAny>>,
+    options: evaluator::EvaluatorOptions,
+) -> PyResult<evaluator::Evaluator> {
+    let mut context = evaluator::Context::new();
+    if let Some(bindings_obj) = bindings {
+        let bindings_json = python_to_json(py, &bindings_obj)?;
+        if let JValue::Object(map) = bindings_json {
+            for (key, value) in map.iter() {
+                context.bind(key.clone(), value.clone());
+            }
+        } else {
+            return Err(PyTypeError::new_err("bindings must be a dictionary"));
+        }
+    }
+    Ok(evaluator::Evaluator::with_options(context, options))
+}
+```
+(This also simplifies the branch: `with_options` is now used unconditionally, since it behaves identically to `new()`/`with_context()` when `options` is `EvaluatorOptions::default()`.)
+
+- [ ] **Step 3: Thread options through `JsonataExpression::run_eval` and all 4 `#[pymethods]`**
+
+Current (`src/lib.rs:167-185`):
+```rust
+    fn run_eval(&self, py: Python, data: &JValue, bindings: Option<Py<PyAny>>) -> PyResult<JValue> {
+        if bindings.is_none() {
+            let bytecode = self.bytecode.get_or_init(|| {
+                evaluator::try_compile_expr(&self.ast)
+                    .map(|ce| compiler::BytecodeCompiler::compile(&ce))
+            });
+            if let Some(bc) = bytecode {
+                vm::Vm::new(bc)
+                    .run(data, None)
+                    .map_err(evaluator_error_to_py)
+            } else {
+                let mut ev = evaluator::Evaluator::new();
+                ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
+            }
+        } else {
+            let mut ev = create_evaluator(py, bindings)?;
+            ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
+        }
+    }
+```
+Replace with:
+```rust
+    fn run_eval(
+        &self,
+        py: Python,
+        data: &JValue,
+        bindings: Option<Py<PyAny>>,
+        options: evaluator::EvaluatorOptions,
+    ) -> PyResult<JValue> {
+        if bindings.is_none() {
+            let bytecode = self.bytecode.get_or_init(|| {
+                evaluator::try_compile_expr(&self.ast)
+                    .map(|ce| compiler::BytecodeCompiler::compile(&ce))
+            });
+            if let Some(bc) = bytecode {
+                vm::Vm::with_options(bc, options.clone())
+                    .run(data, None)
+                    .map_err(evaluator_error_to_py)
+            } else {
+                let mut ev = evaluator::Evaluator::with_options(evaluator::Context::new(), options);
+                ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
+            }
+        } else {
+            let mut ev = create_evaluator(py, bindings, options)?;
+            ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
+        }
+    }
+```
+Then update every one of the 4 `#[pymethods]` (`src/lib.rs:192-274`) to add the 3 new kwargs and pass them through. Current `evaluate`:
+```rust
+    #[pyo3(signature = (data, bindings=None))]
+    fn evaluate(
+        &self,
+        py: Python,
+        data: Py<PyAny>,
+        bindings: Option<Py<PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
+        let json_data = python_to_json(py, &data)?;
+        json_to_python(py, &self.run_eval(py, &json_data, bindings)?)
+    }
+```
+Replace with:
+```rust
+    #[pyo3(signature = (data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn evaluate(
+        &self,
+        py: Python,
+        data: Py<PyAny>,
+        bindings: Option<Py<PyAny>>,
+        timeout: Option<u64>,
+        max_stack_depth: Option<usize>,
+        max_sequence_length: Option<usize>,
+    ) -> PyResult<Py<PyAny>> {
+        let json_data = python_to_json(py, &data)?;
+        let options = build_evaluator_options(timeout, max_stack_depth, max_sequence_length);
+        json_to_python(py, &self.run_eval(py, &json_data, bindings, options)?)
+    }
+```
+Apply the same pattern (add the 3 kwargs to the `#[pyo3(signature = ...)]` attribute and function parameters, build `options` via `build_evaluator_options`, pass `options` as `run_eval`'s new 4th argument) to `evaluate_with_data` (`:213-221`), `evaluate_data_to_json` (`:233-243`), and `evaluate_json` (`:262-274`) — each follows the identical shape, only the first positional parameter (`data: &JsonataData` / `data: &JsonataData` / `json_str: &str`) and return-value construction differs; keep those parts unchanged.
+
+- [ ] **Step 4: Thread options through the 2 free functions `compile`/`evaluate`**
+
+`compile()` doesn't need new kwargs itself per the design spec (guardrails are per-*evaluation*, not baked into a compiled `JsonataExpression` — reread the spec's Python API example: `jsonatapy.compile("...", timeout=5000)` followed by `expr.evaluate(data)` with NO `timeout` kwarg at the call site — this means `compile()` DOES take the guardrail kwargs, and they must be remembered on the `JsonataExpression` instance for later `evaluate()` calls that don't repeat them). Re-examine: **this changes the design** — `JsonataExpression` needs to optionally store a "default options" set from `compile()`, and each `evaluate*()` call's own kwargs (Step 3) should override the stored default per-call, not require re-specifying every time.
+
+Current `JsonataExpression` struct (`src/lib.rs:152-161`):
+```rust
+#[cfg(feature = "python")]
+#[pyclass(unsendable)]
+struct JsonataExpression {
+    ast: ast::AstNode,
+    bytecode: std::cell::OnceCell<Option<vm::BytecodeProgram>>,
+}
+```
+Replace with:
+```rust
+#[cfg(feature = "python")]
+#[pyclass(unsendable)]
+struct JsonataExpression {
+    ast: ast::AstNode,
+    bytecode: std::cell::OnceCell<Option<vm::BytecodeProgram>>,
+    default_options: evaluator::EvaluatorOptions,
+}
+```
+Current `compile()` free function (`src/lib.rs:300-309`):
+```rust
+#[cfg(feature = "python")]
+#[pyfunction]
+fn compile(expression: &str) -> PyResult<JsonataExpression> {
+    let ast = parser::parse(expression).map_err(parser_error_to_py)?;
+
+    Ok(JsonataExpression {
+        ast,
+        bytecode: std::cell::OnceCell::new(),
+    })
+}
+```
+Replace with:
+```rust
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (expression, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+fn compile(
+    expression: &str,
+    timeout: Option<u64>,
+    max_stack_depth: Option<usize>,
+    max_sequence_length: Option<usize>,
+) -> PyResult<JsonataExpression> {
+    let ast = parser::parse(expression).map_err(parser_error_to_py)?;
+
+    Ok(JsonataExpression {
+        ast,
+        bytecode: std::cell::OnceCell::new(),
+        default_options: build_evaluator_options(timeout, max_stack_depth, max_sequence_length),
+    })
+}
+```
+Then, in EACH of the 4 `#[pymethods]` (Step 3), change `build_evaluator_options(...)` construction to fall back to `self.default_options` per-field when a given call's kwarg is `None` — e.g. `evaluate`'s body becomes:
+```rust
+        let json_data = python_to_json(py, &data)?;
+        let options = evaluator::EvaluatorOptions {
+            timeout_ms: timeout.or(self.default_options.timeout_ms),
+            max_stack_depth: max_stack_depth.or(self.default_options.max_stack_depth),
+            max_sequence_length: max_sequence_length.or(self.default_options.max_sequence_length),
+        };
+        json_to_python(py, &self.run_eval(py, &json_data, bindings, options)?)
+```
+Apply the same 3-field `.or(self.default_options.<field>)` merge in the other 3 methods, replacing their `build_evaluator_options(...)` call. (`build_evaluator_options` from Step 1 is still used, unchanged, by the free-standing `evaluate()` function below and by `compile()` above, where there's no "existing defaults" to merge with.)
+
+Current free-function `evaluate()` (`src/lib.rs:338-349`):
+```rust
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (expression, data, bindings=None))]
+fn evaluate(
+    py: Python,
+    expression: &str,
+    data: Py<PyAny>,
+    bindings: Option<Py<PyAny>>,
+) -> PyResult<Py<PyAny>> {
+    let expr = compile(expression)?;
+    expr.evaluate(py, data, bindings)
+}
+```
+Replace with:
+```rust
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (expression, data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+#[allow(clippy::too_many_arguments)]
+fn evaluate(
+    py: Python,
+    expression: &str,
+    data: Py<PyAny>,
+    bindings: Option<Py<PyAny>>,
+    timeout: Option<u64>,
+    max_stack_depth: Option<usize>,
+    max_sequence_length: Option<usize>,
+) -> PyResult<Py<PyAny>> {
+    let expr = compile(expression, None, None, None)?;
+    expr.evaluate(py, data, bindings, timeout, max_stack_depth, max_sequence_length)
+}
+```
+
+- [ ] **Step 5: Compile and fix fallout**
+
+Run: `cargo build --features python --lib 2>&1 | tail -80` (this crate's `python` feature must be enabled to compile `lib.rs`'s PyO3 code — check `Cargo.toml`/`pyproject.toml` for the exact feature name and build command already used elsewhere, e.g. `maturin develop --release` implicitly enables it). Fix any remaining call-site mismatches (e.g. the `_bench` facade at `src/lib.rs:52-` if it constructs `JsonataExpression`/calls `compile` directly — check with `grep -n "JsonataExpression {" src/lib.rs` for any other struct-literal site besides `compile()`).
+Run: `maturin develop --release`
+Run: `uv run pytest tests/python/test_reference_suite.py -q` — expect 1682/1682 (no reference-suite case passes these kwargs, so this is a pure regression check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "feat(guardrails): expose timeout/max_stack_depth/max_sequence_length kwargs at the PyO3 boundary"
+```
+
+---
+
+## Task 11: Python-level `jsonatapy` wrappers — kwargs and type hints
+
+**Files:**
+- Modify: `python/jsonatapy/__init__.py:115-328` (`JsonataExpression` class, `compile()`, `evaluate()`)
+
+**Interfaces:**
+- Produces: `jsonatapy.compile(expression, *, timeout=None, max_stack_depth=None, max_sequence_length=None)`, `jsonatapy.evaluate(expression, data, bindings=None, *, timeout=None, max_stack_depth=None, max_sequence_length=None)`, and matching kwargs on all 4 `JsonataExpression` methods and its `compile()` classmethod.
+
+- [ ] **Step 1: Update `JsonataExpression.evaluate` and its 3 siblings**
+
+Current (`python/jsonatapy/__init__.py:144-165`):
+```python
+    def evaluate(self, data: Any, bindings: dict[str, Any] | None = None) -> Any:
+        """
+        Evaluate this expression against data.
+
+        Args:
+            data: The data to query/transform (typically a dict or list)
+            bindings: Optional additional variable bindings
+
+        Returns:
+            The result of evaluating the expression
+
+        Raises:
+            ValueError: If evaluation fails
+
+        Example:
+            >>> expr = compile("orders[price > 100]")
+            >>> data = {"orders": [{"price": 150}, {"price": 50}]}
+            >>> result = expr.evaluate(data)
+            >>> print(len(result))
+            1
+        """
+        return self._expr.evaluate(data, bindings)
+```
+Replace with:
+```python
+    def evaluate(
+        self,
+        data: Any,
+        bindings: dict[str, Any] | None = None,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
+    ) -> Any:
+        """
+        Evaluate this expression against data.
+
+        Args:
+            data: The data to query/transform (typically a dict or list)
+            bindings: Optional additional variable bindings
+            timeout: Maximum evaluation time in milliseconds (raises ValueError
+                with a D1012 code on timeout). Overrides any default set via
+                `compile(timeout=...)` for this call only.
+            max_stack_depth: Maximum recursion stack depth (raises ValueError
+                with a D1011 code when exceeded). Overrides any compile-time default.
+            max_sequence_length: Maximum length of a query-result sequence
+                (map/filter/wildcard/descendants/etc; raises ValueError with a
+                D2015 code when exceeded). Overrides any compile-time default.
+
+        Returns:
+            The result of evaluating the expression
+
+        Raises:
+            ValueError: If evaluation fails, or a guardrail is exceeded
+
+        Example:
+            >>> expr = compile("orders[price > 100]")
+            >>> data = {"orders": [{"price": 150}, {"price": 50}]}
+            >>> result = expr.evaluate(data)
+            >>> print(len(result))
+            1
+        """
+        return self._expr.evaluate(
+            data, bindings, timeout, max_stack_depth, max_sequence_length
+        )
+```
+Apply the identical `*, timeout, max_stack_depth, max_sequence_length` kwarg addition (same docstring args block, same trailing-argument pass-through) to `evaluate_json` (`:167-197`), `evaluate_with_data` (`:199-220`), and `evaluate_data_to_json` (`:222-249`) — each's positional-argument-forwarding call to `self._expr.<method>(...)` gains the same 3 trailing arguments.
+
+- [ ] **Step 2: Update `JsonataExpression.compile` classmethod and `__init__`**
+
+Current (`python/jsonatapy/__init__.py:251-270`):
+```python
+    @classmethod
+    def compile(cls, expression: str) -> "JsonataExpression":
+        """
+        Compile a JSONata expression.
+
+        This is an alternative constructor that compiles an expression string.
+
+        Args:
+            expression: A JSONata expression string
+
+        Returns:
+            A compiled JsonataExpression
+
+        Raises:
+            ValueError: If the expression cannot be parsed
+
+        Example:
+            >>> expr = JsonataExpression.compile("$.name")
+        """
+        return cls(_compile(expression))
+```
+Replace with:
+```python
+    @classmethod
+    def compile(
+        cls,
+        expression: str,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
+    ) -> "JsonataExpression":
+        """
+        Compile a JSONata expression.
+
+        This is an alternative constructor that compiles an expression string.
+
+        Args:
+            expression: A JSONata expression string
+            timeout: Default max evaluation time in milliseconds for all
+                evaluate*() calls on this expression (can be overridden per-call).
+            max_stack_depth: Default max recursion stack depth (can be overridden per-call).
+            max_sequence_length: Default max query-result sequence length
+                (can be overridden per-call).
+
+        Returns:
+            A compiled JsonataExpression
+
+        Raises:
+            ValueError: If the expression cannot be parsed
+
+        Example:
+            >>> expr = JsonataExpression.compile("$.name")
+            >>> expr = JsonataExpression.compile("$.name", timeout=5000)
+        """
+        return cls(_compile(expression, timeout, max_stack_depth, max_sequence_length))
+```
+
+- [ ] **Step 3: Update the module-level `compile()` and `evaluate()` functions**
+
+Current (`python/jsonatapy/__init__.py:273-295`):
+```python
+def compile(expression: str) -> JsonataExpression:
+    """
+    Compile a JSONata expression into an executable form.
+
+    Args:
+        expression: A JSONata query/transformation expression string
+
+    Returns:
+        A compiled JsonataExpression that can be evaluated multiple times
+
+    Raises:
+        ValueError: If the expression cannot be parsed
+
+    Example:
+        >>> expr = compile("orders[price > 100].product")
+        >>> result = expr.evaluate(data)
+
+    Note:
+        Compiling an expression once and evaluating it multiple times
+        is more efficient than calling `evaluate()` repeatedly with
+        the same expression string.
+    """
+    return JsonataExpression(_compile(expression))
+```
+Replace with:
+```python
+def compile(
+    expression: str,
+    *,
+    timeout: int | None = None,
+    max_stack_depth: int | None = None,
+    max_sequence_length: int | None = None,
+) -> JsonataExpression:
+    """
+    Compile a JSONata expression into an executable form.
+
+    Args:
+        expression: A JSONata query/transformation expression string
+        timeout: Default max evaluation time in milliseconds for all
+            evaluate*() calls on this expression (can be overridden per-call).
+        max_stack_depth: Default max recursion stack depth (can be overridden per-call).
+        max_sequence_length: Default max query-result sequence length
+            (can be overridden per-call).
+
+    Returns:
+        A compiled JsonataExpression that can be evaluated multiple times
+
+    Raises:
+        ValueError: If the expression cannot be parsed
+
+    Example:
+        >>> expr = compile("orders[price > 100].product")
+        >>> result = expr.evaluate(data)
+        >>> expr = compile("$sum(items.price)", timeout=5000)
+
+    Note:
+        Compiling an expression once and evaluating it multiple times
+        is more efficient than calling `evaluate()` repeatedly with
+        the same expression string.
+    """
+    return JsonataExpression(_compile(expression, timeout, max_stack_depth, max_sequence_length))
+```
+Current (`python/jsonatapy/__init__.py:298-327`):
+```python
+def evaluate(expression: str, data: Any, bindings: dict[str, Any] | None = None) -> Any:
+    """
+    ...
+    """
+    return _evaluate(expression, data, bindings)
+```
+Replace with:
+```python
+def evaluate(
+    expression: str,
+    data: Any,
+    bindings: dict[str, Any] | None = None,
+    *,
+    timeout: int | None = None,
+    max_stack_depth: int | None = None,
+    max_sequence_length: int | None = None,
+) -> Any:
+    """
+    Compile and evaluate a JSONata expression in one step.
+
+    This is a convenience function for one-off evaluations.
+    For repeated evaluations, use `compile()` instead.
+
+    Args:
+        expression: A JSONata query/transformation expression string
+        data: The data to query/transform (typically a dict or list)
+        bindings: Optional additional variable bindings
+        timeout: Maximum evaluation time in milliseconds (raises ValueError
+            with a D1012 code on timeout).
+        max_stack_depth: Maximum recursion stack depth (raises ValueError
+            with a D1011 code when exceeded).
+        max_sequence_length: Maximum length of a query-result sequence
+            (raises ValueError with a D2015 code when exceeded).
+
+    Returns:
+        The result of evaluating the expression
+
+    Raises:
+        ValueError: If parsing or evaluation fails, or a guardrail is exceeded
+
+    Example:
+        >>> data = {"name": "alice"}
+        >>> result = evaluate("$uppercase(name)", data)
+        >>> print(result)
+        "ALICE"
+
+        >>> # With bindings
+        >>> result = evaluate("name & suffix", {"name": "Hello"}, {"suffix": "!"})
+        >>> print(result)
+        "Hello!"
+
+        >>> # With a timeout guardrail
+        >>> evaluate("$inf := function(){$inf()}; $inf()", {}, timeout=100)
+        Traceback (most recent call last):
+            ...
+        ValueError: D1012: Evaluation timeout after 100 milliseconds. Check for infinite loop
+    """
+    return _evaluate(expression, data, bindings, timeout, max_stack_depth, max_sequence_length)
+```
+
+- [ ] **Step 4: Verify with ruff/mypy**
+
+Run: `ruff check python/jsonatapy/__init__.py`
+Run: `mypy python/jsonatapy/__init__.py` (or the project's configured mypy invocation — check `pyproject.toml`'s `[tool.mypy]` section for the exact target if a bare `mypy python/` is what's normally run)
+Expected: clean on both.
+
+- [ ] **Step 5: Rebuild and smoke-test manually**
+
+Run: `maturin develop --release`
+Run:
+```bash
+uv run python -c "
+import jsonatapy
+try:
+    jsonatapy.evaluate('(\$inf := function(){\$inf()}; \$inf())', {}, timeout=100)
+    print('FAIL: expected ValueError')
+except ValueError as e:
+    print('OK:', e)
+"
+```
+Expected output: `OK: D1012: ...` (or similar — confirms the whole chain works end-to-end before writing the full pytest suite in Task 12).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/jsonatapy/__init__.py
+git commit -m "feat(guardrails): expose timeout/max_stack_depth/max_sequence_length kwargs in the Python API"
+```
+
+---
+
+## Task 12: `tests/python/test_guardrails.py` — comprehensive guardrail test suite
+
+**Files:**
+- Create: `tests/python/test_guardrails.py`
+
+**Interfaces:**
+- Consumes: `jsonatapy.evaluate`, `jsonatapy.compile`, `jsonatapy.JsonataExpression` (all from Tasks 10-11).
+
+- [ ] **Step 1: Write the test file**
+
+```python
+"""Tests for the resource-guardrails feature (timeout/max_stack_depth/max_sequence_length).
+
+Mirrors jsonata-js 2.2.1's guardrails: D1011 (stack), D1012 (timeout), D2015 (sequence).
+See docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md, Phase 2.
+"""
+
+import pytest
+
+import jsonatapy
+
+
+def _force_tree_walker(expr: jsonatapy.JsonataExpression, data, **guardrails):
+    """Force the tree-walker fallback by passing a non-None bindings dict
+    (even empty), per the mechanism `JsonataExpression.run_eval` uses in
+    `src/lib.rs`: any non-None `bindings` always routes through
+    `create_evaluator()`/`Evaluator::with_options()`, bypassing the cached
+    bytecode VM entirely."""
+    return expr.evaluate(data, bindings={}, **guardrails)
+
+
+class TestStackDepthD1011:
+    def test_recursive_lambda_raises_d1011(self):
+        expr = "($inf := function($n){$n+$inf($n-1)}; $inf(5))"
+        with pytest.raises(ValueError, match="D1011"):
+            jsonatapy.evaluate(expr, None, max_stack_depth=10)
+
+    def test_without_option_recursive_lambda_raises_u1001_not_d1011(self):
+        # No max_stack_depth set: the hardcoded native-stack backstop (U1001)
+        # is what fires, not D1011.
+        expr = "($inf := function($n){$n+$inf($n-1)}; $inf(5))"
+        with pytest.raises(ValueError, match="U1001"):
+            jsonatapy.evaluate(expr, None)
+
+    def test_parity_vm_vs_tree_walker(self):
+        # Self-recursive named lambdas can't compile to CompiledExpr (no
+        # "call named lambda" IR node exists), so both the default (VM-
+        # preferred) path and the bindings-forced tree-walker path fall
+        # through to the same guarded evaluate_internal/evaluate_internal_impl
+        # code — this is true "for free", not because of extra plumbing.
+        expr_str = "($inf := function($n){$n+$inf($n-1)}; $inf(5))"
+        compiled = jsonatapy.compile(expr_str)
+        with pytest.raises(ValueError, match="D1011"):
+            compiled.evaluate(None, max_stack_depth=10)
+        with pytest.raises(ValueError, match="D1011"):
+            _force_tree_walker(compiled, None, max_stack_depth=10)
+
+
+class TestTimeoutD1012:
+    def test_slow_expression_raises_d1012(self):
+        expr = "(" + "+".join(["1"] * 200_000) + ")"
+        with pytest.raises(ValueError, match="D1012"):
+            jsonatapy.evaluate(expr, None, timeout=1)
+
+    def test_without_option_never_times_out(self):
+        expr = "(" + "+".join(["1"] * 50_000) + ")"
+        result = jsonatapy.evaluate(expr, None)
+        assert result == 50_000
+
+    def test_compiled_map_fast_path_raises_d1012(self):
+        # Forces the eval_compiled_inner MapCall loop, which bypasses
+        # evaluate_internal's per-node checkpoint entirely — the timeout
+        # check here is a deliberate extension beyond the design spec's
+        # literal text (which only mentions checking at evaluate_internal).
+        data = {"items": list(range(500_000))}
+        with pytest.raises(ValueError, match="D1012"):
+            jsonatapy.evaluate("$map(items, function($x){$x*2})", data, timeout=1)
+
+    def test_parity_vm_vs_tree_walker_vs_compiled(self):
+        data = {"items": list(range(500_000))}
+        compiled = jsonatapy.compile("$map(items, function($x){$x*2})")
+        with pytest.raises(ValueError, match="D1012"):
+            compiled.evaluate(data, timeout=1)
+        with pytest.raises(ValueError, match="D1012"):
+            _force_tree_walker(compiled, data, timeout=1)
+
+
+class TestSequenceLengthD2015:
+    @pytest.mark.parametrize(
+        "expr,data",
+        [
+            ("[1..1000]", None),
+            ("items.name", {"items": [{"name": f"n{i}"} for i in range(1000)]}),
+            ("*", {f"k{i}": i for i in range(1000)}),
+            ("**", {"items": [{"v": i} for i in range(1000)]}),
+            ("$keys(items)", {"items": [{f"k{i}": 1} for i in range(1000)]}),
+            ("$lookup(items, 'v')", {"items": [{"v": i} for i in range(1000)]}),
+            ("$append(a, b)", {"a": list(range(500)), "b": list(range(500))}),
+            (
+                "$spread(items)",
+                {"items": [{f"k{i}": i} for i in range(1000)]},
+            ),
+            (
+                "$each(items, function($v){$v})",
+                {"items": {f"k{i}": i for i in range(1000)}},
+            ),
+        ],
+    )
+    def test_raises_d2015_generic_tree_walker_path(self, expr, data):
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(expr, data, max_sequence_length=10)
+
+    def test_map_raises_d2015_both_fast_and_generic_path(self):
+        data = {"items": list(range(1000))}
+        # Compilable lambda body -> CompiledExpr::MapCall fast path
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$map(items, function($x){$x*2})", data, max_sequence_length=10
+            )
+        # Non-compilable lambda body (`$x.*` has no CompiledExpr::Wildcard arm)
+        # -> generic tree-walker loop
+        data2 = {"items": [{"a": i} for i in range(1000)]}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$map(items, function($x){$x.*})", data2, max_sequence_length=10
+            )
+
+    def test_filter_raises_d2015(self):
+        data = {"items": list(range(1000))}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$filter(items, function($x){$x >= 0})",
+                data,
+                max_sequence_length=10,
+            )
+
+    def test_predicate_filter_raises_d2015_pure_vm_path(self):
+        # `items[price > 0]` compiles fully to bytecode (GetDataField +
+        # FilterByBytecode) when there's no bindings -> pure VM path, no
+        # tree-walker/eval_compiled fallback involved at all.
+        data = {"items": [{"price": i} for i in range(1000)]}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate("items[price >= 0]", data, max_sequence_length=10)
+
+    def test_predicate_filter_parity_vm_vs_tree_walker(self):
+        data = {"items": [{"price": i} for i in range(1000)]}
+        compiled = jsonatapy.compile("items[price >= 0]")
+        with pytest.raises(ValueError, match="D2015"):
+            compiled.evaluate(data, max_sequence_length=10)
+        with pytest.raises(ValueError, match="D2015"):
+            _force_tree_walker(compiled, data, max_sequence_length=10)
+
+    def test_without_option_no_cap(self):
+        data = {"items": list(range(1000))}
+        result = jsonatapy.evaluate("items", data)
+        assert len(result) == 1000
+
+    def test_reduce_accumulator_itself_uncapped_but_append_inside_it_is_capped(self):
+        # $reduce has no createSequence() call upstream (jsonata-js
+        # functions.js) - its accumulator is intentionally NOT subject to
+        # max_sequence_length, even if the accumulator happens to be an array.
+        # This expression's accumulator grows via repeated $append calls
+        # (0, 1, 2, ... elements); $append's own pre-check is
+        # `arr.len() + second_len > max`, so it raises as soon as the
+        # accumulator already holds `max` elements and a further single-item
+        # append would exceed it — i.e. on the 11th call (10 + 1 > 10), long
+        # before $reduce's own (uncapped) loop would reach 1000 iterations.
+        # This confirms the cap comes from $append's independent guard, not
+        # from $reduce itself capping its accumulator.
+        data = {"items": list(range(1000))}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$reduce(items, function($acc, $x){$append($acc, $x)}, [])",
+                data,
+                max_sequence_length=10,
+            )
+
+
+class TestCompileTimeDefaults:
+    def test_compile_time_default_applies_to_evaluate_without_kwargs(self):
+        expr = jsonatapy.compile(
+            "($inf := function($n){$n+$inf($n-1)}; $inf(5))", max_stack_depth=10
+        )
+        with pytest.raises(ValueError, match="D1011"):
+            expr.evaluate(None)
+
+    def test_per_call_kwarg_overrides_compile_time_default(self):
+        expr = jsonatapy.compile(
+            "($inf := function($n){$n+$inf($n-1)}; $inf(5))", max_stack_depth=10
+        )
+        # Override with a much higher limit at call time - should now hit the
+        # hardcoded U1001 ceiling instead of D1011, or succeed if the
+        # recursion terminates within both limits (it won't terminate - $inf
+        # has no base case - so expect U1001 here).
+        with pytest.raises(ValueError, match="U1001"):
+            expr.evaluate(None, max_stack_depth=100_000)
+```
+
+- [ ] **Step 2: Run the suite, fix issues as they surface**
+
+Run: `uv run pytest tests/python/test_guardrails.py -v`
+Expected: all tests pass given Tasks 1-11 are complete. Any test that fails unexpectedly indicates either a gap in Tasks 1-11 (go back and fix the corresponding Rust site) or an incorrect assumption in the test itself (e.g. whether a given expression really takes the code path the test's comment claims — verify with a temporary `eprintln!` in the relevant arm if a test's pass/fail doesn't match its stated intent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/python/test_guardrails.py
+git commit -m "test(guardrails): comprehensive D1011/D1012/D2015 test suite with VM/tree-walker parity"
+```
+
+---
+
+## Task 13: Final verification pass and spec update
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md` (Status section)
+
+**Interfaces:** None — this task is verification and documentation only.
+
+- [ ] **Step 1: Full Rust verification**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+Expected: all clean/green.
+
+- [ ] **Step 2: Full Python verification**
+
+```bash
+maturin develop --release
+uv run pytest tests/python/ -v
+ruff check python/ tests/
+mypy python/
+```
+Expected: `tests/python/test_reference_suite.py` at 1682/1682 (unchanged from before this plan — no reference-suite case exercises guardrails), all of `tests/python/test_guardrails.py` green, `ruff`/`mypy` clean.
+
+- [ ] **Step 3: Update the design spec's Status section**
+
+Current (`docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md:1-17`):
+```markdown
+# jsonata-js 2.2.1 compatibility upgrade
+
+## Status (as of 2026-07-05)
+
+**Phase 1 is done and merged** (`bbce6e7`, "jsonata-js 2.2.1 Phase 1: signature engine rewrite for
++/- support", #36). The submodule is bumped to `v2.2.1` on `main` and the reference suite passes
+1274/1274 — all shipped under jsonatapy `2.1.5`, no version bump needed, since Phase 1 was pure
+bug-fix/parity work.
+
+**Phase 2 (guardrails) is deferred, on hold.** Decision: since Phase 2 is a new-feature addition
+(not a bug fix) and is the *only* reason a `2.2.0` jsonatapy release would ever make sense, it's
+being put on hold rather than pursued for its own sake. Priority instead goes to
+`docs/superpowers/specs/2026-07-05-reference-suite-coverage-gap-design.md` — a separate, unrelated
+reference-suite coverage gap (408 previously-untested cases, ~325 real failures) discovered while
+investigating this upgrade, entirely fixable as ordinary `2.1.x` patch releases with no dependency
+on Phase 2 either way. Do that work first; revisit Phase 2 afterward if/when guardrails parity is
+actually wanted.
+```
+Replace the "Phase 2" paragraph with (fill in the actual commit hash after Task 12's commit):
+```markdown
+**Phase 2 (guardrails) is done**, implemented per
+`docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md`. `EvaluatorOptions`
+(`timeout_ms`/`max_stack_depth`/`max_sequence_length`) is threaded through all three execution
+surfaces (tree-walker, bytecode VM, `eval_compiled` fast-path interpreter), raising D1011/D1012/
+D2015 respectively, with parity verified between the VM-preferred and forced-tree-walker paths.
+Two corrections were made to this document's original construct list during implementation
+(verified against `tests/jsonata-js/src/*.js`): `$sift` is NOT sequence-capped upstream (excluded);
+`$lookup` IS sequence-capped upstream (added, wasn't originally listed). A version bump/release
+(this is the first behavioral reason for a `2.2.0`, per the original Scope note below) is a
+separate follow-up decision, not part of this implementation.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
+git commit -m "docs: mark jsonata-js 2.2.1 Phase 2 (guardrails) as done"
+```

--- a/docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md
+++ b/docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md
@@ -14,6 +14,13 @@
 - `Evaluator::new()` and `Evaluator::with_context()` keep their exact current signatures — existing Rust callers (tests, benches, examples) must not need changes.
 - The hardcoded native-stack safety net (`max_recursion_depth = 302`, U1001) is an always-on backstop regardless of user options (GitHub issue #34) — never relaxed by a user-supplied `max_stack_depth` higher than 302.
 - D2015 applies only to *query-result* sequences, never to literal array construction (`[1,2,3]`) — this exclusion is load-bearing; verify it holds at every site.
+  **Post-implementation correction (final review, 2026-07-07):** this exclusion does NOT match
+  upstream for flat/non-nested literals — jsonata-js's array-literal evaluation routes each
+  non-nested element through `fn.append`'s `createSequence` cap, so `[1,2,3,4,5]` with
+  `sequence: 2` raises D2015 upstream. The Rust port's exclusion here was implemented as designed
+  and is a deliberate, temporary divergence (deferred behind the separate `MakeArray(u16)`
+  truncation bug), not a faithful match to upstream — see the design spec's "Sequence length →
+  D2015" section for the corrected, current-state explanation.
 - `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` must stay clean throughout. `uv run pytest tests/python/test_reference_suite.py` must stay at 1682/1682 (no reference-suite case exercises guardrails, so this is a pure regression check).
 - Error message format matches existing convention: the code is embedded in the `EvaluatorError::EvaluationError(String)` payload as `"CODE: message"` — there is no structured error-code field to add (see Task 1 note).
 

--- a/docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
+++ b/docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
@@ -1,5 +1,54 @@
 # jsonata-js 2.2.1 compatibility upgrade
 
+## Status (as of 2026-07-07)
+
+**Phase 1 is done and merged** (`bbce6e7`, "jsonata-js 2.2.1 Phase 1: signature engine rewrite for
++/- support", #36). The submodule is bumped to `v2.2.1` on `main` and the reference suite passes
+1274/1274 — all shipped under jsonatapy `2.1.5`, no version bump needed, since Phase 1 was pure
+bug-fix/parity work.
+
+**Phase 2 (guardrails) is done**, implemented per the 13-task
+`docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md`, all tasks committed
+on this branch. `EvaluatorOptions` (`timeout_ms`/`max_stack_depth`/`max_sequence_length`, all
+`Option<_>`, default `None` = unlimited/unchanged behavior) is threaded through all three
+execution surfaces this port has grown beyond jsonata-js's single-engine model — the tree-walker,
+the "compiled expression" fast-path interpreter (`eval_compiled`), and the bytecode VM (`vm.rs`) —
+raising `D1011` (stack depth), `D1012` (timeout), and `D2015` (sequence length) respectively.
+Parity across all three surfaces is verified by a dedicated test suite
+(`tests/python/test_guardrails.py`, 26 cases, plus Rust-side coverage in
+`tests/integration_test.rs` and `src/vm.rs`'s `#[cfg(test)]` module) that exercises both the
+VM-preferred path and the path forced through the tree-walker fallback.
+
+Two corrections were made to this document's original D2015 construct list (see the "Sequence
+length → D2015" section below) during implementation, verified against
+`tests/jsonata-js/src/{jsonata,functions}.js` directly rather than just this spec's summary of it:
+`$sift` is **not** sequence-capped upstream (`sift()` returns a plain filtered object, no
+`createSequence()` call — excluded, despite being named in the original list below); `$lookup`
+**is** sequence-capped upstream (`functions.js`'s array-fanout branch calls `createSequence()` —
+added, despite not being in the original list below).
+
+One structural decision went beyond the original plan text: rather than enumerating every call
+site in compiled/HOF code that could bypass the `D1012` timeout check, a single checkpoint was
+placed at the entry of `eval_compiled_inner` (the compiled-expression interpreter's single funnel
+point) plus one inside the TCO trampoline (`invoke_lambda_with_tco`) — these are the two execution
+loops that are genuinely independent of each other and of `evaluate_internal`'s own per-node
+checkpoint, so no other site needed its own separate check.
+
+Two pre-existing bugs were found along the way. Both are **out of scope for this plan and were
+NOT fixed** — they're recorded here for future work, not claimed as resolved:
+- The parser has no recursion-depth guard and can crash the whole process (SIGSEGV) on deeply
+  left-nested arithmetic expressions (roughly 4000+ terms) — independent of, and prior to, the
+  evaluator's own `D1011`/`U1001` guards, which never get a chance to run since the crash happens
+  during parsing, before evaluation starts.
+- `Instr::MakeArray(u16)` (`src/compiler.rs`) silently produces **wrong, truncated** results — not
+  even an error — for JSONata array literals with more than 65,536 elements, because the element
+  count is cast to `u16` and overflows silently. This is more severe than the parser crash (silent
+  data corruption vs. a loud failure) and should be prioritized in any follow-up.
+
+Per this document's Scope section below, Phase 2 is the first behavioral reason a `2.2.0`
+jsonatapy release would make sense — a version bump/release is a separate follow-up decision, not
+part of this implementation.
+
 ## Context
 
 `tests/jsonata-js` (the reference test-suite submodule) is currently pinned at `v2.1.0-3-gff36f0b`

--- a/docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
+++ b/docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
@@ -13,7 +13,12 @@ on this branch. `EvaluatorOptions` (`timeout_ms`/`max_stack_depth`/`max_sequence
 `Option<_>`, default `None` = unlimited/unchanged behavior) is threaded through all three
 execution surfaces this port has grown beyond jsonata-js's single-engine model — the tree-walker,
 the "compiled expression" fast-path interpreter (`eval_compiled`), and the bytecode VM (`vm.rs`) —
-raising `D1011` (stack depth), `D1012` (timeout), and `D2015` (sequence length) respectively.
+raising `D1011` (stack depth), `D1012` (timeout), and `D2015` (sequence length) as applicable —
+these are not a 1:1 mapping to the three surfaces: `D1011` is tree-walker-only (self-recursive
+lambdas can't compile into `eval_compiled` or the VM), while both `D1012` and `D2015` are enforced
+independently in all three (the VM's `FilterByBytecode` and `eval_compiled_inner`'s entry
+checkpoint each needed their own checks, since neither shares a checkpoint with the tree-walker's
+`evaluate_internal` or with each other).
 Parity across all three surfaces is verified by a dedicated test suite
 (`tests/python/test_guardrails.py`, 26 cases, plus Rust-side coverage in
 `tests/integration_test.rs` and `src/vm.rs`'s `#[cfg(test)]` module) that exercises both the

--- a/docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
+++ b/docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md
@@ -48,7 +48,10 @@ NOT fixed** — they're recorded here for future work, not claimed as resolved:
 - `Instr::MakeArray(u16)` (`src/compiler.rs`) silently produces **wrong, truncated** results — not
   even an error — for JSONata array literals with more than 65,536 elements, because the element
   count is cast to `u16` and overflows silently. This is more severe than the parser crash (silent
-  data corruption vs. a loud failure) and should be prioritized in any follow-up.
+  data corruption vs. a loud failure) and should be prioritized in any follow-up. Fixing this would
+  also unblock adding a literal-array `D2015` check (`MakeArray`/`ArrayConstruct` are currently
+  unguarded — see the "Sequence length → D2015" section below) for full upstream parity, since a
+  length cap can't safely be layered on top of a length computation that already overflows.
 
 Per this document's Scope section below, Phase 2 is the first behavioral reason a `2.2.0`
 jsonatapy release would make sense — a version bump/release is a separate follow-up decision, not
@@ -178,14 +181,26 @@ it piggybacks on an existing hot-path check rather than introducing a new timer 
 ### Sequence length → D2015
 
 New plumbing — unlike depth/timeout there is no existing hook for this. jsonata-js applies this
-cap only to *query-result* sequences (map/filter/group/wildcard/descendants/append/spread/keys/
-each/sift/range), not literal array construction (`[1,2,3]`). The Rust port needs equivalent
-scoping: enforce the cap at the analogous result-construction sites in `evaluator.rs`, **and**
-since compiled expressions run through the bytecode VM by default, the same cap must be enforced
-at the equivalent instructions in `vm.rs` (`MakeArray`, map/filter opcodes, etc.) — otherwise the
-VM path would silently bypass the guardrail for any expression that happens to compile. This is
-the largest, most invasive piece of Phase 2; the implementation plan must enumerate every such
-call site in both engines.
+cap to *query-result* sequences (map/filter/group/wildcard/descendants/append/spread/keys/each/
+sift/range) **and** to flat/non-nested literal array construction (`[1,2,3]`): upstream's array
+literal evaluation (`evaluateUnary`'s `[` case, `tests/jsonata-js/src/jsonata.js:544`) routes each
+non-nested element through `fn.append`, which itself calls the `createSequence`-based cap
+(`tests/jsonata-js/src/functions.js:1727`) — confirmed empirically against live jsonata-js:
+`[1,2,3,4,5]` with `sequence: 2` raises `D2015` upstream. Nested-array literals (e.g.
+`[[1,2],[3,4]]`) escape the cap in upstream, since each nested sub-array is a single element
+passed to `append`, not fanned out.
+
+**This Rust port currently caps only the query-result sites, not literal array construction —**
+`Instr::MakeArray`/`CompiledExpr::ArrayConstruct` are unguarded, a deliberate, temporary
+divergence from upstream (see the Status section's bug list: capping `MakeArray` safely is
+entangled with the pre-existing, unfixed `MakeArray(u16)` truncation bug, so a length check can't
+be safely added on top of code whose length computation already overflows silently for arrays over
+65,536 elements). The Rust port's nested-array-literals-escape-the-cap behavior already matches
+upstream correctly; only the flat-literal case is a known gap. The implementation plan enumerates
+every query-result call site that IS guarded in both the tree-walker (`evaluator.rs`) and the
+bytecode VM (`vm.rs`) — since compiled expressions run through the VM by default, the same cap
+must be enforced at the equivalent instructions there (map/filter opcodes, etc.) or the VM path
+would silently bypass the guardrail for any expression that happens to compile.
 
 `D2014`'s message (range-operator size cap) already says "10,000,000" matching upstream's 2.2.1
 wording bump from 1e6 — no action needed there.

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -141,19 +141,35 @@ class JsonataExpression:
         """
         self._expr = expr
 
-    def evaluate(self, data: Any, bindings: dict[str, Any] | None = None) -> Any:
+    def evaluate(
+        self,
+        data: Any,
+        bindings: dict[str, Any] | None = None,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
+    ) -> Any:
         """
         Evaluate this expression against data.
 
         Args:
             data: The data to query/transform (typically a dict or list)
             bindings: Optional additional variable bindings
+            timeout: Maximum evaluation time in milliseconds (raises ValueError
+                with a D1012 code on timeout). Overrides any default set via
+                `compile(timeout=...)` for this call only.
+            max_stack_depth: Maximum recursion stack depth (raises ValueError
+                with a D1011 code when exceeded). Overrides any compile-time default.
+            max_sequence_length: Maximum length of a query-result sequence
+                (map/filter/wildcard/descendants/etc; raises ValueError with a
+                D2015 code when exceeded). Overrides any compile-time default.
 
         Returns:
             The result of evaluating the expression
 
         Raises:
-            ValueError: If evaluation fails
+            ValueError: If evaluation fails, or a guardrail is exceeded
 
         Example:
             >>> expr = compile("orders[price > 100]")
@@ -162,9 +178,19 @@ class JsonataExpression:
             >>> print(len(result))
             1
         """
-        return self._expr.evaluate(data, bindings)
+        return self._expr.evaluate(
+            data, bindings, timeout, max_stack_depth, max_sequence_length
+        )
 
-    def evaluate_json(self, json_str: str, bindings: dict[str, Any] | None = None) -> str:
+    def evaluate_json(
+        self,
+        json_str: str,
+        bindings: dict[str, Any] | None = None,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
+    ) -> str:
         """
         Evaluate this expression with JSON string input/output (faster for large data).
 
@@ -174,12 +200,20 @@ class JsonataExpression:
         Args:
             json_str: Input data as a JSON string
             bindings: Optional additional variable bindings
+            timeout: Maximum evaluation time in milliseconds (raises ValueError
+                with a D1012 code on timeout). Overrides any default set via
+                `compile(timeout=...)` for this call only.
+            max_stack_depth: Maximum recursion stack depth (raises ValueError
+                with a D1011 code when exceeded). Overrides any compile-time default.
+            max_sequence_length: Maximum length of a query-result sequence
+                (map/filter/wildcard/descendants/etc; raises ValueError with a
+                D2015 code when exceeded). Overrides any compile-time default.
 
         Returns:
             The result as a JSON string
 
         Raises:
-            ValueError: If JSON parsing or evaluation fails
+            ValueError: If JSON parsing or evaluation fails, or a guardrail is exceeded
 
         Example:
             >>> import json
@@ -194,10 +228,18 @@ class JsonataExpression:
             For large datasets (1000+ items), this can be 10-50x faster than evaluate()
             due to avoiding the Python↔Rust object conversion overhead.
         """
-        return self._expr.evaluate_json(json_str, bindings)
+        return self._expr.evaluate_json(
+            json_str, bindings, timeout, max_stack_depth, max_sequence_length
+        )
 
     def evaluate_with_data(
-        self, data: "JsonataData", bindings: dict[str, Any] | None = None
+        self,
+        data: "JsonataData",
+        bindings: dict[str, Any] | None = None,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
     ) -> Any:
         """
         Evaluate with pre-converted data (fastest for repeated evaluation).
@@ -205,22 +247,38 @@ class JsonataExpression:
         Args:
             data: A JsonataData handle (pre-converted data)
             bindings: Optional additional variable bindings
+            timeout: Maximum evaluation time in milliseconds (raises ValueError
+                with a D1012 code on timeout). Overrides any default set via
+                `compile(timeout=...)` for this call only.
+            max_stack_depth: Maximum recursion stack depth (raises ValueError
+                with a D1011 code when exceeded). Overrides any compile-time default.
+            max_sequence_length: Maximum length of a query-result sequence
+                (map/filter/wildcard/descendants/etc; raises ValueError with a
+                D2015 code when exceeded). Overrides any compile-time default.
 
         Returns:
             The result of evaluating the expression
 
         Raises:
-            ValueError: If evaluation fails
+            ValueError: If evaluation fails, or a guardrail is exceeded
 
         Example:
             >>> data = JsonataData({"orders": [{"price": 150}, {"price": 50}]})
             >>> expr = compile("orders[price > 100]")
             >>> result = expr.evaluate_with_data(data)
         """
-        return self._expr.evaluate_with_data(data._data, bindings)
+        return self._expr.evaluate_with_data(
+            data._data, bindings, timeout, max_stack_depth, max_sequence_length
+        )
 
     def evaluate_data_to_json(
-        self, data: "JsonataData", bindings: dict[str, Any] | None = None
+        self,
+        data: "JsonataData",
+        bindings: dict[str, Any] | None = None,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
     ) -> str:
         """
         Evaluate with pre-converted data, return JSON string (zero-overhead output).
@@ -232,12 +290,20 @@ class JsonataExpression:
         Args:
             data: A JsonataData handle (pre-converted data)
             bindings: Optional additional variable bindings
+            timeout: Maximum evaluation time in milliseconds (raises ValueError
+                with a D1012 code on timeout). Overrides any default set via
+                `compile(timeout=...)` for this call only.
+            max_stack_depth: Maximum recursion stack depth (raises ValueError
+                with a D1011 code when exceeded). Overrides any compile-time default.
+            max_sequence_length: Maximum length of a query-result sequence
+                (map/filter/wildcard/descendants/etc; raises ValueError with a
+                D2015 code when exceeded). Overrides any compile-time default.
 
         Returns:
             The result as a JSON string
 
         Raises:
-            ValueError: If evaluation fails
+            ValueError: If evaluation fails, or a guardrail is exceeded
 
         Example:
             >>> import json
@@ -246,10 +312,19 @@ class JsonataExpression:
             >>> result_str = expr.evaluate_data_to_json(data)
             >>> result = json.loads(result_str)
         """
-        return self._expr.evaluate_data_to_json(data._data, bindings)
+        return self._expr.evaluate_data_to_json(
+            data._data, bindings, timeout, max_stack_depth, max_sequence_length
+        )
 
     @classmethod
-    def compile(cls, expression: str) -> "JsonataExpression":
+    def compile(
+        cls,
+        expression: str,
+        *,
+        timeout: int | None = None,
+        max_stack_depth: int | None = None,
+        max_sequence_length: int | None = None,
+    ) -> "JsonataExpression":
         """
         Compile a JSONata expression.
 
@@ -257,6 +332,11 @@ class JsonataExpression:
 
         Args:
             expression: A JSONata expression string
+            timeout: Default max evaluation time in milliseconds for all
+                evaluate*() calls on this expression (can be overridden per-call).
+            max_stack_depth: Default max recursion stack depth (can be overridden per-call).
+            max_sequence_length: Default max query-result sequence length
+                (can be overridden per-call).
 
         Returns:
             A compiled JsonataExpression
@@ -266,16 +346,28 @@ class JsonataExpression:
 
         Example:
             >>> expr = JsonataExpression.compile("$.name")
+            >>> expr = JsonataExpression.compile("$.name", timeout=5000)
         """
-        return cls(_compile(expression))
+        return cls(_compile(expression, timeout, max_stack_depth, max_sequence_length))
 
 
-def compile(expression: str) -> JsonataExpression:
+def compile(
+    expression: str,
+    *,
+    timeout: int | None = None,
+    max_stack_depth: int | None = None,
+    max_sequence_length: int | None = None,
+) -> JsonataExpression:
     """
     Compile a JSONata expression into an executable form.
 
     Args:
         expression: A JSONata query/transformation expression string
+        timeout: Default max evaluation time in milliseconds for all
+            evaluate*() calls on this expression (can be overridden per-call).
+        max_stack_depth: Default max recursion stack depth (can be overridden per-call).
+        max_sequence_length: Default max query-result sequence length
+            (can be overridden per-call).
 
     Returns:
         A compiled JsonataExpression that can be evaluated multiple times
@@ -286,16 +378,25 @@ def compile(expression: str) -> JsonataExpression:
     Example:
         >>> expr = compile("orders[price > 100].product")
         >>> result = expr.evaluate(data)
+        >>> expr = compile("$sum(items.price)", timeout=5000)
 
     Note:
         Compiling an expression once and evaluating it multiple times
         is more efficient than calling `evaluate()` repeatedly with
         the same expression string.
     """
-    return JsonataExpression(_compile(expression))
+    return JsonataExpression(_compile(expression, timeout, max_stack_depth, max_sequence_length))
 
 
-def evaluate(expression: str, data: Any, bindings: dict[str, Any] | None = None) -> Any:
+def evaluate(
+    expression: str,
+    data: Any,
+    bindings: dict[str, Any] | None = None,
+    *,
+    timeout: int | None = None,
+    max_stack_depth: int | None = None,
+    max_sequence_length: int | None = None,
+) -> Any:
     """
     Compile and evaluate a JSONata expression in one step.
 
@@ -306,12 +407,18 @@ def evaluate(expression: str, data: Any, bindings: dict[str, Any] | None = None)
         expression: A JSONata query/transformation expression string
         data: The data to query/transform (typically a dict or list)
         bindings: Optional additional variable bindings
+        timeout: Maximum evaluation time in milliseconds (raises ValueError
+            with a D1012 code on timeout).
+        max_stack_depth: Maximum recursion stack depth (raises ValueError
+            with a D1011 code when exceeded).
+        max_sequence_length: Maximum length of a query-result sequence
+            (raises ValueError with a D2015 code when exceeded).
 
     Returns:
         The result of evaluating the expression
 
     Raises:
-        ValueError: If parsing or evaluation fails
+        ValueError: If parsing or evaluation fails, or a guardrail is exceeded
 
     Example:
         >>> data = {"name": "alice"}
@@ -323,5 +430,11 @@ def evaluate(expression: str, data: Any, bindings: dict[str, Any] | None = None)
         >>> result = evaluate("name & suffix", {"name": "Hello"}, {"suffix": "!"})
         >>> print(result)
         "Hello!"
+
+        >>> # With a timeout guardrail
+        >>> evaluate("$map([1..200000], function($x){$x*2})", None, timeout=1)
+        Traceback (most recent call last):
+            ...
+        ValueError: D1012: Evaluation timeout after 1 milliseconds. Check for infinite loop
     """
-    return _evaluate(expression, data, bindings)
+    return _evaluate(expression, data, bindings, timeout, max_stack_depth, max_sequence_length)

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -178,9 +178,7 @@ class JsonataExpression:
             >>> print(len(result))
             1
         """
-        return self._expr.evaluate(
-            data, bindings, timeout, max_stack_depth, max_sequence_length
-        )
+        return self._expr.evaluate(data, bindings, timeout, max_stack_depth, max_sequence_length)
 
     def evaluate_json(
         self,

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -431,10 +431,10 @@ def evaluate(
         >>> print(result)
         "Hello!"
 
-        >>> # With a timeout guardrail
-        >>> evaluate("$map([1..200000], function($x){$x*2})", None, timeout=1)
+        >>> # With a timeout guardrail (protects against non-terminating expressions)
+        >>> evaluate("($inf := function(){$inf()}; $inf())", None, timeout=100)
         Traceback (most recent call last):
             ...
-        ValueError: D1012: Evaluation timeout after 1 milliseconds. Check for infinite loop
+        ValueError: D1012: Evaluation timeout after 100 milliseconds. Check for infinite loop
     """
     return _evaluate(expression, data, bindings, timeout, max_stack_depth, max_sequence_length)

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -11273,6 +11273,7 @@ impl Evaluator {
                 "D2014: Range operator results in too many elements (> 10,000,000)".to_string(),
             ));
         }
+        check_sequence_length(size, &self.options)?;
 
         let mut result = Vec::with_capacity(size);
         if start <= end {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -7543,6 +7543,14 @@ impl Evaluator {
                     other => vec![other.clone()], // Wrap non-array in array
                 };
 
+                // Pre-check combined size before concatenating, mirroring
+                // jsonata-js's append() (`arg1.length + arg2.length > options.sequence`).
+                let second_len = match second {
+                    JValue::Array(a) => a.len(),
+                    _ => 1,
+                };
+                check_sequence_length(arr.len() + second_len, &self.options)?;
+
                 Ok(functions::array::append(&arr, second)?)
             }
             "reverse" => {
@@ -7804,6 +7812,7 @@ impl Evaluator {
                         } else {
                             let keys: Vec<JValue> =
                                 obj.keys().map(|k| JValue::string(k.clone())).collect();
+                            check_sequence_length(keys.len(), &self.options)?;
                             Ok(unwrap_single(keys))
                         }
                     }
@@ -7826,6 +7835,7 @@ impl Evaluator {
                         if all_keys.is_empty() {
                             Ok(JValue::Null)
                         } else {
+                            check_sequence_length(all_keys.len(), &self.options)?;
                             Ok(unwrap_single(all_keys))
                         }
                     }
@@ -7883,6 +7893,7 @@ impl Evaluator {
                 } else if results.len() == 1 {
                     Ok(results[0].clone())
                 } else {
+                    check_sequence_length(results.len(), &self.options)?;
                     Ok(JValue::array(results))
                 }
             }
@@ -7897,7 +7908,15 @@ impl Evaluator {
                     // Not a container - pass through unchanged (e.g. so $string() still
                     // sees the function value and applies its own function->"" rule).
                     lambda @ (JValue::Lambda { .. } | JValue::Builtin { .. }) => Ok(lambda.clone()),
-                    JValue::Object(obj) => Ok(functions::object::spread(obj)?),
+                    JValue::Object(obj) => {
+                        // functions::object::spread() always returns an array with one
+                        // element per key (mirrors jsonata-js's push-per-key loop through
+                        // this.createSequence()), so it needs the same cap as the
+                        // array-fanout branch below and as the "keys" arm's single-object
+                        // branch.
+                        check_sequence_length(obj.len(), &self.options)?;
+                        Ok(functions::object::spread(obj)?)
+                    }
                     JValue::Array(arr) => {
                         // Spread each object in the array
                         let mut result = Vec::new();
@@ -7919,6 +7938,7 @@ impl Evaluator {
                                 other => result.push(other.clone()),
                             }
                         }
+                        check_sequence_length(result.len(), &self.options)?;
                         Ok(JValue::array(result))
                     }
                     // Non-objects are returned unchanged
@@ -7990,6 +8010,7 @@ impl Evaluator {
                                             result.push(mapped);
                                         }
                                     }
+                                    check_sequence_length(result.len(), &self.options)?;
                                     return Ok(JValue::array(result));
                                 }
                             }
@@ -8025,6 +8046,7 @@ impl Evaluator {
                                                     result.push(mapped);
                                                 }
                                             }
+                                            check_sequence_length(result.len(), &self.options)?;
                                             return Ok(JValue::array(result));
                                         }
                                     }
@@ -8059,6 +8081,7 @@ impl Evaluator {
                                 result.push(mapped);
                             }
                         }
+                        check_sequence_length(result.len(), &self.options)?;
                         Ok(JValue::array(result))
                     }
                     JValue::Null => Ok(JValue::Null),
@@ -8133,6 +8156,7 @@ impl Evaluator {
                                     return Ok(JValue::Undefined);
                                 }
                             }
+                            check_sequence_length(result.len(), &self.options)?;
                             return Ok(JValue::array(result));
                         }
                     }
@@ -8168,6 +8192,7 @@ impl Evaluator {
                                             return Ok(JValue::Undefined);
                                         }
                                     }
+                                    check_sequence_length(result.len(), &self.options)?;
                                     return Ok(JValue::array(result));
                                 }
                             }
@@ -8212,6 +8237,7 @@ impl Evaluator {
                     }
                 }
 
+                check_sequence_length(result.len(), &self.options)?;
                 Ok(JValue::array(result))
             }
 
@@ -8465,6 +8491,7 @@ impl Evaluator {
                                 result.push(fn_result);
                             }
                         }
+                        check_sequence_length(result.len(), &self.options)?;
                         Ok(JValue::array(result))
                     }
                     JValue::Null => Ok(JValue::Null),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -780,6 +780,16 @@ fn eval_compiled_inner(
     options: &EvaluatorOptions,
     start_time: Option<Instant>,
 ) -> Result<JValue, EvaluatorError> {
+    // Single, structurally-unbypassable D1012 checkpoint for the entire compiled fast
+    // path. Every route into compiled evaluation -- the VM's EvalFallback, this task's
+    // MapCall/FilterCall/ReduceCall loop bodies, invoke_stored_lambda's compiled fast
+    // path, evaluate_function_call's inline $map/$filter fast-path loops, and any future
+    // caller -- funnels through this one function (both eval_compiled and
+    // eval_compiled_shaped delegate here), so checking once at entry covers all of them
+    // without having to enumerate call sites. Deliberately timeout-only, no depth check:
+    // self-recursive lambdas cannot compile to CompiledExpr, so genuine recursion always
+    // routes through evaluate_internal's own (already guarded) recursion-depth counter.
+    check_loop_timeout(options, start_time)?;
     match expr {
         // ── Leaves ──────────────────────────────────────────────────────
         CompiledExpr::Literal(v) => Ok(v.clone()),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1593,7 +1593,7 @@ fn compiled_eval_field_path(
         // Determine if this step will do array mapping before we overwrite `current`
         let is_array = matches!(current, JValue::Array(_));
         // Field access with implicit array mapping
-        current = compiled_field_step(&step.field, &current);
+        current = compiled_field_step(&step.field, &current, options)?;
         if is_array {
             did_array_mapping = true;
         } else {
@@ -1623,19 +1623,25 @@ fn compiled_eval_field_path(
 ///
 /// - Object: look up `field`, return its value or Undefined
 /// - Array: map field extraction over each element, flatten nested arrays, skip Undefined
+///   (this is a query-result sequence, so D2015 applies — mirrors `evaluate_path`'s
+///   array-mapping check and `vm.rs`'s `get_field_cached`)
 /// - Tuple objects (`__tuple__: true`): look up in the `@` inner object
 /// - Other: Undefined
-fn compiled_field_step(field: &str, value: &JValue) -> JValue {
+fn compiled_field_step(
+    field: &str,
+    value: &JValue,
+    options: &EvaluatorOptions,
+) -> Result<JValue, EvaluatorError> {
     match value {
         JValue::Object(obj) => {
             // Check for tuple: extract from "@" inner object
             if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
                 if let Some(JValue::Object(inner)) = obj.get("@") {
-                    return inner.get(field).cloned().unwrap_or(JValue::Undefined);
+                    return Ok(inner.get(field).cloned().unwrap_or(JValue::Undefined));
                 }
-                return JValue::Undefined;
+                return Ok(JValue::Undefined);
             }
-            obj.get(field).cloned().unwrap_or(JValue::Undefined)
+            Ok(obj.get(field).cloned().unwrap_or(JValue::Undefined))
         }
         JValue::Array(arr) => {
             // Build shape cache from first plain (non-tuple) object for O(1) positional access.
@@ -1652,7 +1658,7 @@ fn compiled_field_step(field: &str, value: &JValue) -> JValue {
                 let extracted = if let (Some(ref sh), JValue::Object(obj)) = (&shape, item) {
                     // Tuple objects need the recursive path for "@" inner lookup.
                     if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
-                        compiled_field_step(field, item)
+                        compiled_field_step(field, item, options)?
                     } else if let Some(&pos) = sh.get(field) {
                         // Positional access with key verification: guards against heterogeneous
                         // schemas (objects where the same field is at a different index).
@@ -1667,7 +1673,7 @@ fn compiled_field_step(field: &str, value: &JValue) -> JValue {
                         obj.get(field).cloned().unwrap_or(JValue::Undefined)
                     }
                 } else {
-                    compiled_field_step(field, item)
+                    compiled_field_step(field, item, options)?
                 };
                 match extracted {
                     JValue::Undefined => {}
@@ -1675,13 +1681,14 @@ fn compiled_field_step(field: &str, value: &JValue) -> JValue {
                     other => result.push(other),
                 }
             }
-            if result.is_empty() {
+            check_sequence_length(result.len(), options)?;
+            Ok(if result.is_empty() {
                 JValue::Undefined
             } else {
                 JValue::array(result)
-            }
+            })
         }
-        _ => JValue::Undefined,
+        _ => Ok(JValue::Undefined),
     }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1079,6 +1079,7 @@ fn eval_compiled_inner(
                 // 2-param lambda (element + index): build per-iteration because idx_val
                 // is loop-local and cannot outlive the iteration.
                 for (idx, item) in items.iter().enumerate() {
+                    check_loop_timeout(options, start_time)?;
                     let idx_val = JValue::Number(idx as f64);
                     let mut call_vars = clone_outer_vars(vars, 2);
                     if let Some(p) = p0 {
@@ -1102,6 +1103,7 @@ fn eval_compiled_inner(
                 // 1-param lambda (most common): build HashMap once, update element ref each iteration.
                 let mut call_vars = clone_outer_vars(vars, 1);
                 for item in items.iter() {
+                    check_loop_timeout(options, start_time)?;
                     call_vars.insert(p0, item);
                     let mapped = eval_compiled_inner(
                         body,
@@ -1117,6 +1119,7 @@ fn eval_compiled_inner(
                     }
                 }
             }
+            check_sequence_length(result.len(), options)?;
             Ok(if result.is_empty() {
                 JValue::Undefined
             } else {
@@ -1146,6 +1149,7 @@ fn eval_compiled_inner(
 
             if let Some(p1) = params.get(1).map(|s| s.as_str()) {
                 for (idx, item) in items.iter().enumerate() {
+                    check_loop_timeout(options, start_time)?;
                     let idx_val = JValue::Number(idx as f64);
                     let mut call_vars = clone_outer_vars(vars, 2);
                     if let Some(p) = p0 {
@@ -1168,6 +1172,7 @@ fn eval_compiled_inner(
             } else if let Some(p0) = p0 {
                 let mut call_vars = clone_outer_vars(vars, 1);
                 for item in items.iter() {
+                    check_loop_timeout(options, start_time)?;
                     call_vars.insert(p0, item);
                     let pred = eval_compiled_inner(
                         body,
@@ -1187,9 +1192,13 @@ fn eval_compiled_inner(
                 Ok(match result.len() {
                     0 => JValue::Undefined,
                     1 => result.remove(0),
-                    _ => JValue::array(result),
+                    _ => {
+                        check_sequence_length(result.len(), options)?;
+                        JValue::array(result)
+                    }
                 })
             } else {
+                check_sequence_length(result.len(), options)?;
                 Ok(JValue::array(result))
             }
         }
@@ -1227,6 +1236,7 @@ fn eval_compiled_inner(
             let acc_param = params[0].as_str();
             let item_param = params[1].as_str();
             for item in items[start_idx..].iter() {
+                check_loop_timeout(options, start_time)?;
                 // Per-iteration HashMap: &accumulator borrow must be released before we
                 // can reassign `accumulator`. `drop(call_vars)` ends the borrow.
                 let mut call_vars = clone_outer_vars(vars, 2);
@@ -1691,6 +1701,7 @@ fn compiled_apply_filter(
             };
             let effective_shape = shape.or(local_shape.as_ref());
             for item in arr.iter() {
+                check_loop_timeout(options, start_time)?;
                 let pred = eval_compiled_inner(
                     filter,
                     item,
@@ -1709,6 +1720,7 @@ fn compiled_apply_filter(
             } else if result.len() == 1 {
                 Ok(result.remove(0))
             } else {
+                check_sequence_length(result.len(), options)?;
                 Ok(JValue::array(result))
             }
         }
@@ -2643,6 +2655,27 @@ pub(crate) fn check_sequence_length(
                 "D2015: The maximum sequence length of {} was exceeded.",
                 max
             )));
+        }
+    }
+    Ok(())
+}
+
+/// Per-iteration D1012 check for loop-based compiled/VM constructs (map/filter/
+/// reduce element loops, FilterByBytecode) that don't pass through
+/// `evaluate_internal`'s per-node checkpoint and would otherwise run untimed.
+#[inline]
+pub(crate) fn check_loop_timeout(
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
+) -> Result<(), EvaluatorError> {
+    if let Some(timeout_ms) = options.timeout_ms {
+        if let Some(start) = start_time {
+            if start.elapsed().as_millis() as u64 > timeout_ms {
+                return Err(EvaluatorError::EvaluationError(format!(
+                    "D1012: Evaluation timeout after {} milliseconds. Check for infinite loop",
+                    timeout_ms
+                )));
+            }
         }
     }
     Ok(())

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2983,14 +2983,30 @@ impl Evaluator {
             return result;
         }
 
-        // Check recursion depth to prevent stack overflow
+        // Check recursion depth to prevent stack overflow. `effective_limit` is
+        // whichever is tighter: the user's `max_stack_depth` guardrail or the
+        // hardcoded native-stack-safety ceiling (`max_recursion_depth`, always
+        // 302, GitHub issue #34). The hardcoded ceiling is an always-on backstop
+        // regardless of user options — only a user limit BELOW it can produce
+        // D1011; hitting the hardcoded ceiling itself (no option set, or an
+        // option set at/above 302) still produces U1001.
         self.recursion_depth += 1;
-        if self.recursion_depth > self.max_recursion_depth {
+        let effective_limit = match self.options.max_stack_depth {
+            Some(limit) => limit.min(self.max_recursion_depth),
+            None => self.max_recursion_depth,
+        };
+        if self.recursion_depth > effective_limit {
             self.recursion_depth -= 1;
-            return Err(EvaluatorError::EvaluationError(format!(
-                "U1001: Stack overflow - maximum recursion depth ({}) exceeded",
-                self.max_recursion_depth
-            )));
+            return Err(EvaluatorError::EvaluationError(
+                if effective_limit < self.max_recursion_depth {
+                    "D1011: Stack overflow. Check for non-terminating recursive function. Consider rewriting as tail-recursive".to_string()
+                } else {
+                    format!(
+                        "U1001: Stack overflow - maximum recursion depth ({}) exceeded",
+                        effective_limit
+                    )
+                },
+            ));
         }
 
         // The soft depth counter above is calibrated against a comfortably

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2142,6 +2142,11 @@ fn call_pure_builtin(
                 JValue::Array(a) => a.to_vec(),
                 other => vec![other.clone()],
             };
+            let second_len = match second {
+                JValue::Array(a) => a.len(),
+                _ => 1,
+            };
+            check_sequence_length(arr.len() + second_len, options)?;
             Ok(functions::array::append(&arr, second)?)
         }
         "reverse" => match effective_args.first() {
@@ -2168,6 +2173,7 @@ fn call_pure_builtin(
                     Ok(JValue::Null)
                 } else {
                     let keys: Vec<JValue> = obj.keys().map(|k| JValue::string(k.clone())).collect();
+                    check_sequence_length(keys.len(), options)?;
                     if keys.len() == 1 {
                         Ok(keys.into_iter().next().unwrap())
                     } else {
@@ -2192,6 +2198,7 @@ fn call_pure_builtin(
                 } else if all_keys.len() == 1 {
                     Ok(all_keys.into_iter().next().unwrap())
                 } else {
+                    check_sequence_length(all_keys.len(), options)?;
                     Ok(JValue::array(all_keys))
                 }
             }
@@ -10408,6 +10415,7 @@ impl Evaluator {
                     other => result.push(other.clone()),
                 }
 
+                check_sequence_length(result.len(), &self.options)?;
                 Ok(JValue::array(result))
             }
             "reverse" => match arg {
@@ -10424,6 +10432,7 @@ impl Evaluator {
             "keys" => match arg {
                 JValue::Object(obj) => {
                     let keys: Vec<JValue> = obj.keys().map(|k| JValue::string(k.clone())).collect();
+                    check_sequence_length(keys.len(), &self.options)?;
                     Ok(JValue::array(keys))
                 }
                 JValue::Null => Ok(JValue::Null),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -8,6 +8,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 
 use crate::ast::{AstNode, BinaryOp, PathStep, Stage};
 use crate::parser;
@@ -2540,6 +2541,42 @@ impl TupleKeyBindings {
     }
 }
 
+/// Resource-limit guardrails, mirroring jsonata-js 2.2.1's `timeout`/`stack`/`sequence`
+/// evaluator options. All fields default to `None` = unlimited (current behavior).
+#[derive(Default, Clone, Debug)]
+pub struct EvaluatorOptions {
+    /// Maximum wall-clock evaluation time in milliseconds. Exceeding it raises D1012.
+    pub timeout_ms: Option<u64>,
+    /// Maximum AST-recursion stack depth. Exceeding it raises D1011 if this is the
+    /// tighter of this value and the hardcoded native-stack safety ceiling (302);
+    /// otherwise the hardcoded ceiling still raises U1001 (see GitHub issue #34).
+    pub max_stack_depth: Option<usize>,
+    /// Maximum length of a query-result sequence (map/filter/wildcard/descendants/
+    /// keys/lookup/append/spread/each/range/path-mapping). Exceeding it raises D2015.
+    /// Does NOT apply to literal array construction.
+    pub max_sequence_length: Option<usize>,
+}
+
+/// Checks a constructed query-result sequence's length against the configured
+/// `max_sequence_length` guardrail. Call this ONLY at sites that build a
+/// query-result sequence (map/filter/wildcard/descendants/keys/lookup/append/
+/// spread/each/range/path-mapping) — never at literal array construction
+/// (`[1,2,3]`), matching jsonata-js's `createSequence()` scoping.
+pub(crate) fn check_sequence_length(
+    len: usize,
+    options: &EvaluatorOptions,
+) -> Result<(), EvaluatorError> {
+    if let Some(max) = options.max_sequence_length {
+        if len > max {
+            return Err(EvaluatorError::EvaluationError(format!(
+                "D2015: The maximum sequence length of {} was exceeded.",
+                max
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Evaluator for JSONata expressions
 pub struct Evaluator {
     context: Context,
@@ -2567,6 +2604,10 @@ pub struct Evaluator {
     /// wrapper). Mirrors jsonata-js keeping `path.tuple` for such a path instead
     /// of projecting each tuple's `@`.
     keep_tuple_stream: bool,
+    options: EvaluatorOptions,
+    /// Set in `evaluate()` (only when `options.timeout_ms` is configured) and
+    /// checked in `evaluate_internal`'s per-node checkpoint for D1012.
+    start_time: Option<Instant>,
 }
 
 impl Evaluator {
@@ -2580,6 +2621,8 @@ impl Evaluator {
             next_lambda_id: 0,
             tuple_stream_created: false,
             keep_tuple_stream: false,
+            options: EvaluatorOptions::default(),
+            start_time: None,
         }
     }
 
@@ -2591,6 +2634,23 @@ impl Evaluator {
             next_lambda_id: 0,
             tuple_stream_created: false,
             keep_tuple_stream: false,
+            options: EvaluatorOptions::default(),
+            start_time: None,
+        }
+    }
+
+    /// Construct an `Evaluator` with guardrail options. `Evaluator::new()`/
+    /// `with_context()` remain unchanged (unlimited options) for existing callers.
+    pub fn with_options(context: Context, options: EvaluatorOptions) -> Self {
+        Evaluator {
+            context,
+            recursion_depth: 0,
+            max_recursion_depth: 302,
+            next_lambda_id: 0,
+            tuple_stream_created: false,
+            keep_tuple_stream: false,
+            options,
+            start_time: None,
         }
     }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3600,6 +3600,7 @@ impl Evaluator {
                                 _ => result.push(value.clone()),
                             }
                         }
+                        check_sequence_length(result.len(), &self.options)?;
                         Ok(JValue::array(result))
                     }
                     JValue::Array(arr) => {
@@ -3616,6 +3617,7 @@ impl Evaluator {
                 if descendants.is_empty() {
                     Ok(JValue::Null) // No descendants means undefined
                 } else {
+                    check_sequence_length(descendants.len(), &self.options)?;
                     Ok(JValue::array(descendants))
                 }
             }
@@ -5140,6 +5142,10 @@ impl Evaluator {
         } else {
             result
         };
+
+        if let JValue::Array(arr) = &result {
+            check_sequence_length(arr.len(), &self.options)?;
+        }
 
         Ok(result)
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2920,6 +2920,10 @@ impl Evaluator {
             self.context.set_parent(data.clone());
         }
 
+        if self.options.timeout_ms.is_some() {
+            self.start_time = Some(Instant::now());
+        }
+
         self.tuple_stream_created = false;
         let result = self.evaluate_internal(node, data)?;
         Ok(if self.tuple_stream_created {
@@ -3007,6 +3011,21 @@ impl Evaluator {
                     )
                 },
             ));
+        }
+
+        // Check evaluation timeout (D1012). `start_time` is only set (in
+        // `evaluate()`) when `options.timeout_ms` is configured, so this is a
+        // single `is_none()` branch of overhead when no timeout is set.
+        if let Some(timeout_ms) = self.options.timeout_ms {
+            if let Some(start) = self.start_time {
+                if start.elapsed().as_millis() as u64 > timeout_ms {
+                    self.recursion_depth -= 1;
+                    return Err(EvaluatorError::EvaluationError(format!(
+                        "D1012: Evaluation timeout after {} milliseconds. Check for infinite loop",
+                        timeout_ms
+                    )));
+                }
+            }
         }
 
         // The soft depth counter above is calibrated against a comfortably

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4062,6 +4062,7 @@ impl Evaluator {
                             } else if result.len() == 1 {
                                 Ok(result.into_iter().next().unwrap())
                             } else {
+                                check_sequence_length(result.len(), &self.options)?;
                                 Ok(JValue::array(result))
                             }
                         } else {
@@ -4152,6 +4153,7 @@ impl Evaluator {
                             } else if result.len() == 1 {
                                 Ok(result.into_iter().next().unwrap())
                             } else {
+                                check_sequence_length(result.len(), &self.options)?;
                                 Ok(JValue::array(result))
                             }
                         } // end else (tuple path)
@@ -4193,7 +4195,10 @@ impl Evaluator {
                                 return match result.len() {
                                     0 => Ok(JValue::Null),
                                     1 => Ok(result.pop().unwrap()),
-                                    _ => Ok(JValue::array(result)),
+                                    _ => {
+                                        check_sequence_length(result.len(), &self.options)?;
+                                        Ok(JValue::array(result))
+                                    }
                                 };
                             }
                             _ => {} // Fall through to general path evaluation

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -974,7 +974,8 @@ fn eval_compiled_inner(
         CompiledExpr::ArrayConstruct(elems) => {
             let mut result = Vec::new();
             for (elem_expr, is_nested) in elems {
-                let value = eval_compiled_inner(elem_expr, data, vars, ctx, shape, options, start_time)?;
+                let value =
+                    eval_compiled_inner(elem_expr, data, vars, ctx, shape, options, start_time)?;
                 // Undefined values are excluded from array constructors (tree-walker parity)
                 if value.is_undefined() {
                     continue;
@@ -1023,7 +1024,9 @@ fn eval_compiled_inner(
         CompiledExpr::BuiltinCall { name, args } => {
             let mut evaled_args = Vec::with_capacity(args.len());
             for arg in args.iter() {
-                evaled_args.push(eval_compiled_inner(arg, data, vars, ctx, shape, options, start_time)?);
+                evaled_args.push(eval_compiled_inner(
+                    arg, data, vars, ctx, shape, options, start_time,
+                )?);
             }
             call_pure_builtin(name, &evaled_args, data, options)
         }
@@ -1082,7 +1085,15 @@ fn eval_compiled_inner(
                         call_vars.insert(p, item);
                     }
                     call_vars.insert(p1, &idx_val);
-                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    let mapped = eval_compiled_inner(
+                        body,
+                        data,
+                        Some(&call_vars),
+                        ctx,
+                        shape,
+                        options,
+                        start_time,
+                    )?;
                     if !mapped.is_undefined() {
                         result.push(mapped);
                     }
@@ -1092,7 +1103,15 @@ fn eval_compiled_inner(
                 let mut call_vars = clone_outer_vars(vars, 1);
                 for item in items.iter() {
                     call_vars.insert(p0, item);
-                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    let mapped = eval_compiled_inner(
+                        body,
+                        data,
+                        Some(&call_vars),
+                        ctx,
+                        shape,
+                        options,
+                        start_time,
+                    )?;
                     if !mapped.is_undefined() {
                         result.push(mapped);
                     }
@@ -1133,7 +1152,15 @@ fn eval_compiled_inner(
                         call_vars.insert(p, item);
                     }
                     call_vars.insert(p1, &idx_val);
-                    let pred = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    let pred = eval_compiled_inner(
+                        body,
+                        data,
+                        Some(&call_vars),
+                        ctx,
+                        shape,
+                        options,
+                        start_time,
+                    )?;
                     if compiled_is_truthy(&pred) {
                         result.push(item.clone());
                     }
@@ -1142,7 +1169,15 @@ fn eval_compiled_inner(
                 let mut call_vars = clone_outer_vars(vars, 1);
                 for item in items.iter() {
                     call_vars.insert(p0, item);
-                    let pred = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                    let pred = eval_compiled_inner(
+                        body,
+                        data,
+                        Some(&call_vars),
+                        ctx,
+                        shape,
+                        options,
+                        start_time,
+                    )?;
                     if compiled_is_truthy(&pred) {
                         result.push(item.clone());
                     }
@@ -1177,7 +1212,8 @@ fn eval_compiled_inner(
                 }
             };
             let (start_idx, mut accumulator) = if let Some(init_expr) = initial {
-                let init_val = eval_compiled_inner(init_expr, data, vars, ctx, shape, options, start_time)?;
+                let init_val =
+                    eval_compiled_inner(init_expr, data, vars, ctx, shape, options, start_time)?;
                 if items.is_empty() {
                     return Ok(init_val);
                 }
@@ -1196,7 +1232,15 @@ fn eval_compiled_inner(
                 let mut call_vars = clone_outer_vars(vars, 2);
                 call_vars.insert(acc_param, &accumulator);
                 call_vars.insert(item_param, item);
-                let new_acc = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
+                let new_acc = eval_compiled_inner(
+                    body,
+                    data,
+                    Some(&call_vars),
+                    ctx,
+                    shape,
+                    options,
+                    start_time,
+                )?;
                 drop(call_vars);
                 accumulator = new_acc;
             }
@@ -1538,7 +1582,8 @@ fn compiled_eval_field_path(
         }
         // Apply filter if present (filter is an array operation — keep the flag set)
         if let Some(filter) = &step.filter {
-            current = compiled_apply_filter(filter, &current, vars, ctx, shape, options, start_time)?;
+            current =
+                compiled_apply_filter(filter, &current, vars, ctx, shape, options, start_time)?;
             // Filter always implies we operated on an array
             did_array_mapping = true;
         }
@@ -1646,8 +1691,15 @@ fn compiled_apply_filter(
             };
             let effective_shape = shape.or(local_shape.as_ref());
             for item in arr.iter() {
-                let pred =
-                    eval_compiled_inner(filter, item, vars, ctx, effective_shape, options, start_time)?;
+                let pred = eval_compiled_inner(
+                    filter,
+                    item,
+                    vars,
+                    ctx,
+                    effective_shape,
+                    options,
+                    start_time,
+                )?;
                 if compiled_is_truthy(&pred) {
                     result.push(item.clone());
                 }
@@ -3846,9 +3898,22 @@ impl Evaluator {
                         let mut filtered = Vec::with_capacity(arr.len());
                         for item in arr.iter() {
                             let result = if let Some(ref s) = shape {
-                                eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
+                                eval_compiled_shaped(
+                                    &compiled,
+                                    item,
+                                    None,
+                                    s,
+                                    &self.options,
+                                    self.start_time,
+                                )?
                             } else {
-                                eval_compiled(&compiled, item, None, &self.options, self.start_time)?
+                                eval_compiled(
+                                    &compiled,
+                                    item,
+                                    None,
+                                    &self.options,
+                                    self.start_time,
+                                )?
                             };
                             if compiled_is_truthy(&result) {
                                 filtered.push(item.clone());
@@ -5017,9 +5082,22 @@ impl Evaluator {
                                 let mut result = Vec::with_capacity(arr.len());
                                 for item in arr.iter() {
                                     let value = if let Some(ref s) = shape {
-                                        eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
+                                        eval_compiled_shaped(
+                                            &compiled,
+                                            item,
+                                            None,
+                                            s,
+                                            &self.options,
+                                            self.start_time,
+                                        )?
                                     } else {
-                                        eval_compiled(&compiled, item, None, &self.options, self.start_time)?
+                                        eval_compiled(
+                                            &compiled,
+                                            item,
+                                            None,
+                                            &self.options,
+                                            self.start_time,
+                                        )?
                                     };
                                     if !value.is_null() && !value.is_undefined() {
                                         result.push(value);
@@ -5524,9 +5602,22 @@ impl Evaluator {
                         let mut mapped = Vec::with_capacity(arr.len());
                         for item in arr.iter() {
                             let result = if let Some(ref s) = shape {
-                                eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
+                                eval_compiled_shaped(
+                                    &compiled,
+                                    item,
+                                    None,
+                                    s,
+                                    &self.options,
+                                    self.start_time,
+                                )?
                             } else {
-                                eval_compiled(&compiled, item, None, &self.options, self.start_time)?
+                                eval_compiled(
+                                    &compiled,
+                                    item,
+                                    None,
+                                    &self.options,
+                                    self.start_time,
+                                )?
                             };
                             if !result.is_undefined() {
                                 mapped.push(result);
@@ -8024,7 +8115,13 @@ impl Evaluator {
                                     let mut vars = HashMap::new();
                                     for item in arr.iter() {
                                         vars.insert(param_name, item);
-                                        let mapped = eval_compiled(&compiled, data, Some(&vars), &self.options, self.start_time)?;
+                                        let mapped = eval_compiled(
+                                            &compiled,
+                                            data,
+                                            Some(&vars),
+                                            &self.options,
+                                            self.start_time,
+                                        )?;
                                         if !mapped.is_undefined() {
                                             result.push(mapped);
                                         }
@@ -8165,7 +8262,13 @@ impl Evaluator {
                             let mut vars = HashMap::new();
                             for item in items.iter() {
                                 vars.insert(param_name, item);
-                                let pred_result = eval_compiled(&compiled, data, Some(&vars), &self.options, self.start_time)?;
+                                let pred_result = eval_compiled(
+                                    &compiled,
+                                    data,
+                                    Some(&vars),
+                                    &self.options,
+                                    self.start_time,
+                                )?;
                                 if compiled_is_truthy(&pred_result) {
                                     result.push(item.clone());
                                 }
@@ -8200,8 +8303,13 @@ impl Evaluator {
                                         .collect();
                                     for item in items.iter() {
                                         vars.insert(param_name.as_str(), item);
-                                        let pred_result =
-                                            eval_compiled(&ce_clone, call_data, Some(&vars), &self.options, self.start_time)?;
+                                        let pred_result = eval_compiled(
+                                            &ce_clone,
+                                            call_data,
+                                            Some(&vars),
+                                            &self.options,
+                                            self.start_time,
+                                        )?;
                                         if compiled_is_truthy(&pred_result) {
                                             result.push(item.clone());
                                         }
@@ -8335,7 +8443,13 @@ impl Evaluator {
                             for item in items[start_idx..].iter() {
                                 let vars: HashMap<&str, &JValue> =
                                     HashMap::from([(acc_name, &accumulator), (item_name, item)]);
-                                accumulator = eval_compiled(&compiled, data, Some(&vars), &self.options, self.start_time)?;
+                                accumulator = eval_compiled(
+                                    &compiled,
+                                    data,
+                                    Some(&vars),
+                                    &self.options,
+                                    self.start_time,
+                                )?;
                             }
                             return Ok(accumulator);
                         }
@@ -8364,8 +8478,13 @@ impl Evaluator {
                                             vars.insert(item_param.as_str(), item);
                                             // Evaluate and drop vars before assigning accumulator
                                             // to satisfy borrow checker (vars borrows accumulator)
-                                            let new_acc =
-                                                eval_compiled(&ce_clone, call_data, Some(&vars), &self.options, self.start_time)?;
+                                            let new_acc = eval_compiled(
+                                                &ce_clone,
+                                                call_data,
+                                                Some(&vars),
+                                                &self.options,
+                                                self.start_time,
+                                            )?;
                                             drop(vars);
                                             accumulator = new_acc;
                                         }
@@ -10348,9 +10467,22 @@ impl Evaluator {
                         let mut filtered = Vec::with_capacity(_arr.len());
                         for item in _arr.iter() {
                             let result = if let Some(ref s) = shape {
-                                eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
+                                eval_compiled_shaped(
+                                    &compiled,
+                                    item,
+                                    None,
+                                    s,
+                                    &self.options,
+                                    self.start_time,
+                                )?
                             } else {
-                                eval_compiled(&compiled, item, None, &self.options, self.start_time)?
+                                eval_compiled(
+                                    &compiled,
+                                    item,
+                                    None,
+                                    &self.options,
+                                    self.start_time,
+                                )?
                             };
                             if compiled_is_truthy(&result) {
                                 filtered.push(item.clone());
@@ -10438,7 +10570,14 @@ impl Evaluator {
                     let mut filtered = Vec::with_capacity(_arr.len());
                     for item in _arr.iter() {
                         let result = if let Some(ref s) = shape {
-                            eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
+                            eval_compiled_shaped(
+                                &compiled,
+                                item,
+                                None,
+                                s,
+                                &self.options,
+                                self.start_time,
+                            )?
                         } else {
                             eval_compiled(&compiled, item, None, &self.options, self.start_time)?
                         };

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1201,7 +1201,10 @@ fn eval_compiled_inner(
             if was_single {
                 Ok(match result.len() {
                     0 => JValue::Undefined,
-                    1 => result.remove(0),
+                    1 => {
+                        check_sequence_length(1, options)?;
+                        result.remove(0)
+                    }
                     _ => {
                         check_sequence_length(result.len(), options)?;
                         JValue::array(result)
@@ -1735,6 +1738,7 @@ fn compiled_apply_filter(
             if result.is_empty() {
                 Ok(JValue::Undefined)
             } else if result.len() == 1 {
+                check_sequence_length(1, options)?;
                 Ok(result.remove(0))
             } else {
                 check_sequence_length(result.len(), options)?;
@@ -2660,15 +2664,22 @@ pub struct EvaluatorOptions {
     pub max_stack_depth: Option<usize>,
     /// Maximum length of a query-result sequence (map/filter/wildcard/descendants/
     /// keys/lookup/append/spread/each/range/path-mapping). Exceeding it raises D2015.
-    /// Does NOT apply to literal array construction.
+    /// Does NOT currently apply to literal array construction (`MakeArray`/
+    /// `ArrayConstruct`) — NOTE this is a deliberate, temporary divergence from
+    /// upstream, not a match: jsonata-js DOES cap flat/non-nested array literals
+    /// (via `fn.append`'s `createSequence` hook in `evaluateUnary`'s `[` case).
+    /// Deferred until the separate `MakeArray(u16)` truncation bug is fixed (see
+    /// the design spec's "Sequence length → D2015" section).
     pub max_sequence_length: Option<usize>,
 }
 
 /// Checks a constructed query-result sequence's length against the configured
-/// `max_sequence_length` guardrail. Call this ONLY at sites that build a
-/// query-result sequence (map/filter/wildcard/descendants/keys/lookup/append/
-/// spread/each/range/path-mapping) — never at literal array construction
-/// (`[1,2,3]`), matching jsonata-js's `createSequence()` scoping.
+/// `max_sequence_length` guardrail. Call this at sites that build a query-result
+/// sequence (map/filter/wildcard/descendants/keys/lookup/append/spread/each/range/
+/// path-mapping). NOT currently called at literal array construction (`[1,2,3]`) —
+/// unlike upstream jsonata-js, which caps flat/non-nested literals too via
+/// `fn.append`'s `createSequence()` hook. See `EvaluatorOptions::max_sequence_length`
+/// doc comment above for why this is a deliberate, temporary gap.
 pub(crate) fn check_sequence_length(
     len: usize,
     options: &EvaluatorOptions,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -738,8 +738,10 @@ pub(crate) fn eval_compiled(
     expr: &CompiledExpr,
     data: &JValue,
     vars: Option<&HashMap<&str, &JValue>>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
 ) -> Result<JValue, EvaluatorError> {
-    eval_compiled_inner(expr, data, vars, None, None)
+    eval_compiled_inner(expr, data, vars, None, None, options, start_time)
 }
 
 /// Like `eval_compiled` but with an optional shape cache for O(1) positional
@@ -751,8 +753,10 @@ fn eval_compiled_shaped(
     data: &JValue,
     vars: Option<&HashMap<&str, &JValue>>,
     shape: &ShapeCache,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
 ) -> Result<JValue, EvaluatorError> {
-    eval_compiled_inner(expr, data, vars, None, Some(shape))
+    eval_compiled_inner(expr, data, vars, None, Some(shape), options, start_time)
 }
 
 /// Clone the outer variable bindings into a new HashMap with the given capacity hint.
@@ -773,6 +777,8 @@ fn eval_compiled_inner(
     vars: Option<&HashMap<&str, &JValue>>,
     ctx: Option<&Context>,
     shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
 ) -> Result<JValue, EvaluatorError> {
     match expr {
         // ── Leaves ──────────────────────────────────────────────────────
@@ -840,8 +846,8 @@ fn eval_compiled_inner(
         CompiledExpr::Compare { op, lhs, rhs } => {
             let lhs_explicit_null = is_compiled_explicit_null(lhs);
             let rhs_explicit_null = is_compiled_explicit_null(rhs);
-            let left = eval_compiled_inner(lhs, data, vars, ctx, shape)?;
-            let right = eval_compiled_inner(rhs, data, vars, ctx, shape)?;
+            let left = eval_compiled_inner(lhs, data, vars, ctx, shape, options, start_time)?;
+            let right = eval_compiled_inner(rhs, data, vars, ctx, shape, options, start_time)?;
             match op {
                 CompiledCmp::Eq => Ok(JValue::Bool(crate::functions::array::values_equal(
                     &left, &right,
@@ -888,15 +894,15 @@ fn eval_compiled_inner(
         CompiledExpr::Arithmetic { op, lhs, rhs } => {
             let lhs_explicit_null = is_compiled_explicit_null(lhs);
             let rhs_explicit_null = is_compiled_explicit_null(rhs);
-            let left = eval_compiled_inner(lhs, data, vars, ctx, shape)?;
-            let right = eval_compiled_inner(rhs, data, vars, ctx, shape)?;
+            let left = eval_compiled_inner(lhs, data, vars, ctx, shape, options, start_time)?;
+            let right = eval_compiled_inner(rhs, data, vars, ctx, shape, options, start_time)?;
             compiled_arithmetic(*op, &left, &right, lhs_explicit_null, rhs_explicit_null)
         }
 
         // ── String concat ───────────────────────────────────────────────
         CompiledExpr::Concat(lhs, rhs) => {
-            let left = eval_compiled_inner(lhs, data, vars, ctx, shape)?;
-            let right = eval_compiled_inner(rhs, data, vars, ctx, shape)?;
+            let left = eval_compiled_inner(lhs, data, vars, ctx, shape, options, start_time)?;
+            let right = eval_compiled_inner(rhs, data, vars, ctx, shape, options, start_time)?;
             let ls = compiled_to_concat_string(&left)?;
             let rs = compiled_to_concat_string(&right)?;
             Ok(JValue::string(format!("{}{}", ls, rs)))
@@ -904,27 +910,27 @@ fn eval_compiled_inner(
 
         // ── Logical ─────────────────────────────────────────────────────
         CompiledExpr::And(lhs, rhs) => {
-            let left = eval_compiled_inner(lhs, data, vars, ctx, shape)?;
+            let left = eval_compiled_inner(lhs, data, vars, ctx, shape, options, start_time)?;
             if !compiled_is_truthy(&left) {
                 return Ok(JValue::Bool(false));
             }
-            let right = eval_compiled_inner(rhs, data, vars, ctx, shape)?;
+            let right = eval_compiled_inner(rhs, data, vars, ctx, shape, options, start_time)?;
             Ok(JValue::Bool(compiled_is_truthy(&right)))
         }
         CompiledExpr::Or(lhs, rhs) => {
-            let left = eval_compiled_inner(lhs, data, vars, ctx, shape)?;
+            let left = eval_compiled_inner(lhs, data, vars, ctx, shape, options, start_time)?;
             if compiled_is_truthy(&left) {
                 return Ok(JValue::Bool(true));
             }
-            let right = eval_compiled_inner(rhs, data, vars, ctx, shape)?;
+            let right = eval_compiled_inner(rhs, data, vars, ctx, shape, options, start_time)?;
             Ok(JValue::Bool(compiled_is_truthy(&right)))
         }
         CompiledExpr::Not(inner) => {
-            let val = eval_compiled_inner(inner, data, vars, ctx, shape)?;
+            let val = eval_compiled_inner(inner, data, vars, ctx, shape, options, start_time)?;
             Ok(JValue::Bool(!compiled_is_truthy(&val)))
         }
         CompiledExpr::Negate(inner) => {
-            let val = eval_compiled_inner(inner, data, vars, ctx, shape)?;
+            let val = eval_compiled_inner(inner, data, vars, ctx, shape, options, start_time)?;
             match val {
                 JValue::Number(n) => Ok(JValue::Number(-n)),
                 JValue::Null => Ok(JValue::Null),
@@ -942,11 +948,11 @@ fn eval_compiled_inner(
             then_expr,
             else_expr,
         } => {
-            let cond = eval_compiled_inner(condition, data, vars, ctx, shape)?;
+            let cond = eval_compiled_inner(condition, data, vars, ctx, shape, options, start_time)?;
             if compiled_is_truthy(&cond) {
-                eval_compiled_inner(then_expr, data, vars, ctx, shape)
+                eval_compiled_inner(then_expr, data, vars, ctx, shape, options, start_time)
             } else if let Some(else_e) = else_expr {
-                eval_compiled_inner(else_e, data, vars, ctx, shape)
+                eval_compiled_inner(else_e, data, vars, ctx, shape, options, start_time)
             } else {
                 Ok(JValue::Undefined)
             }
@@ -956,7 +962,7 @@ fn eval_compiled_inner(
         CompiledExpr::ObjectConstruct(fields) => {
             let mut result = IndexMap::with_capacity(fields.len());
             for (key, expr) in fields {
-                let value = eval_compiled_inner(expr, data, vars, ctx, shape)?;
+                let value = eval_compiled_inner(expr, data, vars, ctx, shape, options, start_time)?;
                 if !value.is_undefined() {
                     result.insert(key.clone(), value);
                 }
@@ -968,7 +974,7 @@ fn eval_compiled_inner(
         CompiledExpr::ArrayConstruct(elems) => {
             let mut result = Vec::new();
             for (elem_expr, is_nested) in elems {
-                let value = eval_compiled_inner(elem_expr, data, vars, ctx, shape)?;
+                let value = eval_compiled_inner(elem_expr, data, vars, ctx, shape, options, start_time)?;
                 // Undefined values are excluded from array constructors (tree-walker parity)
                 if value.is_undefined() {
                     continue;
@@ -1009,22 +1015,24 @@ fn eval_compiled_inner(
         }
 
         // FieldPath: multi-step field access with implicit array mapping.
-        CompiledExpr::FieldPath(steps) => compiled_eval_field_path(steps, data, vars, ctx, shape),
+        CompiledExpr::FieldPath(steps) => {
+            compiled_eval_field_path(steps, data, vars, ctx, shape, options, start_time)
+        }
 
         // BuiltinCall: evaluate all args, dispatch to pure builtin.
         CompiledExpr::BuiltinCall { name, args } => {
             let mut evaled_args = Vec::with_capacity(args.len());
             for arg in args.iter() {
-                evaled_args.push(eval_compiled_inner(arg, data, vars, ctx, shape)?);
+                evaled_args.push(eval_compiled_inner(arg, data, vars, ctx, shape, options, start_time)?);
             }
-            call_pure_builtin(name, &evaled_args, data)
+            call_pure_builtin(name, &evaled_args, data, options)
         }
 
         // Block: evaluate each expression in sequence, return the last value.
         CompiledExpr::Block(exprs) => {
             let mut result = JValue::Undefined;
             for expr in exprs.iter() {
-                result = eval_compiled_inner(expr, data, vars, ctx, shape)?;
+                result = eval_compiled_inner(expr, data, vars, ctx, shape, options, start_time)?;
             }
             Ok(result)
         }
@@ -1032,9 +1040,9 @@ fn eval_compiled_inner(
         // Coalesce (`??`): return lhs unless it is Undefined; null IS a valid value.
         // JSONata spec: "returns the RHS operand if the LHS operand evaluates to undefined".
         CompiledExpr::Coalesce(lhs, rhs) => {
-            let left = eval_compiled_inner(lhs, data, vars, ctx, shape)?;
+            let left = eval_compiled_inner(lhs, data, vars, ctx, shape, options, start_time)?;
             if left.is_undefined() {
-                eval_compiled_inner(rhs, data, vars, ctx, shape)
+                eval_compiled_inner(rhs, data, vars, ctx, shape, options, start_time)
             } else {
                 Ok(left)
             }
@@ -1051,7 +1059,7 @@ fn eval_compiled_inner(
             params,
             body,
         } => {
-            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape)?;
+            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape, options, start_time)?;
             let single_holder;
             let items: &[JValue] = match &arr_val {
                 JValue::Array(a) => a.as_slice(),
@@ -1074,7 +1082,7 @@ fn eval_compiled_inner(
                         call_vars.insert(p, item);
                     }
                     call_vars.insert(p1, &idx_val);
-                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape)?;
+                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
                     if !mapped.is_undefined() {
                         result.push(mapped);
                     }
@@ -1084,7 +1092,7 @@ fn eval_compiled_inner(
                 let mut call_vars = clone_outer_vars(vars, 1);
                 for item in items.iter() {
                     call_vars.insert(p0, item);
-                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape)?;
+                    let mapped = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
                     if !mapped.is_undefined() {
                         result.push(mapped);
                     }
@@ -1102,7 +1110,7 @@ fn eval_compiled_inner(
             params,
             body,
         } => {
-            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape)?;
+            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape, options, start_time)?;
             if arr_val.is_undefined() || arr_val.is_null() {
                 return Ok(JValue::Undefined);
             }
@@ -1125,7 +1133,7 @@ fn eval_compiled_inner(
                         call_vars.insert(p, item);
                     }
                     call_vars.insert(p1, &idx_val);
-                    let pred = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape)?;
+                    let pred = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
                     if compiled_is_truthy(&pred) {
                         result.push(item.clone());
                     }
@@ -1134,7 +1142,7 @@ fn eval_compiled_inner(
                 let mut call_vars = clone_outer_vars(vars, 1);
                 for item in items.iter() {
                     call_vars.insert(p0, item);
-                    let pred = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape)?;
+                    let pred = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
                     if compiled_is_truthy(&pred) {
                         result.push(item.clone());
                     }
@@ -1157,7 +1165,7 @@ fn eval_compiled_inner(
             body,
             initial,
         } => {
-            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape)?;
+            let arr_val = eval_compiled_inner(array, data, vars, ctx, shape, options, start_time)?;
             let single_holder;
             let items: &[JValue] = match &arr_val {
                 JValue::Array(a) => a.as_slice(),
@@ -1169,7 +1177,7 @@ fn eval_compiled_inner(
                 }
             };
             let (start_idx, mut accumulator) = if let Some(init_expr) = initial {
-                let init_val = eval_compiled_inner(init_expr, data, vars, ctx, shape)?;
+                let init_val = eval_compiled_inner(init_expr, data, vars, ctx, shape, options, start_time)?;
                 if items.is_empty() {
                     return Ok(init_val);
                 }
@@ -1188,7 +1196,7 @@ fn eval_compiled_inner(
                 let mut call_vars = clone_outer_vars(vars, 2);
                 call_vars.insert(acc_param, &accumulator);
                 call_vars.insert(item_param, item);
-                let new_acc = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape)?;
+                let new_acc = eval_compiled_inner(body, data, Some(&call_vars), ctx, shape, options, start_time)?;
                 drop(call_vars);
                 accumulator = new_acc;
             }
@@ -1378,8 +1386,9 @@ pub(crate) fn call_pure_builtin_by_name(
     name: &str,
     args: &[JValue],
     data: &JValue,
+    options: &EvaluatorOptions,
 ) -> Result<JValue, EvaluatorError> {
-    call_pure_builtin(name, args, data)
+    call_pure_builtin(name, args, data, options)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1509,6 +1518,8 @@ fn compiled_eval_field_path(
     vars: Option<&HashMap<&str, &JValue>>,
     ctx: Option<&Context>,
     shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
 ) -> Result<JValue, EvaluatorError> {
     let mut current = data.clone();
     // Track whether the most recent field step mapped over an array (like the tree-walker's
@@ -1527,7 +1538,7 @@ fn compiled_eval_field_path(
         }
         // Apply filter if present (filter is an array operation — keep the flag set)
         if let Some(filter) = &step.filter {
-            current = compiled_apply_filter(filter, &current, vars, ctx, shape)?;
+            current = compiled_apply_filter(filter, &current, vars, ctx, shape, options, start_time)?;
             // Filter always implies we operated on an array
             did_array_mapping = true;
         }
@@ -1620,6 +1631,8 @@ fn compiled_apply_filter(
     vars: Option<&HashMap<&str, &JValue>>,
     ctx: Option<&Context>,
     shape: Option<&ShapeCache>,
+    options: &EvaluatorOptions,
+    start_time: Option<Instant>,
 ) -> Result<JValue, EvaluatorError> {
     match value {
         JValue::Array(arr) => {
@@ -1633,7 +1646,8 @@ fn compiled_apply_filter(
             };
             let effective_shape = shape.or(local_shape.as_ref());
             for item in arr.iter() {
-                let pred = eval_compiled_inner(filter, item, vars, ctx, effective_shape)?;
+                let pred =
+                    eval_compiled_inner(filter, item, vars, ctx, effective_shape, options, start_time)?;
                 if compiled_is_truthy(&pred) {
                     result.push(item.clone());
                 }
@@ -1648,7 +1662,7 @@ fn compiled_apply_filter(
         }
         JValue::Undefined => Ok(JValue::Undefined),
         _ => {
-            let pred = eval_compiled_inner(filter, value, vars, ctx, shape)?;
+            let pred = eval_compiled_inner(filter, value, vars, ctx, shape, options, start_time)?;
             if compiled_is_truthy(&pred) {
                 Ok(value.clone())
             } else {
@@ -1663,7 +1677,12 @@ fn compiled_apply_filter(
 /// Replicates the tree-walker's evaluation for the subset of builtins in
 /// `COMPILABLE_BUILTINS`: no side effects, no lambdas, no context mutations.
 /// `data` is the current context value for implicit-argument insertion.
-fn call_pure_builtin(name: &str, args: &[JValue], data: &JValue) -> Result<JValue, EvaluatorError> {
+fn call_pure_builtin(
+    name: &str,
+    args: &[JValue],
+    data: &JValue,
+    options: &EvaluatorOptions,
+) -> Result<JValue, EvaluatorError> {
     use crate::functions;
 
     // Apply implicit context insertion matching the tree-walker
@@ -2689,7 +2708,7 @@ impl Evaluator {
                     .map(|(p, v)| (p.as_str(), v))
                     .chain(stored.captured_env.iter().map(|(k, v)| (k.as_str(), v)))
                     .collect();
-                return eval_compiled(ce, call_data, Some(&vars));
+                return eval_compiled(ce, call_data, Some(&vars), &self.options, self.start_time);
             }
         }
 
@@ -3827,9 +3846,9 @@ impl Evaluator {
                         let mut filtered = Vec::with_capacity(arr.len());
                         for item in arr.iter() {
                             let result = if let Some(ref s) = shape {
-                                eval_compiled_shaped(&compiled, item, None, s)?
+                                eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
                             } else {
-                                eval_compiled(&compiled, item, None)?
+                                eval_compiled(&compiled, item, None, &self.options, self.start_time)?
                             };
                             if compiled_is_truthy(&result) {
                                 filtered.push(item.clone());
@@ -4998,9 +5017,9 @@ impl Evaluator {
                                 let mut result = Vec::with_capacity(arr.len());
                                 for item in arr.iter() {
                                     let value = if let Some(ref s) = shape {
-                                        eval_compiled_shaped(&compiled, item, None, s)?
+                                        eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
                                     } else {
-                                        eval_compiled(&compiled, item, None)?
+                                        eval_compiled(&compiled, item, None, &self.options, self.start_time)?
                                     };
                                     if !value.is_null() && !value.is_undefined() {
                                         result.push(value);
@@ -5505,9 +5524,9 @@ impl Evaluator {
                         let mut mapped = Vec::with_capacity(arr.len());
                         for item in arr.iter() {
                             let result = if let Some(ref s) = shape {
-                                eval_compiled_shaped(&compiled, item, None, s)?
+                                eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
                             } else {
-                                eval_compiled(&compiled, item, None)?
+                                eval_compiled(&compiled, item, None, &self.options, self.start_time)?
                             };
                             if !result.is_undefined() {
                                 mapped.push(result);
@@ -6315,9 +6334,9 @@ impl Evaluator {
             // Apply compiled filter if present
             if let Some(ref compiled) = filter_compiled {
                 let result = if let Some(ref s) = shape {
-                    eval_compiled_shaped(compiled, item, None, s)?
+                    eval_compiled_shaped(compiled, item, None, s, &self.options, self.start_time)?
                 } else {
-                    eval_compiled(compiled, item, None)?
+                    eval_compiled(compiled, item, None, &self.options, self.start_time)?
                 };
                 if !compiled_is_truthy(&result) {
                     continue;
@@ -8005,7 +8024,7 @@ impl Evaluator {
                                     let mut vars = HashMap::new();
                                     for item in arr.iter() {
                                         vars.insert(param_name, item);
-                                        let mapped = eval_compiled(&compiled, data, Some(&vars))?;
+                                        let mapped = eval_compiled(&compiled, data, Some(&vars), &self.options, self.start_time)?;
                                         if !mapped.is_undefined() {
                                             result.push(mapped);
                                         }
@@ -8041,6 +8060,8 @@ impl Evaluator {
                                                     &ce_clone,
                                                     call_data,
                                                     Some(&vars),
+                                                    &self.options,
+                                                    self.start_time,
                                                 )?;
                                                 if !mapped.is_undefined() {
                                                     result.push(mapped);
@@ -8144,7 +8165,7 @@ impl Evaluator {
                             let mut vars = HashMap::new();
                             for item in items.iter() {
                                 vars.insert(param_name, item);
-                                let pred_result = eval_compiled(&compiled, data, Some(&vars))?;
+                                let pred_result = eval_compiled(&compiled, data, Some(&vars), &self.options, self.start_time)?;
                                 if compiled_is_truthy(&pred_result) {
                                     result.push(item.clone());
                                 }
@@ -8180,7 +8201,7 @@ impl Evaluator {
                                     for item in items.iter() {
                                         vars.insert(param_name.as_str(), item);
                                         let pred_result =
-                                            eval_compiled(&ce_clone, call_data, Some(&vars))?;
+                                            eval_compiled(&ce_clone, call_data, Some(&vars), &self.options, self.start_time)?;
                                         if compiled_is_truthy(&pred_result) {
                                             result.push(item.clone());
                                         }
@@ -8314,7 +8335,7 @@ impl Evaluator {
                             for item in items[start_idx..].iter() {
                                 let vars: HashMap<&str, &JValue> =
                                     HashMap::from([(acc_name, &accumulator), (item_name, item)]);
-                                accumulator = eval_compiled(&compiled, data, Some(&vars))?;
+                                accumulator = eval_compiled(&compiled, data, Some(&vars), &self.options, self.start_time)?;
                             }
                             return Ok(accumulator);
                         }
@@ -8344,7 +8365,7 @@ impl Evaluator {
                                             // Evaluate and drop vars before assigning accumulator
                                             // to satisfy borrow checker (vars borrows accumulator)
                                             let new_acc =
-                                                eval_compiled(&ce_clone, call_data, Some(&vars))?;
+                                                eval_compiled(&ce_clone, call_data, Some(&vars), &self.options, self.start_time)?;
                                             drop(vars);
                                             accumulator = new_acc;
                                         }
@@ -10327,9 +10348,9 @@ impl Evaluator {
                         let mut filtered = Vec::with_capacity(_arr.len());
                         for item in _arr.iter() {
                             let result = if let Some(ref s) = shape {
-                                eval_compiled_shaped(&compiled, item, None, s)?
+                                eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
                             } else {
-                                eval_compiled(&compiled, item, None)?
+                                eval_compiled(&compiled, item, None, &self.options, self.start_time)?
                             };
                             if compiled_is_truthy(&result) {
                                 filtered.push(item.clone());
@@ -10417,9 +10438,9 @@ impl Evaluator {
                     let mut filtered = Vec::with_capacity(_arr.len());
                     for item in _arr.iter() {
                         let result = if let Some(ref s) = shape {
-                            eval_compiled_shaped(&compiled, item, None, s)?
+                            eval_compiled_shaped(&compiled, item, None, s, &self.options, self.start_time)?
                         } else {
-                            eval_compiled(&compiled, item, None)?
+                            eval_compiled(&compiled, item, None, &self.options, self.start_time)?
                         };
                         if compiled_is_truthy(&result) {
                             filtered.push(item.clone());

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -9542,11 +9542,26 @@ impl Evaluator {
         // Trampoline loop - keeps evaluating until we get a final value
         let result = loop {
             iterations += 1;
-            if iterations > MAX_TCO_ITERATIONS {
+            // The hardcoded iteration cap is a backstop for when no timeout is
+            // configured; it must not preempt a configured timeout (which is the
+            // more specific, user-controlled guardrail). Without this gate, an
+            // infinite tail-recursive loop with a cheap per-iteration body hits
+            // this cap in single-digit-to-tens of milliseconds and reports the
+            // misleading "U1001: Stack overflow" (TCO does not grow the stack;
+            // there is no depth-500 stack here) instead of D1012, for *any*
+            // realistic `timeout_ms` (100ms, 1s, the docs' own 5000ms default) -
+            // defeating the purpose of the timeout guardrail for exactly the
+            // scenario it exists to catch (see jsonata-js's own `$inf := function
+            // (){$inf()}; $inf()` guardrails-documentation example).
+            if self.options.timeout_ms.is_none() && iterations > MAX_TCO_ITERATIONS {
                 self.context.pop_scope();
                 return Err(EvaluatorError::EvaluationError(
                     "U1001: Stack overflow - maximum recursion depth (500) exceeded".to_string(),
                 ));
+            }
+            if let Err(e) = check_loop_timeout(&self.options, self.start_time) {
+                self.context.pop_scope();
+                return Err(e);
             }
 
             // Evaluate the lambda body within the persistent scope

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,28 +158,38 @@ struct JsonataExpression {
     /// `Some(bc)` = fast VM path; `None` = must use tree-walker.
     /// `OnceCell` ensures compilation happens at most once per expression instance.
     bytecode: std::cell::OnceCell<Option<vm::BytecodeProgram>>,
+    /// Default guardrail options set at `compile()` time. Per-call `evaluate*()`
+    /// kwargs override these on a field-by-field basis (see the `.or(...)` merges
+    /// in the `#[pymethods]` impl below).
+    default_options: evaluator::EvaluatorOptions,
 }
 
 #[cfg(feature = "python")]
 impl JsonataExpression {
     /// Evaluate the compiled expression against pre-converted data.
     /// Uses bytecode VM when available, falls back to tree-walker.
-    fn run_eval(&self, py: Python, data: &JValue, bindings: Option<Py<PyAny>>) -> PyResult<JValue> {
+    fn run_eval(
+        &self,
+        py: Python,
+        data: &JValue,
+        bindings: Option<Py<PyAny>>,
+        options: evaluator::EvaluatorOptions,
+    ) -> PyResult<JValue> {
         if bindings.is_none() {
             let bytecode = self.bytecode.get_or_init(|| {
                 evaluator::try_compile_expr(&self.ast)
                     .map(|ce| compiler::BytecodeCompiler::compile(&ce))
             });
             if let Some(bc) = bytecode {
-                vm::Vm::new(bc)
+                vm::Vm::with_options(bc, options.clone())
                     .run(data, None)
                     .map_err(evaluator_error_to_py)
             } else {
-                let mut ev = evaluator::Evaluator::new();
+                let mut ev = evaluator::Evaluator::with_options(evaluator::Context::new(), options);
                 ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
             }
         } else {
-            let mut ev = create_evaluator(py, bindings)?;
+            let mut ev = create_evaluator(py, bindings, options)?;
             ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
         }
     }
@@ -189,15 +199,24 @@ impl JsonataExpression {
 #[pymethods]
 impl JsonataExpression {
     /// Returns ValueError if evaluation fails
-    #[pyo3(signature = (data, bindings=None))]
+    #[pyo3(signature = (data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+    #[allow(clippy::too_many_arguments)]
     fn evaluate(
         &self,
         py: Python,
         data: Py<PyAny>,
         bindings: Option<Py<PyAny>>,
+        timeout: Option<u64>,
+        max_stack_depth: Option<usize>,
+        max_sequence_length: Option<usize>,
     ) -> PyResult<Py<PyAny>> {
         let json_data = python_to_json(py, &data)?;
-        json_to_python(py, &self.run_eval(py, &json_data, bindings)?)
+        let options = evaluator::EvaluatorOptions {
+            timeout_ms: timeout.or(self.default_options.timeout_ms),
+            max_stack_depth: max_stack_depth.or(self.default_options.max_stack_depth),
+            max_sequence_length: max_sequence_length.or(self.default_options.max_sequence_length),
+        };
+        json_to_python(py, &self.run_eval(py, &json_data, bindings, options)?)
     }
 
     /// Evaluate with a pre-converted data handle (fastest for repeated evaluation).
@@ -210,14 +229,23 @@ impl JsonataExpression {
     /// # Returns
     ///
     /// The result of evaluating the expression
-    #[pyo3(signature = (data, bindings=None))]
+    #[pyo3(signature = (data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+    #[allow(clippy::too_many_arguments)]
     fn evaluate_with_data(
         &self,
         py: Python,
         data: &JsonataData,
         bindings: Option<Py<PyAny>>,
+        timeout: Option<u64>,
+        max_stack_depth: Option<usize>,
+        max_sequence_length: Option<usize>,
     ) -> PyResult<Py<PyAny>> {
-        json_to_python(py, &self.run_eval(py, &data.data, bindings)?)
+        let options = evaluator::EvaluatorOptions {
+            timeout_ms: timeout.or(self.default_options.timeout_ms),
+            max_stack_depth: max_stack_depth.or(self.default_options.max_stack_depth),
+            max_sequence_length: max_sequence_length.or(self.default_options.max_sequence_length),
+        };
+        json_to_python(py, &self.run_eval(py, &data.data, bindings, options)?)
     }
 
     /// Evaluate with a pre-converted data handle, return JSON string (zero-overhead output).
@@ -230,14 +258,23 @@ impl JsonataExpression {
     /// # Returns
     ///
     /// The result as a JSON string
-    #[pyo3(signature = (data, bindings=None))]
+    #[pyo3(signature = (data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+    #[allow(clippy::too_many_arguments)]
     fn evaluate_data_to_json(
         &self,
         py: Python,
         data: &JsonataData,
         bindings: Option<Py<PyAny>>,
+        timeout: Option<u64>,
+        max_stack_depth: Option<usize>,
+        max_sequence_length: Option<usize>,
     ) -> PyResult<String> {
-        self.run_eval(py, &data.data, bindings)?
+        let options = evaluator::EvaluatorOptions {
+            timeout_ms: timeout.or(self.default_options.timeout_ms),
+            max_stack_depth: max_stack_depth.or(self.default_options.max_stack_depth),
+            max_sequence_length: max_sequence_length.or(self.default_options.max_sequence_length),
+        };
+        self.run_eval(py, &data.data, bindings, options)?
             .to_json_string()
             .map_err(|e| PyValueError::new_err(format!("Failed to serialize result: {}", e)))
     }
@@ -259,16 +296,25 @@ impl JsonataExpression {
     /// # Errors
     ///
     /// Returns ValueError if JSON parsing or evaluation fails
-    #[pyo3(signature = (json_str, bindings=None))]
+    #[pyo3(signature = (json_str, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+    #[allow(clippy::too_many_arguments)]
     fn evaluate_json(
         &self,
         py: Python,
         json_str: &str,
         bindings: Option<Py<PyAny>>,
+        timeout: Option<u64>,
+        max_stack_depth: Option<usize>,
+        max_sequence_length: Option<usize>,
     ) -> PyResult<String> {
         let json_data = JValue::from_json_str(json_str)
             .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {}", e)))?;
-        self.run_eval(py, &json_data, bindings)?
+        let options = evaluator::EvaluatorOptions {
+            timeout_ms: timeout.or(self.default_options.timeout_ms),
+            max_stack_depth: max_stack_depth.or(self.default_options.max_stack_depth),
+            max_sequence_length: max_sequence_length.or(self.default_options.max_sequence_length),
+        };
+        self.run_eval(py, &json_data, bindings, options)?
             .to_json_string()
             .map_err(|e| PyValueError::new_err(format!("Failed to serialize result: {}", e)))
     }
@@ -299,12 +345,19 @@ impl JsonataExpression {
 /// ```
 #[cfg(feature = "python")]
 #[pyfunction]
-fn compile(expression: &str) -> PyResult<JsonataExpression> {
+#[pyo3(signature = (expression, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+fn compile(
+    expression: &str,
+    timeout: Option<u64>,
+    max_stack_depth: Option<usize>,
+    max_sequence_length: Option<usize>,
+) -> PyResult<JsonataExpression> {
     let ast = parser::parse(expression).map_err(parser_error_to_py)?;
 
     Ok(JsonataExpression {
         ast,
         bytecode: std::cell::OnceCell::new(),
+        default_options: build_evaluator_options(timeout, max_stack_depth, max_sequence_length),
     })
 }
 
@@ -337,15 +390,26 @@ fn compile(expression: &str) -> PyResult<JsonataExpression> {
 /// ```
 #[cfg(feature = "python")]
 #[pyfunction]
-#[pyo3(signature = (expression, data, bindings=None))]
+#[pyo3(signature = (expression, data, bindings=None, timeout=None, max_stack_depth=None, max_sequence_length=None))]
+#[allow(clippy::too_many_arguments)]
 fn evaluate(
     py: Python,
     expression: &str,
     data: Py<PyAny>,
     bindings: Option<Py<PyAny>>,
+    timeout: Option<u64>,
+    max_stack_depth: Option<usize>,
+    max_sequence_length: Option<usize>,
 ) -> PyResult<Py<PyAny>> {
-    let expr = compile(expression)?;
-    expr.evaluate(py, data, bindings)
+    let expr = compile(expression, None, None, None)?;
+    expr.evaluate(
+        py,
+        data,
+        bindings,
+        timeout,
+        max_stack_depth,
+        max_sequence_length,
+    )
 }
 
 /// Convert a Python object to a JValue.
@@ -514,13 +578,31 @@ fn json_to_python(py: Python, value: &JValue) -> PyResult<Py<PyAny>> {
     }
 }
 
+/// Build an `EvaluatorOptions` from the Python-facing `timeout`/`max_stack_depth`/
+/// `max_sequence_length` kwargs used by `compile()` and the free-standing `evaluate()`.
+#[cfg(feature = "python")]
+fn build_evaluator_options(
+    timeout: Option<u64>,
+    max_stack_depth: Option<usize>,
+    max_sequence_length: Option<usize>,
+) -> evaluator::EvaluatorOptions {
+    evaluator::EvaluatorOptions {
+        timeout_ms: timeout,
+        max_stack_depth,
+        max_sequence_length,
+    }
+}
+
 /// Create an evaluator, optionally configured with Python bindings
 #[cfg(feature = "python")]
-fn create_evaluator(py: Python, bindings: Option<Py<PyAny>>) -> PyResult<evaluator::Evaluator> {
+fn create_evaluator(
+    py: Python,
+    bindings: Option<Py<PyAny>>,
+    options: evaluator::EvaluatorOptions,
+) -> PyResult<evaluator::Evaluator> {
+    let mut context = evaluator::Context::new();
     if let Some(bindings_obj) = bindings {
         let bindings_json = python_to_json(py, &bindings_obj)?;
-
-        let mut context = evaluator::Context::new();
         if let JValue::Object(map) = bindings_json {
             for (key, value) in map.iter() {
                 context.bind(key.clone(), value.clone());
@@ -528,10 +610,8 @@ fn create_evaluator(py: Python, bindings: Option<Py<PyAny>>) -> PyResult<evaluat
         } else {
             return Err(PyTypeError::new_err("bindings must be a dictionary"));
         }
-        Ok(evaluator::Evaluator::with_context(context))
-    } else {
-        Ok(evaluator::Evaluator::new())
     }
+    Ok(evaluator::Evaluator::with_options(context, options))
 }
 
 /// Convert an EvaluatorError to a PyErr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,8 @@ pub mod _bench {
 
     /// Execute a compiled program against `data`.
     pub fn run(prog: &CompiledProgram, data: &JValue) -> Result<JValue, EvaluatorError> {
-        crate::vm::Vm::new(&prog.0).run(data, None)
+        crate::vm::Vm::with_options(&prog.0, crate::evaluator::EvaluatorOptions::default())
+            .run(data, None)
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -14,7 +14,10 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 
-use crate::evaluator::{eval_compiled, CompiledExpr, EvaluatorError, EvaluatorOptions};
+use crate::evaluator::{
+    check_loop_timeout, check_sequence_length, eval_compiled, CompiledExpr, EvaluatorError,
+    EvaluatorOptions,
+};
 use crate::value::JValue;
 
 // ---------------------------------------------------------------------------
@@ -167,13 +170,23 @@ pub(crate) struct Vm<'prog> {
     prog: &'prog BytecodeProgram,
     /// Operand stack.
     stack: Vec<JValue>,
+    options: EvaluatorOptions,
 }
 
 impl<'prog> Vm<'prog> {
     pub(crate) fn new(prog: &'prog BytecodeProgram) -> Self {
+        Self::with_options(prog, EvaluatorOptions::default())
+    }
+
+    /// Construct a `Vm` with guardrail options (timeout/sequence-length; stack
+    /// depth is not meaningful here — the VM is an iterative flat-instruction
+    /// loop, not native recursion, and self-recursive user lambdas can't
+    /// compile to bytecode in the first place, see design-spec Phase 2 notes).
+    pub(crate) fn with_options(prog: &'prog BytecodeProgram, options: EvaluatorOptions) -> Self {
         Vm {
             prog,
             stack: Vec::with_capacity(16),
+            options,
         }
     }
 
@@ -184,7 +197,19 @@ impl<'prog> Vm<'prog> {
         data: &JValue,
         vars: Option<&HashMap<&str, &JValue>>,
     ) -> Result<JValue, EvaluatorError> {
-        run_inner(self.prog, data, vars, &mut self.stack)
+        let start_time = if self.options.timeout_ms.is_some() {
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+        run_inner(
+            self.prog,
+            data,
+            vars,
+            &mut self.stack,
+            &self.options,
+            start_time,
+        )
     }
 }
 
@@ -197,6 +222,8 @@ fn run_inner(
     data: &JValue,
     vars: Option<&HashMap<&str, &JValue>>,
     stack: &mut Vec<JValue>,
+    options: &EvaluatorOptions,
+    start_time: Option<std::time::Instant>,
 ) -> Result<JValue, EvaluatorError> {
     use crate::evaluator::{
         call_pure_builtin_by_name, compiled_arithmetic, compiled_concat, compiled_equal,
@@ -537,15 +564,7 @@ fn run_inner(
                 let n = *arg_count as usize;
                 let start = stack.len().saturating_sub(n);
                 let args: Vec<JValue> = stack.drain(start..).collect();
-                // TODO(Task 9): thread real EvaluatorOptions through run_inner/Vm instead of
-                // this unlimited default — Task 7 is plumbing-only for eval_compiled's call
-                // graph and must not change vm.rs's own behavior yet.
-                stack.push(call_pure_builtin_by_name(
-                    name,
-                    &args,
-                    data,
-                    &EvaluatorOptions::default(),
-                )?);
+                stack.push(call_pure_builtin_by_name(name, &args, data, options)?);
                 ip += 1;
             }
 
@@ -559,7 +578,15 @@ fn run_inner(
                     JValue::Array(arr) => {
                         let mut kept: Vec<JValue> = Vec::with_capacity(arr.len());
                         for item in arr.iter() {
-                            let test = run_inner(sub_prog, item, vars, &mut sub_stack)?;
+                            check_loop_timeout(options, start_time)?;
+                            let test = run_inner(
+                                sub_prog,
+                                item,
+                                vars,
+                                &mut sub_stack,
+                                options,
+                                start_time,
+                            )?;
                             if compiled_is_truthy(&test) {
                                 kept.push(item.clone());
                             }
@@ -567,13 +594,17 @@ fn run_inner(
                         match kept.len() {
                             0 => JValue::Undefined,
                             1 => kept.pop().unwrap(),
-                            _ => JValue::array(kept),
+                            _ => {
+                                check_sequence_length(kept.len(), options)?;
+                                JValue::array(kept)
+                            }
                         }
                     }
                     JValue::Undefined => JValue::Undefined,
                     other => {
                         // Single value: apply predicate directly
-                        let test = run_inner(sub_prog, &other, vars, &mut sub_stack)?;
+                        let test =
+                            run_inner(sub_prog, &other, vars, &mut sub_stack, options, start_time)?;
                         if compiled_is_truthy(&test) {
                             other
                         } else {
@@ -588,14 +619,7 @@ fn run_inner(
             // ── Fallback ─────────────────────────────────────────────
             Instr::EvalFallback(idx) => {
                 let expr = &fallback_exprs[*idx as usize];
-                // TODO(Task 9): thread real EvaluatorOptions/start_time through here — see note above.
-                stack.push(eval_compiled(
-                    expr,
-                    data,
-                    vars,
-                    &EvaluatorOptions::default(),
-                    None,
-                )?);
+                stack.push(eval_compiled(expr, data, vars, options, start_time)?);
                 ip += 1;
             }
 
@@ -660,5 +684,90 @@ fn get_field_cached(val: &JValue, field: &str, cache: &Cell<Option<usize>>) -> J
             }
         }
         _ => JValue::Undefined,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 9: direct VM-path guardrail tests
+//
+// These live in-crate (rather than in `tests/integration_test.rs`) because
+// `Vm`, `Vm::with_options`, `try_compile_expr`, and `BytecodeCompiler::compile`
+// are all `pub(crate)` and not reachable from an external test crate, and the
+// only external hook (`_bench` facade in `src/lib.rs`, gated on `--features
+// bench`) hardcodes `EvaluatorOptions::default()` — extending it is Task 10's
+// territory. Constructing the pipeline directly here proves `FilterByBytecode`
+// itself (not `eval_compiled_inner`, which Task 8 already covers) enforces
+// D2015/D1012 once `EvaluatorOptions` reaches it.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::BytecodeCompiler;
+    use crate::evaluator::try_compile_expr;
+    use crate::parser::parse;
+
+    /// Compile `expr_src` and assert it produced at least one
+    /// `Instr::FilterByBytecode` — guards against the test silently exercising
+    /// `EvalFallback` instead (which would test nothing about this file).
+    fn compile_and_assert_uses_filter_by_bytecode(expr_src: &str) -> BytecodeProgram {
+        let ast = parse(expr_src).expect("parse");
+        let compiled = try_compile_expr(&ast).unwrap_or_else(|| {
+            panic!("expected `{expr_src}` to compile to a CompiledExpr, got None")
+        });
+        let prog = BytecodeCompiler::compile(&compiled);
+        assert!(
+            prog.instrs
+                .iter()
+                .any(|i| matches!(i, Instr::FilterByBytecode(_))),
+            "expected `{expr_src}` to compile to Instr::FilterByBytecode, got: {:?}",
+            prog.instrs
+        );
+        prog
+    }
+
+    #[test]
+    fn test_filter_by_bytecode_raises_d2015() {
+        let data: JValue = serde_json::json!({
+            "items": (0..1000).collect::<Vec<i32>>()
+        })
+        .into();
+        let prog = compile_and_assert_uses_filter_by_bytecode("items[$ >= 0]");
+        let options = EvaluatorOptions {
+            max_sequence_length: Some(10),
+            ..Default::default()
+        };
+        let err = Vm::with_options(&prog, options)
+            .run(&data, None)
+            .expect_err("expected D2015");
+        assert!(err.to_string().contains("D2015"), "got: {err}");
+    }
+
+    #[test]
+    fn test_filter_by_bytecode_unlimited_options_does_not_raise() {
+        let data: JValue = serde_json::json!({
+            "items": (0..1000).collect::<Vec<i32>>()
+        })
+        .into();
+        let prog = compile_and_assert_uses_filter_by_bytecode("items[$ >= 0]");
+        // Default (unlimited) options must not raise — proves the guardrail is
+        // opt-in and existing unlimited-usage behavior is unchanged.
+        let result = Vm::new(&prog).run(&data, None);
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
+
+    #[test]
+    fn test_filter_by_bytecode_raises_d1012_timeout() {
+        let data: JValue = serde_json::json!({
+            "items": (0..2_000_000).collect::<Vec<i32>>()
+        })
+        .into();
+        let prog = compile_and_assert_uses_filter_by_bytecode("items[$ >= 0]");
+        let options = EvaluatorOptions {
+            timeout_ms: Some(0),
+            ..Default::default()
+        };
+        let err = Vm::with_options(&prog, options)
+            .run(&data, None)
+            .expect_err("expected D1012");
+        assert!(err.to_string().contains("D1012"), "got: {err}");
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -263,12 +263,12 @@ fn run_inner(
             Instr::GetField(idx) => {
                 let val = stack.pop().unwrap_or(JValue::Undefined);
                 let field = &string_pool[*idx as usize];
-                stack.push(get_field_cached(&val, field, &shape_cache[ip]));
+                stack.push(get_field_cached(&val, field, &shape_cache[ip], options)?);
                 ip += 1;
             }
             Instr::GetDataField(idx) => {
                 let field = &string_pool[*idx as usize];
-                stack.push(get_field_cached(data, field, &shape_cache[ip]));
+                stack.push(get_field_cached(data, field, &shape_cache[ip], options)?);
                 ip += 1;
             }
             Instr::GetVar(idx) => {
@@ -289,7 +289,7 @@ fn run_inner(
                 }
                 .unwrap_or(JValue::Undefined);
                 let field = &string_pool[*field_idx as usize];
-                stack.push(get_field_cached(&obj, field, &shape_cache[ip]));
+                stack.push(get_field_cached(&obj, field, &shape_cache[ip], options)?);
                 ip += 1;
             }
 
@@ -642,14 +642,19 @@ fn run_inner(
 /// On objects with IndexMap storage, caches the positional index so subsequent
 /// accesses (for the same object schema) are O(1) positional lookups.
 #[inline]
-fn get_field_cached(val: &JValue, field: &str, cache: &Cell<Option<usize>>) -> JValue {
+fn get_field_cached(
+    val: &JValue,
+    field: &str,
+    cache: &Cell<Option<usize>>,
+    options: &EvaluatorOptions,
+) -> Result<JValue, EvaluatorError> {
     match val {
         JValue::Object(obj) => {
             // Try cached positional index first
             if let Some(idx) = cache.get() {
                 if let Some(v) = obj.get_index(idx) {
                     if v.0 == field {
-                        return v.1.clone();
+                        return Ok(v.1.clone());
                     }
                     // Cache miss (schema changed) — fall through
                 }
@@ -660,30 +665,33 @@ fn get_field_cached(val: &JValue, field: &str, cache: &Cell<Option<usize>>) -> J
                 if let Some(idx) = obj.get_index_of(field) {
                     cache.set(Some(idx));
                 }
-                v.clone()
+                Ok(v.clone())
             } else {
-                JValue::Undefined
+                Ok(JValue::Undefined)
             }
         }
         JValue::Array(arr) => {
             // Array: map field access over elements (implicit array mapping).
             // Mirrors `compiled_field_step`: flatten nested arrays one level.
+            // This is a query-result sequence (D2015 applies, matching
+            // `evaluate_path`'s array-mapping check in evaluator.rs).
             let mut results: Vec<JValue> = Vec::with_capacity(arr.len());
             for item in arr.iter() {
-                let v = get_field_cached(item, field, cache);
+                let v = get_field_cached(item, field, cache, options)?;
                 match v {
                     JValue::Undefined => {}
                     JValue::Array(inner) => results.extend(inner.iter().cloned()),
                     other => results.push(other),
                 }
             }
-            match results.len() {
+            check_sequence_length(results.len(), options)?;
+            Ok(match results.len() {
                 0 => JValue::Undefined,
                 1 => results.pop().unwrap(),
                 _ => JValue::array(results),
-            }
+            })
         }
-        _ => JValue::Undefined,
+        _ => Ok(JValue::Undefined),
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -174,10 +174,6 @@ pub(crate) struct Vm<'prog> {
 }
 
 impl<'prog> Vm<'prog> {
-    pub(crate) fn new(prog: &'prog BytecodeProgram) -> Self {
-        Self::with_options(prog, EvaluatorOptions::default())
-    }
-
     /// Construct a `Vm` with guardrail options (timeout/sequence-length; stack
     /// depth is not meaningful here — the VM is an iterative flat-instruction
     /// loop, not native recursion, and self-recursive user lambdas can't
@@ -593,7 +589,10 @@ fn run_inner(
                         }
                         match kept.len() {
                             0 => JValue::Undefined,
-                            1 => kept.pop().unwrap(),
+                            1 => {
+                                check_sequence_length(1, options)?;
+                                kept.pop().unwrap()
+                            }
                             _ => {
                                 check_sequence_length(kept.len(), options)?;
                                 JValue::array(kept)
@@ -749,6 +748,33 @@ mod tests {
         assert!(err.to_string().contains("D2015"), "got: {err}");
     }
 
+    /// Boundary check: `max_sequence_length=0` must raise D2015 even when the
+    /// filtered result is a single element, not just when it has 2+. Before this
+    /// fix, the `1 => kept.pop().unwrap()` singleton-unwrap arm skipped the
+    /// `check_sequence_length` call entirely, so a 1-element result silently
+    /// bypassed a `sequence: 0` cap — inconsistent with the 2+ arm and with the
+    /// range operator / `MapCall`, which already check unconditionally. Mirrors
+    /// upstream: a single-element push against `sequence: 0` still throws there
+    /// too, since `0 + 1 > 0`.
+    #[test]
+    fn test_filter_by_bytecode_raises_d2015_at_zero_with_single_result() {
+        let data: JValue = serde_json::json!({
+            "items": [1, 2, 3]
+        })
+        .into();
+        // Only one item matches `$ = 2`, so `kept.len() == 1` at the point the
+        // guardrail must fire.
+        let prog = compile_and_assert_uses_filter_by_bytecode("items[$ = 2]");
+        let options = EvaluatorOptions {
+            max_sequence_length: Some(0),
+            ..Default::default()
+        };
+        let err = Vm::with_options(&prog, options)
+            .run(&data, None)
+            .expect_err("expected D2015 for a single-element result against sequence: 0");
+        assert!(err.to_string().contains("D2015"), "got: {err}");
+    }
+
     #[test]
     fn test_filter_by_bytecode_unlimited_options_does_not_raise() {
         let data: JValue = serde_json::json!({
@@ -758,7 +784,7 @@ mod tests {
         let prog = compile_and_assert_uses_filter_by_bytecode("items[$ >= 0]");
         // Default (unlimited) options must not raise — proves the guardrail is
         // opt-in and existing unlimited-usage behavior is unchanged.
-        let result = Vm::new(&prog).run(&data, None);
+        let result = Vm::with_options(&prog, EvaluatorOptions::default()).run(&data, None);
         assert!(result.is_ok(), "expected Ok, got: {result:?}");
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -14,7 +14,7 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 
-use crate::evaluator::{eval_compiled, CompiledExpr, EvaluatorError};
+use crate::evaluator::{eval_compiled, CompiledExpr, EvaluatorError, EvaluatorOptions};
 use crate::value::JValue;
 
 // ---------------------------------------------------------------------------
@@ -537,7 +537,15 @@ fn run_inner(
                 let n = *arg_count as usize;
                 let start = stack.len().saturating_sub(n);
                 let args: Vec<JValue> = stack.drain(start..).collect();
-                stack.push(call_pure_builtin_by_name(name, &args, data)?);
+                // TODO(Task 9): thread real EvaluatorOptions through run_inner/Vm instead of
+                // this unlimited default — Task 7 is plumbing-only for eval_compiled's call
+                // graph and must not change vm.rs's own behavior yet.
+                stack.push(call_pure_builtin_by_name(
+                    name,
+                    &args,
+                    data,
+                    &EvaluatorOptions::default(),
+                )?);
                 ip += 1;
             }
 
@@ -580,7 +588,14 @@ fn run_inner(
             // ── Fallback ─────────────────────────────────────────────
             Instr::EvalFallback(idx) => {
                 let expr = &fallback_exprs[*idx as usize];
-                stack.push(eval_compiled(expr, data, vars)?);
+                // TODO(Task 9): thread real EvaluatorOptions/start_time through here — see note above.
+                stack.push(eval_compiled(
+                    expr,
+                    data,
+                    vars,
+                    &EvaluatorOptions::default(),
+                    None,
+                )?);
                 ip += 1;
             }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1199,3 +1199,41 @@ fn test_path_filter_eval_compiled_inner_raises_d1012_timeout() {
     let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
     assert!(err.to_string().contains("D1012"), "got: {err}");
 }
+
+/// A named/stored lambda (`$storedFn := function($x){$x*2}`) used as the
+/// callback of a top-level `$map(...)` takes an entirely different bypass
+/// than the CompiledExpr::MapCall/FilterCall/ReduceCall arms above: either
+/// `evaluate_function_call`'s own "map" arm's dedicated "stored lambda
+/// variable" fast path (a separate per-item loop calling `eval_compiled`
+/// directly), or -- for other call shapes -- `invoke_stored_lambda`'s
+/// compiled fast path (`src/evaluator.rs`, a single `eval_compiled` call per
+/// invocation, reachable from any tree-walker per-element loop that resolves
+/// a callback to a stored lambda). Neither of those loops is one of this
+/// task's instrumented MapCall/FilterCall/ReduceCall/compiled_apply_filter
+/// arms, so per-loop checks alone do not cover them.
+///
+/// This is closed structurally, not by enumerating more call sites: a single
+/// `check_loop_timeout` at the top of `eval_compiled_inner` itself (before
+/// its `match`) covers every route into compiled evaluation, since both
+/// `eval_compiled` and `eval_compiled_shaped` -- and therefore every caller
+/// of either -- funnel through that one function.
+///
+/// 2,000,000 elements / `timeout_ms: 50`: with the entry-point check firing
+/// on literally every element (not just at loop boundaries), this trips far
+/// more reliably/quickly than the coarser per-loop-only tests above -- a much
+/// smaller timeout budget is safe here.
+#[test]
+fn test_map_stored_lambda_bypass_raises_d1012_timeout() {
+    let data: JValue = serde_json::json!({
+        "bigArray": (0..2_000_000).collect::<Vec<i32>>()
+    })
+    .into();
+    let ast = parse("($storedFn := function($x){$x*2}; $map(bigArray, $storedFn))").unwrap();
+    let options = EvaluatorOptions {
+        timeout_ms: Some(50),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
+    assert!(err.to_string().contains("D1012"), "got: {err}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1002,3 +1002,200 @@ fn test_filter_compiled_fast_path_raises_d2015() {
     let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
     assert!(err.to_string().contains("D2015"), "got: {err}");
 }
+
+// ── Task 8: eval_compiled_inner's CompiledExpr::MapCall/FilterCall/ReduceCall
+// and compiled_apply_filter guardrail coverage ──────────────────────────────
+//
+// The tests above (`test_map_compiled_fast_path_raises_d2015` /
+// `test_filter_compiled_fast_path_raises_d2015`) exercise a *different* fast
+// path: `evaluate_function_call`'s hand-rolled "map"/"filter" arms, which
+// compile only the lambda *body* and loop over the array in the tree walker
+// (already guarded by an earlier task's `check_sequence_length`). A bare
+// top-level `$map(...)`/`$filter(...)` call is dispatched there directly and
+// never reaches `eval_compiled_inner`'s `CompiledExpr::MapCall`/`FilterCall`/
+// `ReduceCall` arms.
+//
+// A naive zero-arg IIFE wrapper (`(function(){...})()`) does NOT reach them
+// either: the parser marks *any* lambda whose body's tail position is a
+// function call as a TCO "thunk" (`parser.rs::is_tail_call`), and thunks
+// unconditionally get `compiled_body: None` (both at `AstNode::Lambda`
+// definition time and via `extract_inline_lambda`'s `thunk: false` guard),
+// so they always fall back to the full tree-walker -- confirmed empirically
+// (a temporary `eprintln!` in each target arm showed zero hits, and the
+// "D2015" assertions were passing for the wrong reason: the tree-walker's
+// already-guarded path #2 above, not this task's target).
+//
+// The reliable way to reach `eval_compiled_inner`'s HOF arms is the pattern
+// the arms' own doc comment describes: nest the HOF/path call as a
+// *non-tail* expression inside another (already thunk:false) lambda body
+// compiled by path #2, e.g. `function($x){ (INNER_CALL; 1) }` -- wrapping in
+// a `Block` whose last expression is a plain literal keeps the outer
+// callback's tail position a non-function-call, so it stays thunk:false and
+// compiles via `try_compile_expr_with_allowed_vars`. That compiled `Block`
+// (`CompiledExpr::Block([inner_call_compiled, Literal(1)])`) is then run via
+// `eval_compiled_inner`, which evaluates `inner_call_compiled` first --
+// landing squarely in the target arm. Confirmed empirically the same way
+// (temporary `eprintln!`s in each target arm all fired for these exact
+// expressions, and all returned `is_err() == false` pre-implementation,
+// i.e. genuinely unguarded fast paths, not false negatives).
+//
+// `outer` is a single-element array purely to drive one iteration of the
+// (harmless, already-guarded) outer path #2 loop; all the guardrail action
+// happens in the untouched inner call.
+
+/// $map's CompiledExpr::MapCall arm must respect max_sequence_length.
+/// Distinct return point from `test_map_compiled_fast_path_raises_d2015` above.
+#[test]
+fn test_map_eval_compiled_inner_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..1000).collect::<Vec<i32>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){($map(items, function($y){$y*2}); 1)})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// A timeout must trip inside CompiledExpr::MapCall's per-element loop, even
+/// though it never passes through evaluate_internal's per-node checkpoint.
+///
+/// `timeout_ms: 200` + 2,000,000 items (not a tighter/smaller budget): reaching
+/// this arm first runs through `evaluate_function_call`'s generic "evaluate all
+/// args" preamble for the OUTER `$map`, which itself evaluates+compiles the
+/// callback `Lambda` -- setup that was empirically observed to occasionally
+/// take several ms under load. 200ms comfortably clears that, while the full
+/// uninstrumented loop reliably takes 700ms+, giving a wide, non-flaky margin.
+#[test]
+fn test_map_eval_compiled_inner_raises_d1012_timeout() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..2_000_000).collect::<Vec<i32>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){($map(items, function($y){$y*2}); 1)})").unwrap();
+    let options = EvaluatorOptions {
+        timeout_ms: Some(200),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
+    assert!(err.to_string().contains("D1012"), "got: {err}");
+}
+
+/// $filter's CompiledExpr::FilterCall arm must respect max_sequence_length.
+#[test]
+fn test_filter_eval_compiled_inner_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..1000).collect::<Vec<i32>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){($filter(items, function($y){$y>=0}); 1)})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// A timeout must trip inside CompiledExpr::FilterCall's per-element loop.
+/// See `test_map_eval_compiled_inner_raises_d1012_timeout` for why this uses
+/// a 200ms/2,000,000-item margin rather than a razor-thin budget.
+#[test]
+fn test_filter_eval_compiled_inner_raises_d1012_timeout() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..2_000_000).collect::<Vec<i32>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){($filter(items, function($y){$y>=0}); 1)})").unwrap();
+    let options = EvaluatorOptions {
+        timeout_ms: Some(200),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
+    assert!(err.to_string().contains("D1012"), "got: {err}");
+}
+
+/// A timeout must trip inside CompiledExpr::ReduceCall's per-element loop.
+/// No corresponding D2015 test: jsonata-js's own `reduce()` never calls
+/// `createSequence()`, so the accumulator is intentionally uncapped upstream
+/// too -- ReduceCall must NOT gain a check_sequence_length call. See
+/// `test_map_eval_compiled_inner_raises_d1012_timeout` for why this uses a
+/// 200ms/2,000,000-item margin rather than a razor-thin budget.
+#[test]
+fn test_reduce_eval_compiled_inner_raises_d1012_timeout() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..2_000_000).collect::<Vec<i32>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){($reduce(items, function($acc,$y){$acc+$y}); 1)})")
+        .unwrap();
+    let options = EvaluatorOptions {
+        timeout_ms: Some(200),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
+    assert!(err.to_string().contains("D1012"), "got: {err}");
+}
+
+/// A compiled path predicate (`items[val>=0]`, compiling to
+/// CompiledExpr::FieldPath with a filter step) must respect
+/// max_sequence_length via `compiled_apply_filter`.
+#[test]
+fn test_path_filter_eval_compiled_inner_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..1000).map(|i| serde_json::json!({"val": i})).collect::<Vec<_>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){(items[val>=0]; 1)})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// A timeout must trip inside `compiled_apply_filter`'s per-element loop.
+///
+/// Uses a much larger margin than the sibling MapCall/FilterCall/ReduceCall
+/// D1012 tests (`timeout_ms: 200` + 2,000,000 items, vs. their `1`ms +
+/// 500,000): empirically, reaching this specific arm first runs through
+/// `evaluate_function_call`'s generic "evaluate all args" preamble (which
+/// evaluates the whole callback `Lambda` node, compiling its body) before
+/// entering the fast path, and that setup alone was observed to occasionally
+/// take several ms under load -- enough to make a 1ms budget flaky (it could
+/// fire during setup, "passing" without ever exercising this arm's loop).
+/// 200ms comfortably exceeds worst-case observed setup while the full
+/// 2,000,000-element uninstrumented loop reliably takes 500-650ms, giving a
+/// wide, non-flaky margin either side.
+#[test]
+fn test_path_filter_eval_compiled_inner_raises_d1012_timeout() {
+    let data: JValue = serde_json::json!({
+        "outer": [1],
+        "items": (0..2_000_000).map(|i| serde_json::json!({"val": i})).collect::<Vec<_>>()
+    })
+    .into();
+    let ast = parse("$map(outer, function($x){(items[val>=0]; 1)})").unwrap();
+    let options = EvaluatorOptions {
+        timeout_ms: Some(200),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D1012");
+    assert!(err.to_string().contains("D1012"), "got: {err}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -783,9 +783,7 @@ fn test_range_operator_raises_d2015_when_configured() {
         ..Default::default()
     };
     let mut evaluator = Evaluator::with_options(Context::new(), options);
-    let err = evaluator
-        .evaluate(&ast, &data)
-        .expect_err("expected D2015");
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
     assert!(err.to_string().contains("D2015"), "got: {err}");
 }
 
@@ -845,7 +843,8 @@ fn test_wildcard_raises_d2015() {
 fn test_descendant_raises_d2015() {
     let data: JValue = serde_json::json!({
         "items": (0..1000).map(|i| serde_json::json!({"v": i})).collect::<Vec<_>>()
-    }).into();
+    })
+    .into();
     let ast = parse("**").unwrap();
     let options = EvaluatorOptions {
         max_sequence_length: Some(10),
@@ -912,9 +911,10 @@ fn test_path_variable_field_fast_path_raises_d2015() {
 /// array branch) load-bearing, not redundant.
 #[test]
 fn test_bare_single_step_path_over_root_array_raises_d2015() {
-    let data: JValue = serde_json::json!(
-        (0..1000).map(|i| serde_json::json!({"name": format!("item{i}")})).collect::<Vec<_>>()
-    ).into();
+    let data: JValue = serde_json::json!((0..1000)
+        .map(|i| serde_json::json!({"name": format!("item{i}")}))
+        .collect::<Vec<_>>())
+    .into();
     let ast = parse("name").unwrap();
     let options = EvaluatorOptions {
         max_sequence_length: Some(10),
@@ -933,7 +933,8 @@ fn test_bare_single_step_path_over_root_array_raises_d2015() {
 fn test_map_generic_path_raises_d2015() {
     let data: JValue = serde_json::json!({
         "items": (0..1000).map(|i| serde_json::json!({"a": i})).collect::<Vec<_>>()
-    }).into();
+    })
+    .into();
     let ast = parse("$map(items, function($x){$x.*})").unwrap();
     let options = EvaluatorOptions {
         max_sequence_length: Some(10),
@@ -953,7 +954,8 @@ fn test_map_generic_path_raises_d2015() {
 fn test_map_compiled_fast_path_raises_d2015() {
     let data: JValue = serde_json::json!({
         "items": (0..1000).map(|i| serde_json::json!(i)).collect::<Vec<_>>()
-    }).into();
+    })
+    .into();
     let ast = parse("$map(items, function($x){$x*2})").unwrap();
     let options = EvaluatorOptions {
         max_sequence_length: Some(10),
@@ -970,7 +972,8 @@ fn test_map_compiled_fast_path_raises_d2015() {
 fn test_filter_generic_path_raises_d2015() {
     let data: JValue = serde_json::json!({
         "items": (0..1000).map(|i| serde_json::json!({"a": i})).collect::<Vec<_>>()
-    }).into();
+    })
+    .into();
     let ast = parse("$filter(items, function($x){$x.* != null})").unwrap();
     let options = EvaluatorOptions {
         max_sequence_length: Some(10),
@@ -988,7 +991,8 @@ fn test_filter_generic_path_raises_d2015() {
 fn test_filter_compiled_fast_path_raises_d2015() {
     let data: JValue = serde_json::json!({
         "items": (0..1000).map(|i| serde_json::json!(i)).collect::<Vec<_>>()
-    }).into();
+    })
+    .into();
     let ast = parse("$filter(items, function($x){$x >= 0})").unwrap();
     let options = EvaluatorOptions {
         max_sequence_length: Some(10),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -550,6 +550,52 @@ fn test_deep_recursion_does_not_overflow_native_stack() {
     );
 }
 
+/// A user-configured `max_stack_depth` tighter than the hardcoded native-stack
+/// ceiling (302) must trip D1011, not U1001 — the tree-walker's own guardrail,
+/// not the Rust-specific native-stack safety net.
+#[test]
+fn test_max_stack_depth_raises_d1011_not_u1001() {
+    let data = JValue::Null;
+    let ast = parse("($inf := function($n){$n+$inf($n-1)}; $inf(5))").unwrap();
+    let context = Context::new();
+    let options = jsonata_core::evaluator::EvaluatorOptions {
+        max_stack_depth: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(context, options);
+    let result = evaluator.evaluate(&ast, &data);
+    let err = result.expect_err("expected a D1011 stack-overflow error");
+    assert!(
+        err.to_string().contains("D1011"),
+        "expected D1011, got: {err}"
+    );
+}
+
+/// A `max_stack_depth` at or above the hardcoded ceiling changes nothing — the
+/// hardcoded 302 ceiling (and its U1001 error) remains the effective, always-on
+/// backstop (GitHub issue #34).
+#[test]
+fn test_max_stack_depth_above_hardcoded_ceiling_still_raises_u1001() {
+    let handle = std::thread::Builder::new()
+        .stack_size(1024 * 1024)
+        .spawn(|| {
+            let data = JValue::Null;
+            let ast = parse("($inf := function($n){$n+$inf($n-1)}; $inf(5))").unwrap();
+            let options = jsonata_core::evaluator::EvaluatorOptions {
+                max_stack_depth: Some(100_000),
+                ..Default::default()
+            };
+            let mut evaluator = Evaluator::with_options(Context::new(), options);
+            match evaluator.evaluate(&ast, &data) {
+                Ok(v) => format!("Ok({v:?})"),
+                Err(e) => format!("Err({e})"),
+            }
+        })
+        .unwrap();
+    let outcome = handle.join().unwrap();
+    assert!(outcome.contains("U1001"), "expected U1001, got: {outcome}");
+}
+
 /// Object construction must drop keys whose value is an undefined (no-match)
 /// path, matching reference JSONata and this crate's own VM backend - not
 /// keep them as an explicit `null` (see GitHub issue #32).

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -731,3 +731,42 @@ fn test_percent_in_two_sort_terms() {
         .collect();
     assert_eq!(got, want);
 }
+
+/// A configured timeout must trip D1012 on a pathologically slow (but
+/// terminating) expression. Note: the brief's originally proposed shape (a
+/// 200,000-term chained-addition string, "1+1+1+...+1") was tried first and
+/// rejected — see the task report for why (it overflows the native stack
+/// inside the recursive-descent *parser* itself, before evaluation even
+/// starts, regardless of any timeout). `$map` over a large range with cheap
+/// per-element work is expensive to evaluate node-by-node (~200,000 lambda
+/// invocations) without producing a deeply-nested AST, so it exercises the
+/// D1012 checkpoint without tripping D1011/U1001 or a parser stack overflow.
+#[test]
+fn test_timeout_raises_d1012() {
+    let data = JValue::Null;
+    let expr_str = "$map([1..200000], function($x){$x*2})";
+    let ast = parse(expr_str).unwrap();
+    let options = jsonata_core::evaluator::EvaluatorOptions {
+        timeout_ms: Some(1), // 1ms — must expire before 200k lambda invocations finish
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let result = evaluator.evaluate(&ast, &data);
+    let err = result.expect_err("expected a D1012 timeout error");
+    assert!(
+        err.to_string().contains("D1012"),
+        "expected D1012, got: {err}"
+    );
+}
+
+/// No timeout configured (the default) must never raise D1012, however long
+/// evaluation takes.
+#[test]
+fn test_no_timeout_configured_never_raises_d1012() {
+    let data = JValue::Null;
+    let expr_str = "$map([1..200000], function($x){$x*2})";
+    let ast = parse(expr_str).unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data);
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,7 +4,7 @@
 // to process complete JSONata expressions.
 
 use jsonata_core::{
-    evaluator::{Context, Evaluator},
+    evaluator::{Context, Evaluator, EvaluatorOptions},
     parser::parse,
     value::JValue,
 };
@@ -769,4 +769,36 @@ fn test_no_timeout_configured_never_raises_d1012() {
     let mut evaluator = Evaluator::new();
     let result = evaluator.evaluate(&ast, &data);
     assert!(result.is_ok(), "expected Ok, got: {result:?}");
+}
+
+/// The range operator must respect `max_sequence_length` (D2015) in addition
+/// to its existing hardcoded 10-million-element cap (D2014) — mirrors
+/// jsonata-js's `evaluateRangeExpression`, which checks D2014 then D2015.
+#[test]
+fn test_range_operator_raises_d2015_when_configured() {
+    let data = JValue::Null;
+    let ast = parse("[1..1000]").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator
+        .evaluate(&ast, &data)
+        .expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// Without `max_sequence_length` set, ranges up to the existing 10M hardcoded
+/// cap are unaffected.
+#[test]
+fn test_range_operator_unaffected_without_max_sequence_length() {
+    let data = JValue::Null;
+    let ast = parse("[1..1000]").unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data).unwrap();
+    match result {
+        JValue::Array(arr) => assert_eq!(arr.len(), 1000),
+        other => panic!("expected array, got {other:?}"),
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -865,12 +865,12 @@ fn test_descendant_raises_d2015() {
 /// chokepoint). Note: for this specific construction the *outer* `items.name`
 /// call still separately hits the shared chokepoint too (its own `result`
 /// accumulates the same 1000 elements via the general per-step loop before
-/// returning), so this particular data shape doesn't prove the fast path's own
-/// check is independently load-bearing — every currently-reachable call into
-/// this fast path is itself a nested recursive call from a frame whose
-/// steps.len() >= 2, which always has an active chokepoint of its own. It is
-/// still correct and consistent (defense-in-depth parity with every other
-/// query-result-sequence exit point in this function) to check here directly.
+/// returning), so this particular data shape alone doesn't prove the fast
+/// path's own check is independently load-bearing — see
+/// `test_bare_single_step_path_over_root_array_raises_d2015` below for the
+/// top-level, no-enclosing-frame construction that does prove it. Both tests
+/// are kept: this one covers the nested-recursion route into the fast path,
+/// the other covers the top-level route.
 #[test]
 fn test_path_single_step_fast_path_raises_d2015() {
     let data: JValue = serde_json::json!({

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -771,6 +771,72 @@ fn test_no_timeout_configured_never_raises_d1012() {
     assert!(result.is_ok(), "expected Ok, got: {result:?}");
 }
 
+/// jsonata-js's own canonical guardrails-documentation example: an infinite
+/// tail-recursive call. `invoke_lambda_with_tco`'s trampoline loop previously
+/// had no timeout check at all -- only the hardcoded `MAX_TCO_ITERATIONS`
+/// iteration cap -- so this expression ran up to 100,000 iterations
+/// completely ignoring `timeout_ms` and failed with U1001 instead of D1012.
+#[test]
+fn test_tco_trampoline_infinite_recursion_raises_d1012_timeout() {
+    let data = JValue::Null;
+    let expr_str = "($inf := function(){$inf()}; $inf())";
+    let ast = parse(expr_str).unwrap();
+    let options = jsonata_core::evaluator::EvaluatorOptions {
+        timeout_ms: Some(5),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator
+        .evaluate(&ast, &data)
+        .expect_err("expected a D1012 timeout error");
+    assert!(
+        err.to_string().contains("D1012"),
+        "expected D1012, got: {err}"
+    );
+}
+
+/// Without a configured timeout, the new per-iteration `check_loop_timeout`
+/// call in the TCO trampoline must remain a no-op (it early-returns when
+/// `options.timeout_ms` is `None`), so a bounded tail-recursive loop still
+/// completes normally and produces the correct result. Uses a moderate bound
+/// (not 100,000 iterations) to keep the test suite fast; the pre-existing
+/// U1001-at-100k-iterations behavior is unchanged and not the target of this
+/// regression guard.
+#[test]
+fn test_tco_trampoline_no_timeout_configured_completes_normally() {
+    let data = JValue::Null;
+    let expr_str = "(\
+        $count := function($n, $acc){$n <= 0 ? $acc : $count($n - 1, $acc + 1)};\
+        $count(1000, 0)\
+    )";
+    let ast = parse(expr_str).unwrap();
+    let mut evaluator = Evaluator::new();
+    let result = evaluator.evaluate(&ast, &data).unwrap();
+    assert_eq!(result, JValue::from(json!(1000.0)));
+}
+
+/// Without a configured timeout, the `MAX_TCO_ITERATIONS` hardcoded backstop
+/// must still apply to genuinely infinite tail recursion -- the timeout gate
+/// added to `invoke_lambda_with_tco` (`timeout_ms.is_none() && iterations >
+/// MAX_TCO_ITERATIONS`) must not disable the cap when there is no timeout to
+/// take over as the exit condition, or this would hang forever. Takes on the
+/// order of tens of milliseconds (100,000 trivial trampoline iterations); not
+/// a bounded/fast variant, since the whole point is exercising the cap itself.
+#[test]
+fn test_tco_trampoline_no_timeout_configured_still_hits_iteration_cap() {
+    let data = JValue::Null;
+    let expr_str = "($inf := function(){$inf()}; $inf())";
+    let ast = parse(expr_str).unwrap();
+    let mut evaluator = Evaluator::new();
+    let err = evaluator
+        .evaluate(&ast, &data)
+        .expect_err("expected U1001 at the iteration cap");
+    assert!(
+        err.to_string().contains("U1001"),
+        "expected U1001, got: {err}"
+    );
+}
+
 /// The range operator must respect `max_sequence_length` (D2015) in addition
 /// to its existing hardcoded 10-million-element cap (D2014) — mirrors
 /// jsonata-js's `evaluateRangeExpression`, which checks D2014 then D2015.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -802,3 +802,56 @@ fn test_range_operator_unaffected_without_max_sequence_length() {
         other => panic!("expected array, got {other:?}"),
     }
 }
+
+/// Plain field-path mapping over an array (e.g. `items.name`) is a
+/// query-result sequence per jsonata-js's `evaluatePath`/`evaluateStep` and
+/// must respect `max_sequence_length`.
+#[test]
+fn test_path_mapping_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"name": format!("item{i}")})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("items.name").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// Top-level wildcard `*` over a large object must respect max_sequence_length.
+#[test]
+fn test_wildcard_raises_d2015() {
+    let mut obj = serde_json::Map::new();
+    for i in 0..1000 {
+        obj.insert(format!("k{i}"), serde_json::json!(i));
+    }
+    let data: JValue = serde_json::Value::Object(obj).into();
+    let ast = parse("*").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// Top-level descendant `**` over a deeply-nested structure must respect
+/// max_sequence_length.
+#[test]
+fn test_descendant_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"v": i})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("**").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -904,3 +904,23 @@ fn test_path_variable_field_fast_path_raises_d2015() {
     assert!(err.to_string().contains("D2015"), "got: {err}");
 }
 
+/// Bare single-segment field access (`name`, no dots) over root data that IS
+/// itself a large array is a genuine top-level call into evaluate_path's
+/// steps.len()==1 fast path, with no enclosing evaluate_path frame to
+/// backstop it via the shared final-exit chokepoint — this is the case that
+/// makes the check at src/evaluator.rs's single-step fast path (non-tuple
+/// array branch) load-bearing, not redundant.
+#[test]
+fn test_bare_single_step_path_over_root_array_raises_d2015() {
+    let data: JValue = serde_json::json!(
+        (0..1000).map(|i| serde_json::json!({"name": format!("item{i}")})).collect::<Vec<_>>()
+    ).into();
+    let ast = parse("name").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -924,3 +924,77 @@ fn test_bare_single_step_path_over_root_array_raises_d2015() {
     let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
     assert!(err.to_string().contains("D2015"), "got: {err}");
 }
+
+/// $map's generic (non-compiled-fast-path) construction must respect
+/// max_sequence_length. Using `$x.*` as the lambda body (not compilable, per
+/// try_compile_expr_with_allowed_vars's lack of a Wildcard arm) forces this
+/// through the generic per-element loop, not the CompiledExpr fast path.
+#[test]
+fn test_map_generic_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"a": i})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("$map(items, function($x){$x.*})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// $map's CompiledExpr fast path (inline lambda, single param, compilable
+/// arithmetic body) must ALSO respect max_sequence_length -- this is a
+/// distinct return point from the generic loop above, and a prior task
+/// (Task 5) found a real bug where only one of several return points was
+/// instrumented. `$x*2` is compilable per try_compile_expr_with_allowed_vars.
+#[test]
+fn test_map_compiled_fast_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!(i)).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("$map(items, function($x){$x*2})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// $filter's generic (non-compiled-fast-path) loop must respect
+/// max_sequence_length. `$x.*` is not compilable, forcing the generic path.
+#[test]
+fn test_filter_generic_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"a": i})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("$filter(items, function($x){$x.* != null})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// $filter's CompiledExpr fast path (inline lambda, single param, compilable
+/// comparison body) must ALSO respect max_sequence_length -- a distinct
+/// return point from the generic loop above.
+#[test]
+fn test_filter_compiled_fast_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!(i)).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("$filter(items, function($x){$x >= 0})").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -855,3 +855,52 @@ fn test_descendant_raises_d2015() {
     let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
     assert!(err.to_string().contains("D2015"), "got: {err}");
 }
+
+/// `evaluate_path`'s single-step fast path (`steps.len() == 1`, `AstNode::Name`,
+/// non-tuple `JValue::Array` branch, src/evaluator.rs ~4030-4066) is reached via
+/// its own internal recursion for a NESTED array element (`items` is an array
+/// containing one element that is itself a 1000-element array of `{name}`
+/// objects). This exercises and covers the fast path's own D2015 check (its
+/// `return` skips this `evaluate_path` invocation's shared final-return
+/// chokepoint). Note: for this specific construction the *outer* `items.name`
+/// call still separately hits the shared chokepoint too (its own `result`
+/// accumulates the same 1000 elements via the general per-step loop before
+/// returning), so this particular data shape doesn't prove the fast path's own
+/// check is independently load-bearing — every currently-reachable call into
+/// this fast path is itself a nested recursive call from a frame whose
+/// steps.len() >= 2, which always has an active chokepoint of its own. It is
+/// still correct and consistent (defense-in-depth parity with every other
+/// query-result-sequence exit point in this function) to check here directly.
+#[test]
+fn test_path_single_step_fast_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": [(0..1000).map(|i| serde_json::json!({"name": format!("item{i}")})).collect::<Vec<_>>()]
+    }).into();
+    let ast = parse("items.name").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+
+/// `evaluate_path`'s 2-step `$variable.field` fast path (src/evaluator.rs
+/// ~4181-4206) `return`s directly and bypasses the shared final-return
+/// chokepoint, so it needs its own independent D2015 check.
+#[test]
+fn test_path_variable_field_fast_path_raises_d2015() {
+    let data: JValue = serde_json::json!({
+        "items": (0..1000).map(|i| serde_json::json!({"name": format!("item{i}")})).collect::<Vec<_>>()
+    }).into();
+    let ast = parse("($v := items; $v.name)").unwrap();
+    let options = EvaluatorOptions {
+        max_sequence_length: Some(10),
+        ..Default::default()
+    };
+    let mut evaluator = Evaluator::with_options(Context::new(), options);
+    let err = evaluator.evaluate(&ast, &data).expect_err("expected D2015");
+    assert!(err.to_string().contains("D2015"), "got: {err}");
+}
+

--- a/tests/python/test_guardrails.py
+++ b/tests/python/test_guardrails.py
@@ -158,12 +158,29 @@ class TestSequenceLengthD2015:
         # previously had no D2015 check at all (fixed alongside `vm.rs`'s
         # `get_field_cached`, which had the same gap for the simpler
         # `items.name`-shaped case covered above).
+        #
+        # IMPORTANT: the filter predicate must itself be *compilable*
+        # (`try_compile_expr_inner` handles simple comparisons/arithmetic/
+        # literals, but has no arm for function calls like `$exists(...)`).
+        # A non-compilable predicate makes `try_compile_path` return None for
+        # the *whole* path expression, so the entire thing falls straight to
+        # the tree-walker's `evaluate_path` (already correct from an earlier
+        # task) and never reaches `compiled_eval_field_path`/
+        # `compiled_field_step` at all -- silently defeating this regression
+        # test (confirmed via revert-oracle: with `$exists(sub)` as the
+        # filter, this test kept passing even with the `compiled_field_step`
+        # fix reverted). `flag=true` is a plain equality comparison, which
+        # *does* compile (`CompiledExpr::Compare`), so this correctly routes
+        # through `EvalFallback`/`compiled_field_step`.
         data = {
-            "items": [{"sub": [{"v": i} for i in range(1000)]} for _ in range(3)]
+            "items": [
+                {"flag": True, "sub": [{"v": i} for i in range(1000)]}
+                for _ in range(3)
+            ]
         }
         with pytest.raises(ValueError, match="D2015"):
             jsonatapy.evaluate(
-                "items[$exists(sub)].sub.v", data, max_sequence_length=10
+                "items[flag=true].sub.v", data, max_sequence_length=10
             )
 
     def test_filter_raises_d2015(self):

--- a/tests/python/test_guardrails.py
+++ b/tests/python/test_guardrails.py
@@ -1,0 +1,237 @@
+"""Tests for the resource-guardrails feature (timeout/max_stack_depth/max_sequence_length).
+
+Mirrors jsonata-js 2.2.1's guardrails: D1011 (stack), D1012 (timeout), D2015 (sequence).
+See docs/superpowers/specs/2026-07-04-jsonata-2.2.1-design.md, Phase 2.
+"""
+
+import jsonatapy
+import pytest
+
+
+def _force_tree_walker(expr: jsonatapy.JsonataExpression, data, **guardrails):
+    """Force the tree-walker fallback by passing a non-None bindings dict
+    (even empty), per the mechanism `JsonataExpression.run_eval` uses in
+    `src/lib.rs`: any non-None `bindings` always routes through
+    `create_evaluator()`/`Evaluator::with_options()`, bypassing the cached
+    bytecode VM entirely."""
+    return expr.evaluate(data, bindings={}, **guardrails)
+
+
+class TestStackDepthD1011:
+    def test_recursive_lambda_raises_d1011(self):
+        expr = "($inf := function($n){$n+$inf($n-1)}; $inf(5))"
+        with pytest.raises(ValueError, match="D1011"):
+            jsonatapy.evaluate(expr, None, max_stack_depth=10)
+
+    def test_without_option_recursive_lambda_raises_u1001_not_d1011(self):
+        # No max_stack_depth set: the hardcoded native-stack backstop (U1001)
+        # is what fires, not D1011.
+        expr = "($inf := function($n){$n+$inf($n-1)}; $inf(5))"
+        with pytest.raises(ValueError, match="U1001"):
+            jsonatapy.evaluate(expr, None)
+
+    def test_parity_vm_vs_tree_walker(self):
+        # Self-recursive named lambdas can't compile to CompiledExpr (no
+        # "call named lambda" IR node exists), so both the default (VM-
+        # preferred) path and the bindings-forced tree-walker path fall
+        # through to the same guarded evaluate_internal/evaluate_internal_impl
+        # code -- this is true "for free", not because of extra plumbing.
+        expr_str = "($inf := function($n){$n+$inf($n-1)}; $inf(5))"
+        compiled = jsonatapy.compile(expr_str)
+        with pytest.raises(ValueError, match="D1011"):
+            compiled.evaluate(None, max_stack_depth=10)
+        with pytest.raises(ValueError, match="D1011"):
+            _force_tree_walker(compiled, None, max_stack_depth=10)
+
+
+class TestTimeoutD1012:
+    def test_slow_expression_raises_d1012(self):
+        # NOTE: this deliberately avoids a deeply left-nested arithmetic
+        # chain (e.g. `1+1+1+...`) as the brief's starting code originally
+        # used. Both the parser's recursive-descent `parse_expression` and
+        # (independently) the compiler's `MakeArray(u16)` bytecode instr for
+        # array-literal AST nodes have real, pre-existing bugs at large N
+        # that are NOT part of this guardrails feature -- see the report for
+        # detail. A left-nested chain of ~4000+ terms segfaults at *parse*
+        # time (native stack overflow, unguarded by `stacker::maybe_grow`
+        # unlike the evaluator's recursion-depth check), and an array
+        # literal `[1,1,...]` with >65536 elements silently produces a
+        # wrong-length result (u16 truncation in `Instr::MakeArray`). Using
+        # large *data* (a Python-supplied array, not a JSONata source-level
+        # array literal) through a non-compilable lambda body sidesteps both
+        # bugs while still reliably exercising the tree-walker's per-node
+        # `evaluate_internal` timeout checkpoint (not the MapCall fast path,
+        # which has its own dedicated test below).
+        data = {"items": [{"a": i} for i in range(500_000)]}
+        compiled = jsonatapy.compile("$map(items, function($x){$x.*})")
+        with pytest.raises(ValueError, match="D1012"):
+            _force_tree_walker(compiled, data, timeout=1)
+
+    def test_without_option_never_times_out(self):
+        data = {"items": [{"a": i} for i in range(200_000)]}
+        result = jsonatapy.evaluate("items.a", data)
+        assert len(result) == 200_000
+        assert result[0] == 0
+        assert result[-1] == 199_999
+
+    def test_compiled_map_fast_path_raises_d1012(self):
+        # Forces the eval_compiled_inner MapCall loop, which bypasses
+        # evaluate_internal's per-node checkpoint entirely -- the timeout
+        # check here is a deliberate extension beyond the design spec's
+        # literal text (which only mentions checking at evaluate_internal).
+        data = {"items": list(range(500_000))}
+        with pytest.raises(ValueError, match="D1012"):
+            jsonatapy.evaluate("$map(items, function($x){$x*2})", data, timeout=1)
+
+    def test_parity_vm_vs_tree_walker_vs_compiled(self):
+        data = {"items": list(range(500_000))}
+        compiled = jsonatapy.compile("$map(items, function($x){$x*2})")
+        with pytest.raises(ValueError, match="D1012"):
+            compiled.evaluate(data, timeout=1)
+        with pytest.raises(ValueError, match="D1012"):
+            _force_tree_walker(compiled, data, timeout=1)
+
+    def test_tco_trampoline_raises_d1012(self):
+        # jsonata-js's own canonical timeout-guardrail example: a
+        # tail-recursive lambda with no base case, evaluated through the
+        # TCO trampoline (invoke_lambda_with_tco), not the plain recursive
+        # evaluator call stack. Before the Task-11-followup fix, the
+        # trampoline had NO timeout check at all -- only a hardcoded
+        # 100,000-iteration cap producing U1001. Now check_loop_timeout is
+        # called every trampoline iteration, and the 100k cap is skipped
+        # entirely once a timeout is configured, so this must raise D1012,
+        # not U1001.
+        expr = "($inf := function(){$inf()}; $inf())"
+        with pytest.raises(ValueError, match="D1012"):
+            jsonatapy.evaluate(expr, None, timeout=100)
+
+
+class TestSequenceLengthD2015:
+    @pytest.mark.parametrize(
+        "expr,data",
+        [
+            ("[1..1000]", None),
+            ("items.name", {"items": [{"name": f"n{i}"} for i in range(1000)]}),
+            ("*", {f"k{i}": i for i in range(1000)}),
+            ("**", {"items": [{"v": i} for i in range(1000)]}),
+            ("$keys(items)", {"items": [{f"k{i}": 1} for i in range(1000)]}),
+            ("$lookup(items, 'v')", {"items": [{"v": i} for i in range(1000)]}),
+            ("$append(a, b)", {"a": list(range(500)), "b": list(range(500))}),
+            (
+                "$spread(items)",
+                {"items": [{f"k{i}": i} for i in range(1000)]},
+            ),
+            (
+                "$each(items, function($v){$v})",
+                {"items": {f"k{i}": i for i in range(1000)}},
+            ),
+        ],
+    )
+    def test_raises_d2015_generic_tree_walker_path(self, expr, data):
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(expr, data, max_sequence_length=10)
+
+    def test_map_raises_d2015_both_fast_and_generic_path(self):
+        data = {"items": list(range(1000))}
+        # Compilable lambda body -> CompiledExpr::MapCall fast path
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$map(items, function($x){$x*2})", data, max_sequence_length=10
+            )
+        # Non-compilable lambda body (`$x.*` has no CompiledExpr::Wildcard arm)
+        # -> generic tree-walker loop
+        data2 = {"items": [{"a": i} for i in range(1000)]}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$map(items, function($x){$x.*})", data2, max_sequence_length=10
+            )
+
+    def test_multistep_filtered_path_raises_d2015_eval_fallback(self):
+        # `items[filter].sub.v` has >1 field-path step AND a filter on the
+        # first step, so `BytecodeCompiler::compile_expr` cannot inline it as
+        # a simple GetDataField/GetField chain (that only handles all-simple
+        # steps) or as the single-step-with-filter case -- it falls back to
+        # `Instr::EvalFallback` -> `eval_compiled_inner`'s
+        # `CompiledExpr::FieldPath` arm -> `compiled_eval_field_path` ->
+        # `compiled_field_step`'s array-mapping branch. This regression
+        # tests a genuine gap found while writing this suite: that function
+        # previously had no D2015 check at all (fixed alongside `vm.rs`'s
+        # `get_field_cached`, which had the same gap for the simpler
+        # `items.name`-shaped case covered above).
+        data = {
+            "items": [{"sub": [{"v": i} for i in range(1000)]} for _ in range(3)]
+        }
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "items[$exists(sub)].sub.v", data, max_sequence_length=10
+            )
+
+    def test_filter_raises_d2015(self):
+        data = {"items": list(range(1000))}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$filter(items, function($x){$x >= 0})",
+                data,
+                max_sequence_length=10,
+            )
+
+    def test_predicate_filter_raises_d2015_pure_vm_path(self):
+        # `items[price > 0]` compiles fully to bytecode (GetDataField +
+        # FilterByBytecode) when there's no bindings -> pure VM path, no
+        # tree-walker/eval_compiled fallback involved at all.
+        data = {"items": [{"price": i} for i in range(1000)]}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate("items[price >= 0]", data, max_sequence_length=10)
+
+    def test_predicate_filter_parity_vm_vs_tree_walker(self):
+        data = {"items": [{"price": i} for i in range(1000)]}
+        compiled = jsonatapy.compile("items[price >= 0]")
+        with pytest.raises(ValueError, match="D2015"):
+            compiled.evaluate(data, max_sequence_length=10)
+        with pytest.raises(ValueError, match="D2015"):
+            _force_tree_walker(compiled, data, max_sequence_length=10)
+
+    def test_without_option_no_cap(self):
+        data = {"items": list(range(1000))}
+        result = jsonatapy.evaluate("items", data)
+        assert len(result) == 1000
+
+    def test_reduce_accumulator_itself_uncapped_but_append_inside_it_is_capped(self):
+        # $reduce has no createSequence() call upstream (jsonata-js
+        # functions.js) - its accumulator is intentionally NOT subject to
+        # max_sequence_length, even if the accumulator happens to be an array.
+        # This expression's accumulator grows via repeated $append calls
+        # (0, 1, 2, ... elements); $append's own pre-check is
+        # `arr.len() + second_len > max`, so it raises as soon as the
+        # accumulator already holds `max` elements and a further single-item
+        # append would exceed it -- i.e. on the 11th call (10 + 1 > 10), long
+        # before $reduce's own (uncapped) loop would reach 1000 iterations.
+        # This confirms the cap comes from $append's independent guard, not
+        # from $reduce itself capping its accumulator.
+        data = {"items": list(range(1000))}
+        with pytest.raises(ValueError, match="D2015"):
+            jsonatapy.evaluate(
+                "$reduce(items, function($acc, $x){$append($acc, $x)}, [])",
+                data,
+                max_sequence_length=10,
+            )
+
+
+class TestCompileTimeDefaults:
+    def test_compile_time_default_applies_to_evaluate_without_kwargs(self):
+        expr = jsonatapy.compile(
+            "($inf := function($n){$n+$inf($n-1)}; $inf(5))", max_stack_depth=10
+        )
+        with pytest.raises(ValueError, match="D1011"):
+            expr.evaluate(None)
+
+    def test_per_call_kwarg_overrides_compile_time_default(self):
+        expr = jsonatapy.compile(
+            "($inf := function($n){$n+$inf($n-1)}; $inf(5))", max_stack_depth=10
+        )
+        # Override with a much higher limit at call time - should now hit the
+        # hardcoded U1001 ceiling instead of D1011, or succeed if the
+        # recursion terminates within both limits (it won't terminate - $inf
+        # has no base case - so expect U1001 here).
+        with pytest.raises(ValueError, match="U1001"):
+            expr.evaluate(None, max_stack_depth=100_000)

--- a/tests/python/test_guardrails.py
+++ b/tests/python/test_guardrails.py
@@ -135,16 +135,12 @@ class TestSequenceLengthD2015:
         data = {"items": list(range(1000))}
         # Compilable lambda body -> CompiledExpr::MapCall fast path
         with pytest.raises(ValueError, match="D2015"):
-            jsonatapy.evaluate(
-                "$map(items, function($x){$x*2})", data, max_sequence_length=10
-            )
+            jsonatapy.evaluate("$map(items, function($x){$x*2})", data, max_sequence_length=10)
         # Non-compilable lambda body (`$x.*` has no CompiledExpr::Wildcard arm)
         # -> generic tree-walker loop
         data2 = {"items": [{"a": i} for i in range(1000)]}
         with pytest.raises(ValueError, match="D2015"):
-            jsonatapy.evaluate(
-                "$map(items, function($x){$x.*})", data2, max_sequence_length=10
-            )
+            jsonatapy.evaluate("$map(items, function($x){$x.*})", data2, max_sequence_length=10)
 
     def test_multistep_filtered_path_raises_d2015_eval_fallback(self):
         # `items[filter].sub.v` has >1 field-path step AND a filter on the
@@ -172,16 +168,9 @@ class TestSequenceLengthD2015:
         # fix reverted). `flag=true` is a plain equality comparison, which
         # *does* compile (`CompiledExpr::Compare`), so this correctly routes
         # through `EvalFallback`/`compiled_field_step`.
-        data = {
-            "items": [
-                {"flag": True, "sub": [{"v": i} for i in range(1000)]}
-                for _ in range(3)
-            ]
-        }
+        data = {"items": [{"flag": True, "sub": [{"v": i} for i in range(1000)]} for _ in range(3)]}
         with pytest.raises(ValueError, match="D2015"):
-            jsonatapy.evaluate(
-                "items[flag=true].sub.v", data, max_sequence_length=10
-            )
+            jsonatapy.evaluate("items[flag=true].sub.v", data, max_sequence_length=10)
 
     def test_filter_raises_d2015(self):
         data = {"items": list(range(1000))}


### PR DESCRIPTION
## Summary

Ports jsonata-js 2.2.1's resource-guardrails feature to `jsonata-core`/`jsonatapy`: `timeout`, `max_stack_depth`, and `max_sequence_length` limits, raising `D1012`, `D1011`, and `D2015` respectively. Implemented per `docs/superpowers/plans/2026-07-07-jsonata-2.2.1-phase2-guardrails-plan.md` (13 tasks + one follow-up fix), each independently reviewed, plus a final whole-branch review with its own fix-up commit.

- New `EvaluatorOptions { timeout_ms, max_stack_depth, max_sequence_length }` (all `Option<_>`, default `None` = unlimited/unchanged behavior), threaded through all three execution surfaces this port has beyond jsonata-js's single engine: the tree-walker, the compiled-expression fast-path interpreter (`eval_compiled_inner`), and the bytecode VM.
- `D1011` extends the existing `recursion_depth`/`max_recursion_depth` mechanism (the hardcoded native-stack safety net, `U1001`, stays an always-on backstop per GitHub issue #34).
- `D1012` checks at the tree-walker's per-node checkpoint, plus a single entry-point check in `eval_compiled_inner` (every HOF/lambda fast path funnels through it) and in the TCO trampoline (a separate execution loop discovered mid-implementation to have no timeout protection at all).
- `D2015` is enforced at every query-result-sequence construction site across all three engines — range, path-mapping, wildcard, descendants, map/filter/keys/lookup/append/spread/each, and the VM's field-mapping and predicate-filter paths. Two corrections were made to the original construct list, verified against the actual vendored jsonata-js source rather than assumed: `$sift` is excluded (not capped upstream), `$lookup` is included (capped upstream, wasn't in the original list).
- Python surface: `timeout`/`max_stack_depth`/`max_sequence_length` keyword args on `evaluate()`, `compile()`, and all four `JsonataExpression` methods, with compile-time defaults that per-call kwargs can override.
- New test suite `tests/python/test_guardrails.py` (26 cases) plus Rust-side coverage, verifying cross-surface parity (same guardrail fires whether an expression takes the default VM-preferred path or is forced through the tree-walker).

Several real bugs were found and fixed along the way, beyond the original plan text:
- `evaluate_path`'s early-return fast paths bypassed `D2015` (only the shared final exit was originally guarded).
- The TCO trampoline (`invoke_lambda_with_tco`) had no timeout check at all, only a hardcoded 100k-iteration cap producing the wrong error code even with a timeout configured — including for jsonata-js's own canonical guardrails-doc example (`$inf := function(){$inf()}; $inf()`).
- The VM's simple field-mapping path (`items.name`-shaped expressions) had no `D2015` check at all — likely the most common expression shape of any covered.
- Minor: a few 0/1/N boundary inconsistencies in singleton-unwrap branches, and one dead-code cleanup.

## Known, out-of-scope issues (not fixed by this PR — flagged in the design spec for follow-up)

- **Parser has no recursion-depth guard.** Deeply left-nested arithmetic expressions (~4000+ terms) can SIGSEGV the whole process at parse time, before any evaluator guardrail gets a chance to run.
- **`Instr::MakeArray(u16)` silently truncates array literals over 65,536 elements** (unchecked `as u16` cast in `src/compiler.rs`) — wrong results, no error. More severe than the parser crash since it's silent data corruption. Fixing it would also unblock adding a literal-array `D2015` check for full upstream parity (jsonata-js does cap flat literal arrays too, via its `createSequence`-backed `append`; this port currently doesn't).

Given the second issue, holding off on cutting a `2.2.0` release until it's addressed separately.

## Test plan

- [x] `cargo test --all-features` — 244/244 passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `uv run pytest tests/python/` — reference suite 1682/1682 (unchanged, no regressions), `test_guardrails.py` 26/26
- [x] `ruff check` / `mypy` on Python additions — clean (mypy's 5 pre-existing errors confirmed identical to baseline, not regressions)
- [x] Each of the 13 tasks + 1 follow-up individually reviewed (several with review→fix cycles)
- [x] Final whole-branch review (Opus) with its own fix-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)