### PR TITLE
Apply min-of-N repeated trials to all benchmark implementations

### DIFF
--- a/benchmarks/python/benchmark.py
+++ b/benchmarks/python/benchmark.py
@@ -42,10 +42,28 @@ REPEAT_TRIALS = 5
 
 def _describe_platform() -> str:
     """Describe the environment actually running the benchmark, not wherever
-    a later doc-regeneration script happens to be invoked from."""
+    a later doc-regeneration script happens to be invoked from.
+
+    Explicitly distinguishes a self-hosted runner from a GitHub-hosted one
+    (RUNNER_ENVIRONMENT, set by Actions itself) rather than just saying
+    "GitHub Actions (macOS, ARM64)" for both - that phrasing alone reads as
+    a generic, shared macos-14 runner, hiding the one property that actually
+    matters for trusting these numbers: dedicated, single-tenant, physical
+    hardware, not shared/virtualized cloud infrastructure. Confirmed
+    empirically (this project's own benchmark-data history) that the
+    difference is not cosmetic - identical code measured twice on a shared
+    runner swung -66% to +120%.
+    """
     if os.environ.get("GITHUB_ACTIONS") == "true":
         runner_os = os.environ.get("RUNNER_OS", platform.system())
         runner_arch = os.environ.get("RUNNER_ARCH", platform.machine())
+        runner_env = os.environ.get("RUNNER_ENVIRONMENT", "")
+        runner_name = os.environ.get("RUNNER_NAME", "")
+        if runner_env == "self-hosted":
+            label = f"self-hosted {runner_name}" if runner_name else "self-hosted"
+            return (
+                f"GitHub Actions ({label}, physical/dedicated hardware, {runner_os} {runner_arch})"
+            )
         return f"GitHub Actions ({runner_os}, {runner_arch})"
     return f"{platform.system()} {platform.release()} on {platform.machine()}"
 
@@ -157,8 +175,17 @@ class BenchmarkSuite:
             print("  Run 'cd benchmarks && cargo build --release' to build it")
             return False
 
-    def _run_js_benchmark(self, expression: str, data: Any, iterations: int) -> float:
-        """Run benchmark using JavaScript reference implementation."""
+    def _run_js_benchmark(
+        self, expression: str, data: Any, iterations: int, repeats: int = REPEAT_TRIALS
+    ) -> float:
+        """Run benchmark using JavaScript reference implementation.
+
+        Takes the minimum elapsed time across `repeats` independent
+        subprocess invocations - see _run_jsonatapy_benchmark's docstring
+        for why min, not mean/median. Each invocation is a fresh `node`
+        process (the script itself does its own warmup internally), so this
+        also filters out process-startup noise, not just measurement noise.
+        """
         if not self.node_available:
             return -1.0
 
@@ -172,19 +199,25 @@ class BenchmarkSuite:
         benchmark_data = {"expression": expression, "data": data, "iterations": iterations}
 
         try:
-            result = subprocess.run(
-                ["node", str(js_script)],
-                input=json.dumps(benchmark_data),
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
+            best_elapsed = None
+            for _ in range(repeats):
+                result = subprocess.run(
+                    ["node", str(js_script)],
+                    input=json.dumps(benchmark_data),
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
 
-            if result.returncode != 0:
-                print(f"⚠ JavaScript benchmark failed: {result.stderr}")
-                return -1.0
+                if result.returncode != 0:
+                    print(f"⚠ JavaScript benchmark failed: {result.stderr}")
+                    return -1.0
 
-            return float(result.stdout.strip())
+                elapsed = float(result.stdout.strip())
+                if best_elapsed is None or elapsed < best_elapsed:
+                    best_elapsed = elapsed
+
+            return best_elapsed
         except Exception as e:
             print(f"⚠ Error running JavaScript benchmark: {e}")
             return -1.0
@@ -279,7 +312,9 @@ class BenchmarkSuite:
 
         return best_elapsed * 1000  # Convert to milliseconds
 
-    def _run_jsonata_python_benchmark(self, expression: str, data: Any, iterations: int) -> float:
+    def _run_jsonata_python_benchmark(
+        self, expression: str, data: Any, iterations: int, repeats: int = REPEAT_TRIALS
+    ) -> float:
         """Run benchmark using jsonata-python (rayokota) implementation.
 
         jsonata-python doesn't support pre-compiling an *expression*, but its
@@ -293,6 +328,15 @@ class BenchmarkSuite:
         filter (where JSON-string marshalling dominates instead). Using
         Context here matches every other implementation in this suite, which
         all compile/warm once and evaluate many times in the timed loop.
+
+        Takes the minimum elapsed time across `repeats` independent
+        measurement trials (after one shared warmup) - see
+        _run_jsonatapy_benchmark's docstring for why min, not mean/median.
+        Note this multiplies this already-slow implementation's runtime by
+        `repeats` - deliberate, since this function is only used by the
+        release-triggered benchmark job (on the fast Mac Mini runner), never
+        the PR-triggered benchmark.yml (which skips jsonata-python entirely
+        for exactly this cost reason).
         """
         if not JSONATA_PYTHON_AVAILABLE:
             return -1.0
@@ -302,7 +346,7 @@ class BenchmarkSuite:
         else:
             call = jsonata_python.transform
 
-        # Warm up
+        # Warm up (once - shared across all measurement trials below)
         warmup_iters = min(100, max(10, iterations // 10))
         for _ in range(warmup_iters):
             try:
@@ -311,20 +355,33 @@ class BenchmarkSuite:
                 print(f"⚠ jsonata-python warmup failed: {e}")
                 return -1.0
 
-        # Measure
-        start = time.perf_counter()
-        for _ in range(iterations):
-            try:
-                call(expression, data)
-            except Exception as e:
-                print(f"⚠ jsonata-python evaluation failed: {e}")
-                return -1.0
-        elapsed = time.perf_counter() - start
+        # Measure: `repeats` independent trials, keep the minimum
+        best_elapsed = None
+        for _ in range(repeats):
+            start = time.perf_counter()
+            for _ in range(iterations):
+                try:
+                    call(expression, data)
+                except Exception as e:
+                    print(f"⚠ jsonata-python evaluation failed: {e}")
+                    return -1.0
+            elapsed = time.perf_counter() - start
+            if best_elapsed is None or elapsed < best_elapsed:
+                best_elapsed = elapsed
 
-        return elapsed * 1000  # Convert to milliseconds
+        return best_elapsed * 1000  # Convert to milliseconds
 
-    def _run_jsonata_rs_benchmark(self, expression: str, data: Any, iterations: int) -> float:
-        """Run benchmark using jsonata-rs (pure Rust) implementation."""
+    def _run_jsonata_rs_benchmark(
+        self, expression: str, data: Any, iterations: int, repeats: int = REPEAT_TRIALS
+    ) -> float:
+        """Run benchmark using jsonata-rs (pure Rust) implementation.
+
+        Takes the minimum elapsed time across `repeats` independent
+        subprocess invocations - see _run_jsonatapy_benchmark's docstring
+        for why min, not mean/median. Each invocation is a fresh process
+        (warmup happens inside the binary itself, per the "warmup" field
+        below), so this also filters out process-startup noise.
+        """
         if not self.jsonata_rs_available:
             return -1.0
 
@@ -341,17 +398,26 @@ class BenchmarkSuite:
         input_json = json.dumps(input_data)
 
         try:
-            result = subprocess.run(
-                [str(binary_path)], input=input_json, capture_output=True, text=True, timeout=60
-            )
+            best_elapsed = None
+            for _ in range(repeats):
+                result = subprocess.run(
+                    [str(binary_path)],
+                    input=input_json,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
 
-            if result.returncode != 0:
-                print(f"⚠ jsonata-rs failed: {result.stderr}")
-                return -1.0
+                if result.returncode != 0:
+                    print(f"⚠ jsonata-rs failed: {result.stderr}")
+                    return -1.0
 
-            # Parse output JSON
-            output = json.loads(result.stdout)
-            return output["elapsed_ms"]
+                output = json.loads(result.stdout)
+                elapsed = output["elapsed_ms"]
+                if best_elapsed is None or elapsed < best_elapsed:
+                    best_elapsed = elapsed
+
+            return best_elapsed
 
         except subprocess.TimeoutExpired:
             print("⚠ jsonata-rs benchmark timeout")
@@ -745,6 +811,7 @@ class BenchmarkSuite:
             "timestamp": datetime.now().isoformat(),
             "platform": _describe_platform(),
             "python_version": sys.version.split()[0],
+            "repeat_trials": REPEAT_TRIALS,
             "implementations": {
                 "jsonatapy": JSONATAPY_AVAILABLE,
                 "javascript": self.node_available,

--- a/benchmarks/python/generate_performance_doc.py
+++ b/benchmarks/python/generate_performance_doc.py
@@ -41,6 +41,8 @@ INTRO = """# Performance Benchmarks
 
 jsonatapy is a high-performance Rust implementation of JSONata with Python bindings. This page presents benchmark comparisons against other JSONata implementations.
 
+**These numbers come from a dedicated, self-hosted Mac Mini (Apple Silicon), not a shared cloud CI runner** — single-tenant physical hardware with no other workloads competing for CPU. This matters: single-sample measurements on a shared/virtualized runner were previously noisy enough that identical code, measured twice, swung -66% to +120%. Every number below is also the *minimum* of {repeat_trials} independent measurement trials per test (not an average) — for CPU-bound microbenchmarks, interference can only make a run slower than the code's true achievable speed, never faster, so the minimum across repeated trials is the best available estimate of that true speed.
+
 ## Implementations Tested
 
 | Implementation | Language | Version | Description |
@@ -191,6 +193,7 @@ def main() -> int:
     platform = data.get("platform", "unknown")
     python_version = data.get("python_version", "unknown")
     run_date = data.get("timestamp", "unknown")[:10]
+    repeat_trials = data.get("repeat_trials", "an unknown number of")
 
     try:
         import jsonatapy
@@ -219,6 +222,7 @@ def main() -> int:
         jsonatapy_version=jsonatapy_version,
         node_version=node_version,
         run_date=run_date,
+        repeat_trials=repeat_trials,
     )
 
     summary = "## Summary by Category\n\n" + category_summary_table(results)


