### PR TITLE
fix(release): clean up stale /tmp worktrees on the self-hosted runner

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -124,6 +124,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # This runner is a persistent, self-hosted machine, not an
+          # ephemeral GitHub-hosted one - these /tmp worktree paths survive
+          # between job runs (neither path is ever explicitly torn down
+          # after use, on success or failure). Force-clean any leftover from
+          # a previous run before adding a fresh one, or `git worktree add`
+          # fails with "fatal: '<path>' already exists".
+          git worktree remove --force /tmp/performance-doc-commit 2>/dev/null || rm -rf /tmp/performance-doc-commit
+          git worktree prune
+
           git fetch origin main
           git worktree add /tmp/performance-doc-commit FETCH_HEAD
           cp docs/performance.md /tmp/performance-doc-commit/docs/performance.md
@@ -136,6 +145,9 @@ jobs:
             git push origin HEAD:main
           fi
           cd -
+
+          git worktree remove --force /tmp/benchmark-data-manual 2>/dev/null || rm -rf /tmp/benchmark-data-manual
+          git worktree prune
 
           git fetch origin benchmark-data
           git worktree add -B benchmark-data /tmp/benchmark-data-manual FETCH_HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -777,6 +777,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # This runner is a persistent, self-hosted machine, not an
+          # ephemeral GitHub-hosted one - /tmp/performance-doc-commit
+          # survives between job runs (it's never explicitly torn down
+          # after use, on success or failure). Force-clean any leftover from
+          # a previous run before adding a fresh one, or `git worktree add`
+          # fails with "fatal: '<path>' already exists".
+          git worktree remove --force /tmp/performance-doc-commit 2>/dev/null || rm -rf /tmp/performance-doc-commit
+          git worktree prune
+
           git fetch origin main
           git worktree add /tmp/performance-doc-commit FETCH_HEAD
 
@@ -847,6 +856,12 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Same persistent-runner staleness as the performance-doc-commit
+          # worktree above - force-clean any leftover from a previous run
+          # before adding a fresh one.
+          git worktree remove --force /tmp/benchmark-data 2>/dev/null || rm -rf /tmp/benchmark-data
+          git worktree prune
 
           # Read from FETCH_HEAD, not origin/benchmark-data - see the comment in
           # the "Download previous release baseline" step above for why.


### PR DESCRIPTION
## Summary

`benchmark-manual.yml` (dispatched with `record: true`) just failed:

```
fatal: '/tmp/performance-doc-commit' already exists
##[error]Process completed with exit code 128.
```

Root cause: the self-hosted Mac Mini is a persistent machine, not an
ephemeral GitHub-hosted one. None of these three "commit via a throwaway
worktree" steps ever tears its worktree down, on success or failure:

- `benchmark-manual.yml`: `/tmp/performance-doc-commit`, `/tmp/benchmark-data-manual`
- `release.yml`: `/tmp/performance-doc-commit`, `/tmp/benchmark-data`

Any leftover from a prior run (this looks like it predates PR #61, likely
from local development/testing of that worktree-commit logic on the
runner itself) makes the *next* run's `git worktree add` fail outright
with `already exists`. This would just as easily have broken the next
real release's "Commit updated docs/performance.md" step.

- Force-remove (`git worktree remove --force` falling back to `rm -rf`,
  then `git worktree prune`) each of the three paths immediately before
  creating it, in both workflows.
- `benchmark.yml`'s equivalent step is untouched — it runs on
  `ubuntu-latest`, an ephemeral GitHub-hosted runner, so it never
  accumulates cross-run state.

## Test plan

- [x] Reproduced the exact failure locally: created a leftover worktree at
  the same path, re-ran the old `git worktree add` command, got the
  identical `fatal: '<path>' already exists` error.
- [x] Confirmed the fix: same stale state, ran the new pre-cleanup +
  `git worktree add` sequence, succeeded.
- [x] Both workflow YAML files validated with `yaml.safe_load`.
- [x] Extracted and `bash -n`'d the three modified `run:` blocks — no
  syntax errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)