### PR TITLE
ci(release): gate registry publishes on CLI binary build; version archive names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist-cli
-          tar czf dist-cli/jsonata-${{ matrix.platform.target }}.tar.gz \
+          tar czf dist-cli/jsonata-v${{ needs.validate-version.outputs.version }}-${{ matrix.platform.target }}.tar.gz \
             -C target/${{ matrix.platform.target }}/release jsonata
 
       - name: Package binary (Windows)
@@ -354,7 +354,7 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path dist-cli
           Compress-Archive -Path target/${{ matrix.platform.target }}/release/jsonata.exe `
-            -DestinationPath dist-cli/jsonata-${{ matrix.platform.target }}.zip
+            -DestinationPath dist-cli/jsonata-v${{ needs.validate-version.outputs.version }}-${{ matrix.platform.target }}.zip
 
       - name: Upload CLI binary
         uses: actions/upload-artifact@v7
@@ -569,7 +569,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [validate-version, test-wheels, generate-changelog]
+    needs: [validate-version, test-wheels, build-cli-binaries, generate-changelog]
     if: github.event.inputs.dry_run != 'true'
     timeout-minutes: 15
     environment:
@@ -607,7 +607,7 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    needs: [validate-version, test-wheels]
+    needs: [validate-version, test-wheels, build-cli-binaries]
     if: github.event.inputs.dry_run != 'true'
     timeout-minutes: 20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subcommand — previously undocumented outside internal spec/plan files. (#68)
 
 ### Changed
+- Release CLI binary archives are now named `jsonata-v<version>-<target>.tar.gz`/`.zip`
+  (previously `jsonata-<target>.tar.gz`/`.zip` with no version embedded).
 
 ### Deprecated
 
@@ -26,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CLI exactly (`jsonatapy -n '$'` now prints nothing, as `jsonata -n '$'` already did). It
   previously passed an explicit JSON `null` context instead, observable only for expressions
   referencing `$` directly. (#68)
+- Release workflow: `publish-pypi` and `publish-crates` now require `build-cli-binaries` to
+  succeed first. Previously the two registry publishes were independent of the CLI binary
+  build, so a CLI build failure (untested in a real release prior to this) would have shipped
+  a version to PyPI/crates.io with no CLI binaries attached and no way to reuse that version
+  number.
 
 ### Security
 


### PR DESCRIPTION
## Summary
Preparing for the 2.2.3 release, which ships the entire CLI surface (Rust + Python binaries, MCP server, and PR #68's `-n` fix) for the first time since v2.2.2. Two gaps found while auditing `release.yml`:

- `build-cli-binaries` was added on 2026-07-10 (post-v2.2.2) and has **never run in a real release**, but `publish-pypi`/`publish-crates` didn't depend on it succeeding. If it failed, both registries would still publish 2.2.3 (irreversibly, no re-publish at the same version on either) with no CLI binaries attached and `create-github-release` skipped. Fixed by adding `build-cli-binaries` to both publish jobs' `needs:`.
- CLI release archives were named `jsonata-<target>.tar.gz`/`.zip` with no version embedded. Now `jsonata-v<version>-<target>.tar.gz`/`.zip`.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed via GitHub Actions' implicit-`success()` semantics that adding a job to `needs:` (without touching the job's existing `if:`, since it contains no `always()`/`failure()`/`cancelled()`) is sufficient to gate on it
- [ ] Will verify end-to-end when the 2.2.3 release workflow actually runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)