### PR DESCRIPTION
## Summary

The earlier min-of-5 fix (`REPEAT_TRIALS`) that eliminated false-positive regression issues (#48, #51, #59, #60) only covered `_run_jsonatapy_benchmark`/`_run_jsonatapy_json_benchmark` — the two functions the release regression check actually reads. The comparison implementations (`_run_js_benchmark`, `_run_jsonata_python_benchmark`, `_run_jsonata_rs_benchmark`) still took a single sample each, so every "vs JS" speedup ratio in `docs/performance.md` was only half noise-protected: a robust jsonatapy numerator over a noisy single-sample denominator.

- All three now take the minimum across `REPEAT_TRIALS` independent trials, matching jsonatapy's own treatment.
  - `_run_js_benchmark`/`_run_jsonata_rs_benchmark`: repeat the whole subprocess invocation (each is a fresh process; warmup happens inside the script/binary itself), which also filters out process-startup noise, not just measurement noise.
  - `_run_jsonata_python_benchmark`: repeat the in-process measurement loop after one shared warmup, same pattern as jsonatapy's own functions.
- `jsonata-python`'s runtime is multiplied by `REPEAT_TRIALS` on top of its existing ~2,300–69,000x-slower-than-JS cost — deliberate, since this function is only exercised by the release-triggered job (fast Mac Mini runner), never the PR-triggered `benchmark.yml` (which already excludes `jsonata-python` entirely for this exact cost reason).
- `benchmark_results_*.json` now records `repeat_trials`, so `generate_performance_doc.py` can state the actual trial count instead of a hardcoded/guessed number.
- `_describe_platform()` now explicitly distinguishes a self-hosted runner from a generic GitHub-hosted one (`RUNNER_ENVIRONMENT`/`RUNNER_NAME`), since "GitHub Actions (macOS, ARM64)" alone reads as a shared runner and hides the property that actually matters for trusting these numbers.
- `docs/performance.md`'s generator now states both of the above explicitly in its intro paragraph, not just in the methodology footer's platform line.

## Test plan

- [x] `ruff check`/`ruff format --check` clean
- [x] Full local suite run (jsonatapy, JS, jsonata-python) completes successfully end-to-end with all implementations using min-of-5, no errors
- [x] `generate_performance_doc.py` verified to correctly read and display the new `repeat_trials` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhNiLcMUFR3r5tGYqeeMN1