### PR TITLE
fix(cli): -n binds $ to true Undefined, not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `evaluate_json_or_none()`'s `json_str` parameter now accepts `None` (in addition to a JSON
+  string), binding the top-level context (`$`) to a true JSONata `Undefined` rather than an
+  explicit `null`. (#68)
+- `docs/cli.md`: a full command-line reference for both `jsonata` (Rust) and `jsonatapy`
+  (Python), covering flags, input resolution, output/exit-code semantics, and the MCP
+  subcommand — previously undocumented outside internal spec/plan files. (#68)
 
 ### Changed
 
@@ -16,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- The Python CLI's `-n`/`--null-input` now binds `$` to a true `Undefined`, matching the Rust
+  CLI exactly (`jsonatapy -n '$'` now prints nothing, as `jsonata -n '$'` already did). It
+  previously passed an explicit JSON `null` context instead, observable only for expressions
+  referencing `$` directly. (#68)
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ Supports Python 3.10, 3.11, 3.12, 3.13, 3.14 on Linux, macOS (Intel & ARM), and 
 
 ---
 
+## Command-line quick start
+
+Both packages also ship a CLI, `jq`-shaped, with an identical contract:
+
+```bash
+pip install jsonatapy
+echo '{"orders":[{"product":"Laptop","price":1200}]}' | jsonatapy 'orders[price > 100].product'
+# "Laptop"
+```
+
+See [CLI Reference](docs/cli.md) for the full flag/exit-code contract.
+
+---
+
 ## What is JSONata?
 
 JSONata is a query and transformation language for JSON data:
@@ -144,6 +158,7 @@ benchmark methodology.
 - [Installation](docs/installation.md)
 - [API Reference](docs/api.md)
 - [Usage Guide](docs/usage.md)
+- [CLI Reference](docs/cli.md)
 - [Performance](docs/performance.md)
 - [Optimization Tips](docs/optimization-tips.md)
 - [Building from Source](docs/development/building.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Comprehensive documentation for jsonatapy - the high-performance Python implemen
 ### Using jsonatapy
 - **[api.md](api.md)** - Complete Python API reference
 - **[usage.md](usage.md)** - Common patterns and examples
+- **[cli.md](cli.md)** - Command-line interface (`jsonata`/`jsonatapy`): flags, exit codes, examples
 - **[performance.md](performance.md)** - Performance guide and benchmarks
 
 ### Development

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,141 @@
+# Command-line interface
+
+Both packages ship a command-line tool with an identical flag/exit-code
+contract — `jsonata` (Rust, from `jsonata-core`) and `jsonatapy` (Python,
+from `jsonatapy`). Pick whichever matches how you installed the library;
+scripts written against one work unchanged against the other.
+
+The shape deliberately mirrors `jq`: `<tool> [OPTIONS] EXPRESSION [FILE]`,
+reading JSON from a file argument or stdin, printing the result to stdout.
+The expression syntax itself is JSONata, not `jq`'s — but where `jq` often
+needs several piped filters to filter, aggregate, and reshape data, a single
+JSONata expression usually does all three at once. Path expressions
+(`orders[price > 100].product`) will also look familiar if you've used
+JSONPath.
+
+## Installation
+
+```bash
+# Python
+pip install jsonatapy
+jsonatapy 'orders[price > 100].product' data.json
+
+# Rust (from source)
+cargo install jsonata-core --features cli
+jsonata 'orders[price > 100].product' data.json
+```
+
+## Usage
+
+```
+jsonata   [OPTIONS] [EXPRESSION] [FILE]
+jsonatapy [OPTIONS] [EXPRESSION] [FILE]
+
+<tool> [OPTIONS] --from-file <EXPR_FILE> [FILE]
+```
+
+If `FILE` is omitted, input is read from stdin.
+
+```bash
+echo '{"name": "Alice"}' | jsonatapy 'name'
+# "Alice"
+
+jsonatapy 'name' data.json
+# "Alice"
+```
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `-c`, `--compact` | Compact JSON output (default: pretty-printed) |
+| `-r`, `--raw-output` | Print string results without surrounding quotes (non-string results are unaffected) |
+| `-n`, `--null-input` | Don't read input; `$` is `Undefined`. Cannot be combined with a data-file argument. |
+| `-f`, `--from-file <FILE>` | Read the expression from `FILE` instead of the first positional argument. The (now single) remaining positional argument, if given, is the input data file. |
+| `--arg NAME=VALUE` | Bind `$NAME` to the string `VALUE`. Repeatable. `VALUE` may itself contain `=` characters (only the first `=` splits name from value). |
+| `--argjson NAME=JSON` | Bind `$NAME` to the JSON value parsed from `JSON`. Repeatable. |
+| `-V`, `--version` | Print version and exit 0. |
+| `-h`, `--help` | Print help and exit 0. |
+
+```bash
+jsonatapy --arg region=us --argjson limit=5 '$region & ": " & $limit' -n
+# "us: 5"
+```
+
+(The quotes are part of the JSON output — the result is a string. Use `-r` to print it unquoted.)
+
+## `-n`/`--null-input`
+
+Evaluates the expression with no input document at all: `$` is a true
+JSONata `Undefined`, not an explicit `null`. Useful for expressions that
+don't depend on external data (`$now()`, arithmetic, `--arg`/`--argjson`
+bindings):
+
+```bash
+jsonatapy -n '1 + 1'
+# 2
+```
+
+This is only observable for expressions that reference `$` directly — an
+explicit `null` context would print `null` for the bare expression `$`,
+while `Undefined` prints nothing:
+
+```bash
+jsonatapy -n '$'
+# (no output, exit 0)
+```
+
+## Output
+
+- A JSONata `Undefined` result prints nothing to stdout, exit 0.
+- A JSON `null` result prints the literal text `null`, exit 0.
+- Otherwise, the result is printed as JSON (pretty by default, single-line
+  with `-c`), followed by a trailing newline. With `-r`, string results are
+  printed unquoted/unescaped instead; non-string results are unaffected by
+  `-r`.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (including an `Undefined` result, and `--version`/`--help`) |
+| 1 | Expression parse error or evaluation error |
+| 2 | Usage/invocation error: bad flags, malformed `--arg`/`--argjson`, an incompatible flag combination (e.g. `-n` + data file), or an expression/input file that could not be read |
+| 3 | Input was read successfully but is not valid JSON |
+
+## Error message format
+
+Errors go to stderr. JSONata spec-coded errors (e.g. from evaluation or
+parsing — codes match `^[TDUS]\d{4}:`) are printed exactly as `CODE: message`
+with no extra prefix, so scripts/agents can pattern-match on the code
+directly:
+
+```bash
+jsonatapy 'null + 1' -n
+# T2002: The left side of the + operator must evaluate to a number
+```
+
+All other errors are prefixed with `error: ` (or, for non-spec-coded parse
+errors specifically, `Parse error: `).
+
+## MCP server (Python only)
+
+`jsonatapy` can also run as an [MCP](https://modelcontextprotocol.io/) server,
+exposing JSONata evaluation as tools for AI agents:
+
+```bash
+pip install 'jsonatapy[mcp]'
+jsonatapy mcp          # stdio transport
+jsonatapy mcp --http   # HTTP transport (default port 8000)
+```
+
+Because `mcp` is reserved as the first argument for this subcommand, it
+cannot be used as a literal expression naming a field called `mcp` — use
+`--from-file` or a longer path expression (e.g. `$.mcp`) instead.
+
+## Full contract
+
+`study/cli_spec.md` in the repository is the canonical, executable
+flag/exit-code contract both implementations are tested against
+(`study/cli_fixtures.json`) — consult it if you're contributing to either
+CLI implementation rather than just using it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,18 @@ let data = JValue::from_json_str(r#"{"orders":[{"product":"Laptop","price":1200}
 let result = Evaluator::new().evaluate(&ast, &data)?;
 ```
 
+## Command-line quick start
+
+Both packages also ship a CLI, `jq`-shaped, with an identical contract:
+
+```bash
+pip install jsonatapy
+echo '{"orders":[{"product":"Laptop","price":1200}]}' | jsonatapy 'orders[price > 100].product'
+# "Laptop"
+```
+
+See [CLI reference](cli.md) for the full flag/exit-code contract.
+
 ---
 
 ## Performance highlights

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -232,7 +232,7 @@ class JsonataExpression:
 
     def evaluate_json_or_none(
         self,
-        json_str: str,
+        json_str: str | None,
         bindings: dict[str, Any] | None = None,
         *,
         timeout: int | None = None,
@@ -248,7 +248,10 @@ class JsonataExpression:
         string "null" for an explicit null result.
 
         Args:
-            json_str: Input data as a JSON string
+            json_str: Input data as a JSON string, or None for no input
+                document at all -- the top-level context (`$`) is then a
+                true JSONata Undefined, distinct from passing "null" (an
+                explicit JSON null context).
             bindings: Optional additional variable bindings
             timeout: Maximum evaluation time in milliseconds (raises ValueError
                 with a D1012 code on timeout). Overrides any default set via

--- a/python/jsonatapy/_cli/run.py
+++ b/python/jsonatapy/_cli/run.py
@@ -42,7 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
         "-r", "--raw-output", action="store_true", help="Print string results without quotes"
     )
     parser.add_argument(
-        "-n", "--null-input", action="store_true", help="Don't read input; $ is null"
+        "-n", "--null-input", action="store_true", help="Don't read input; $ is Undefined"
     )
     parser.add_argument(
         "-f",
@@ -114,12 +114,13 @@ def _finite_float(text: str) -> float:
     return value
 
 
-def _read_input_json(input_source: InputStdin | InputFile | InputNull) -> str | int:
-    """Returns the raw input JSON text (or "null" for InputNull), or an int
-    exit code on failure. Does NOT parse the JSON itself -- only validates
-    it, since evaluate_json_or_none() takes the raw text directly."""
+def _read_input_json(input_source: InputStdin | InputFile | InputNull) -> str | int | None:
+    """Returns the raw input JSON text, None for InputNull (no input document
+    at all -- binds $ to a true Undefined via evaluate_json_or_none), or an
+    int exit code on failure. Does NOT parse the JSON itself -- only
+    validates it, since evaluate_json_or_none() takes the raw text directly."""
     if isinstance(input_source, InputNull):
-        return "null"
+        return None
     if isinstance(input_source, InputStdin):
         raw = sys.stdin.read()
     else:  # InputFile

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,11 @@ impl JsonataExpression {
     /// is_undefined() BEFORE serializing, exposing the same signal the
     /// Rust CLI (src/bin/jsonata/main.rs) already uses internally.
     ///
+    /// `json_str=None` means no input document at all -- the top-level
+    /// context (`$`) is bound to a true `Undefined`, matching the Rust
+    /// CLI's `--null-input` behavior. This is distinct from passing the
+    /// text `"null"`, which binds `$` to an explicit JSON null.
+    ///
     /// # Errors
     ///
     /// Returns ValueError if JSON parsing or evaluation fails
@@ -336,14 +341,17 @@ impl JsonataExpression {
     fn evaluate_json_or_none(
         &self,
         py: Python,
-        json_str: &str,
+        json_str: Option<&str>,
         bindings: Option<Py<PyAny>>,
         timeout: Option<u64>,
         max_stack_depth: Option<usize>,
         max_sequence_length: Option<usize>,
     ) -> PyResult<Option<String>> {
-        let json_data = JValue::from_json_str(json_str)
-            .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {}", e)))?;
+        let json_data = match json_str {
+            Some(s) => JValue::from_json_str(s)
+                .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {}", e)))?,
+            None => JValue::Undefined,
+        };
         let options = evaluator::EvaluatorOptions {
             timeout_ms: timeout.or(self.default_options.timeout_ms),
             max_stack_depth: max_stack_depth.or(self.default_options.max_stack_depth),

--- a/study/cli_fixtures.json
+++ b/study/cli_fixtures.json
@@ -40,6 +40,14 @@
     "expected_stderr_contains": null
   },
   {
+    "name": "null_input_binds_dollar_to_true_undefined",
+    "args": ["-n", "$"],
+    "stdin": null,
+    "expected_exit": 0,
+    "expected_stdout": "",
+    "expected_stderr_contains": null
+  },
+  {
     "name": "undefined_result_prints_nothing",
     "args": ["nonexistent_field"],
     "stdin": "{\"a\": 1}",

--- a/study/cli_spec.md
+++ b/study/cli_spec.md
@@ -79,24 +79,12 @@ this exact contract, using a new library method, `evaluate_json_or_none()`
 (added in Phase 2 specifically for this purpose), to correctly distinguish
 an Undefined *result* from an explicit null result -- both `evaluate()` and
 `evaluate_json()` collapse that distinction, `evaluate_json_or_none()`
-does not.
+does not. `evaluate_json_or_none()`'s `json_str` parameter also accepts
+`None` (in addition to a JSON string) to bind the top-level context (`$`)
+to a true `Undefined`, which `-n`/`--null-input` uses -- this is distinct
+from passing the text `"null"`, which binds `$` to an explicit JSON null.
 
-Two disclosed divergences remain:
-
-- **`-n`/`--null-input` uses a `null` evaluation context, not JSONata
-  `Undefined`.** The public `jsonatapy` Python API has no way to construct
-  a true `Undefined` top-level context (`None` always maps to `Null` — see
-  `python_to_json` in `src/lib.rs`). This is unobservable for expressions
-  that don't reference `$` (the common `-n` use case: `-n '1 + 1'`,
-  `-n '$now()'`), but is directly observable for the bare context reference
-  itself: `jsonata -n '$'` (Rust) prints nothing (exit 0, `Undefined`),
-  while `jsonatapy -n '$'` (Python) prints the text `null` (exit 0,
-  `Null`). Note `$exists($)` does **not** distinguish these — it returns
-  `false` under `-n` for both CLIs, since this implementation special-cases
-  `$exists($)` to check named-variable-binding presence rather than the
-  context value's actual definedness.
-  Pinned by `test_null_input_uses_null_not_undefined_context_known_divergence`
-  in `tests/python/test_cli.py`.
+One disclosed divergence remains:
 
 - **The literal word `mcp` as the first argument is reserved for the MCP
   subcommand (`jsonatapy mcp ...`) and cannot be used to evaluate an

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -174,27 +174,16 @@ def test_unknown_flag_exits_two_via_argparse_default() -> None:
     assert result.returncode == 2
 
 
-def test_null_input_uses_null_not_undefined_context_known_divergence() -> None:
-    """Documents a known, disclosed divergence from the Rust CLI (see this
-    plan's Global Constraints): the Python jsonatapy API has no way to
-    construct a true JSONata Undefined top-level CONTEXT (input) -- this is
-    distinct from Task 3's result-side fix (evaluate_json_or_none), which
-    already resolved the RESULT-side undefined/null ambiguity. -n passes a
-    null context instead of Undefined. Unobservable for expressions that
-    don't reference $ (the common -n use case). The bare context reference
-    $ itself distinguishes them directly -- confirmed live against the
-    built Rust binary: `jsonata -n '$'` prints nothing (exit 0, Undefined
-    result), while this Python CLI's `-n '$'` prints the text "null" (exit
-    0, Null result). (Do NOT use $exists($) for this -- verified live that
-    it returns false under -n for BOTH CLIs, because this Rust
-    implementation special-cases $exists($) to check named-variable-binding
-    presence rather than the actual context value's definedness, so it
-    never round-trips through Null-vs-Undefined at all.) If this test ever
-    starts failing because the divergence was fixed, delete it and update
-    study/cli_spec.md's Python-specific notes accordingly."""
+def test_null_input_binds_dollar_to_true_undefined() -> None:
+    """-n must bind $ to a true JSONata Undefined, matching the Rust CLI
+    exactly (`jsonata -n '$'` prints nothing, exit 0). Previously this CLI
+    passed an explicit JSON null context instead (Python's evaluate_json_or_none
+    had no way to represent "no input at all"), so `-n '$'` printed the text
+    "null" -- a disclosed divergence, now fixed via evaluate_json_or_none's
+    Optional json_str."""
     result = run_cli(["-n", "$"])
     assert result.returncode == 0
-    assert result.stdout == "null\n"
+    assert result.stdout == ""
 
 
 def test_mcp_subcommand_dispatches_without_crashing_on_missing_fastmcp(

--- a/tests/python/test_evaluate_json_or_none.py
+++ b/tests/python/test_evaluate_json_or_none.py
@@ -47,3 +47,14 @@ def test_evaluation_error_raises_value_error_with_coded_message() -> None:
         assert str(e).startswith("T2002:")
     else:
         raise AssertionError("expected ValueError for null + 1")
+
+
+def test_none_json_str_binds_context_to_true_undefined() -> None:
+    """None (no input at all) must produce a true JSONata Undefined context,
+    distinct from an explicit JSON null context. The bare context reference
+    `$` distinguishes them: with Undefined context, `$` evaluates to
+    Undefined (this method returns None); with a null context, `$` evaluates
+    to the null value itself (this method returns the string "null")."""
+    expr = jsonatapy.compile("$")
+    assert expr.evaluate_json_or_none(None) is None
+    assert expr.evaluate_json_or_none("null") == "null"


### PR DESCRIPTION
## Summary
- `evaluate_json_or_none`'s `json_str` parameter now accepts `None` (in addition to a JSON string). `None` binds the top-level context (`$`) to a true JSONata `Undefined`; passing the text `"null"` still binds it to an explicit JSON `null` — these are now distinguishable, matching what the JSONata spec and the Rust CLI already do.
- The Python CLI's `-n`/`--null-input` now passes `None` instead of the literal string `"null"`, so `jsonatapy -n '$'` now prints nothing (exit 0), matching `jsonata -n '$'` (Rust) exactly. Previously it printed the text `null`.
- Added a `-n '$'` case to `study/cli_fixtures.json`, the shared fixture file both `tests/cli_fixtures_test.rs` (Rust) and `tests/python/test_cli_fixtures.py` (Python) run against, so this exact cross-language parity point is now locked in and can't silently regress.
- Removed the now-fixed "disclosed divergence" from `study/cli_spec.md`; one divergence remains (the `mcp` subcommand reservation), unrelated to this fix.
- Added CLI documentation.

This was previously a known, disclosed limitation (see `study/cli_spec.md`) rather than a silent bug — the public `jsonatapy` API had no way to represent "no input document at all" as opposed to an explicit JSON `null`, since `python_to_json` maps Python `None` to `JValue::Null`. This only affected expressions that reference `$` directly under `-n` (e.g. `-n '$'`, `-n '$type($)'`); the common case (`-n '1 + 1'`) was already correct.

## Test plan
- [x] `cargo test --features cli` — 175 unit tests + `cli_fixtures_test` (24 shared fixture cases, including the new one) + `cli_test` (72 tests) + `parent_and_focus_binding_suite` all pass
- [x] `uv run pytest tests/python/` — 1868 passed, 4 skipped (full reference suite + CLI tests + the new `evaluate_json_or_none(None)` unit test)
- [x] `uv run pytest tests/python/test_cli_fixtures.py -v` — confirmed the shared fixture runner (generic, loads all of `cli_fixtures.json`) executes the new case
- [x] `ruff check` clean on touched paths
- [x] `mypy python/` — same 6 pre-existing errors as main (missing native-extension stub, `no-any-return` from untyped PyO3 calls); no new errors introduced
- [x] TDD: wrote failing tests first at both the library level (`evaluate_json_or_none(None)`) and CLI level (`-n '$'`), watched each fail for the expected reason, then implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)