### PR TITLE
fix(evaluator): tree-walker math builtins propagate undefined

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -7039,6 +7039,9 @@ impl Evaluator {
                         "length() requires exactly 1 argument".to_string(),
                     ));
                 }
+                if evaluated_args[0].is_undefined() {
+                    return Ok(JValue::Undefined);
+                }
                 match &evaluated_args[0] {
                     JValue::String(s) => Ok(functions::string::length(s)?),
                     _ => Err(EvaluatorError::TypeError(
@@ -7711,6 +7714,9 @@ impl Evaluator {
                         "abs() requires exactly 1 argument".to_string(),
                     ));
                 }
+                if evaluated_args[0].is_undefined() {
+                    return Ok(JValue::Undefined);
+                }
                 match &evaluated_args[0] {
                     JValue::Null => Ok(JValue::Null),
                     JValue::Number(n) => Ok(functions::numeric::abs(*n)?),
@@ -7724,6 +7730,9 @@ impl Evaluator {
                     return Err(EvaluatorError::EvaluationError(
                         "floor() requires exactly 1 argument".to_string(),
                     ));
+                }
+                if evaluated_args[0].is_undefined() {
+                    return Ok(JValue::Undefined);
                 }
                 match &evaluated_args[0] {
                     JValue::Null => Ok(JValue::Null),
@@ -7739,6 +7748,9 @@ impl Evaluator {
                         "ceil() requires exactly 1 argument".to_string(),
                     ));
                 }
+                if evaluated_args[0].is_undefined() {
+                    return Ok(JValue::Undefined);
+                }
                 match &evaluated_args[0] {
                     JValue::Null => Ok(JValue::Null),
                     JValue::Number(n) => Ok(functions::numeric::ceil(*n)?),
@@ -7752,6 +7764,9 @@ impl Evaluator {
                     return Err(EvaluatorError::EvaluationError(
                         "round() requires 1 or 2 arguments".to_string(),
                     ));
+                }
+                if evaluated_args[0].is_undefined() {
+                    return Ok(JValue::Undefined);
                 }
                 match &evaluated_args[0] {
                     JValue::Null => Ok(JValue::Null),
@@ -7780,6 +7795,9 @@ impl Evaluator {
                     return Err(EvaluatorError::EvaluationError(
                         "sqrt() requires exactly 1 argument".to_string(),
                     ));
+                }
+                if evaluated_args[0].is_undefined() {
+                    return Ok(JValue::Undefined);
                 }
                 match &evaluated_args[0] {
                     JValue::Null => Ok(JValue::Null),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,15 @@ struct JsonataExpression {
     default_options: evaluator::EvaluatorOptions,
 }
 
+/// Test-support toggle: set JSONATAPY_FORCE_TREE_WALKER=1 to bypass the
+/// bytecode VM and exercise the tree-walking evaluator on every call.
+/// Read per-call (not cached) so tests can flip it via monkeypatch.setenv;
+/// the ~100ns env read is noise next to a µs-scale evaluation.
+#[cfg(feature = "python")]
+fn force_tree_walker() -> bool {
+    std::env::var_os("JSONATAPY_FORCE_TREE_WALKER").is_some_and(|v| !v.is_empty() && v != "0")
+}
+
 #[cfg(feature = "python")]
 impl JsonataExpression {
     /// Evaluate the compiled expression against pre-converted data.
@@ -176,7 +185,7 @@ impl JsonataExpression {
         bindings: Option<Py<PyAny>>,
         options: evaluator::EvaluatorOptions,
     ) -> PyResult<JValue> {
-        if bindings.is_none() {
+        if bindings.is_none() && !force_tree_walker() {
             let bytecode = self.bytecode.get_or_init(|| {
                 evaluator::try_compile_expr(&self.ast)
                     .map(|ce| compiler::BytecodeCompiler::compile(&ce))

--- a/tests/python/test_tree_walker_undefined.py
+++ b/tests/python/test_tree_walker_undefined.py
@@ -1,0 +1,79 @@
+"""
+Regression tests: math/length builtins must propagate undefined through the
+tree-walking evaluator, not raise a TypeError.
+
+Root cause: `evaluate_function_call`'s per-function dispatch arms for `abs`,
+`ceil`, `floor`, `round`, `sqrt`, and `length` checked argument count and then
+matched on the argument's concrete type, but had no explicit
+`is_undefined()` short-circuit -- unlike their neighboring arms
+(`uppercase`/`lowercase`/`number`) which already had one. A missing path
+(e.g. `$abs(nothing)` where `nothing` doesn't exist) evaluates to
+`JValue::Undefined`, which fell through to each arm's catch-all `_ =>` branch
+and raised "... requires a number argument" instead of returning undefined.
+
+The bytecode VM (`call_pure_builtin`, src/evaluator.rs) never had this bug --
+it already special-cased `Null | Undefined` inline for these functions.
+
+Two ways to force the tree-walker are exercised here:
+  1. Passing a non-empty `bindings` dict to `evaluate()` (works on any build).
+  2. The `JSONATAPY_FORCE_TREE_WALKER=1` env toggle (src/lib.rs), which
+     bypasses the bytecode VM on every call including `evaluate()` with no
+     bindings. Read per-call, so it can be flipped via monkeypatch.setenv.
+
+Both must agree with the default (VM) path: the result is undefined, i.e.
+`None` at the Python boundary.
+"""
+
+import os
+
+import jsonatapy
+import pytest
+
+# (expression, description) -- each references a field that does not exist
+# in the (empty) input data, so the builtin's argument evaluates to undefined.
+UNDEFINED_INPUT_CASES = [
+    "$abs(nothing)",
+    "$ceil(nothing)",
+    "$floor(nothing)",
+    "$length(missing)",
+    "$round(unknown)",
+    "$sqrt(nothing)",
+]
+
+
+@pytest.mark.parametrize("expr", UNDEFINED_INPUT_CASES)
+def test_default_path_propagates_undefined(expr):
+    """Sanity baseline: the default (VM-preferred) path already does this correctly."""
+    result = jsonatapy.evaluate(expr, None)
+    assert result is None
+
+
+@pytest.mark.parametrize("expr", UNDEFINED_INPUT_CASES)
+def test_bindings_forced_tree_walker_propagates_undefined(expr):
+    """Non-empty `bindings` routes evaluate() through the tree-walker on any build."""
+    compiled = jsonatapy.compile(expr)
+    result = compiled.evaluate(None, bindings={"__unused": 1})
+    assert result is None
+
+
+@pytest.mark.parametrize("expr", UNDEFINED_INPUT_CASES)
+def test_env_forced_tree_walker_propagates_undefined(expr, monkeypatch):
+    """JSONATAPY_FORCE_TREE_WALKER=1 forces the tree-walker even with bindings=None."""
+    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    compiled = jsonatapy.compile(expr)
+    result = compiled.evaluate(None)
+    assert result is None
+
+
+def test_force_tree_walker_env_var_is_read_per_call(monkeypatch):
+    """The toggle isn't cached at compile time -- flipping it mid-test takes effect."""
+    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER", raising=False)
+    compiled = jsonatapy.compile("$abs(nothing)")
+    assert compiled.evaluate(None) is None
+
+    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    assert compiled.evaluate(None) is None
+
+    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER")
+    assert os.environ.get("JSONATAPY_FORCE_TREE_WALKER") is None
+    assert compiled.evaluate(None) is None


### PR DESCRIPTION
## Summary

Fixes 6 pre-existing tree-walker bugs where math/length builtins raised a
TypeError instead of propagating undefined when their argument was a missing
path (e.g. `$abs(nothing)`).

Failing cases (under `JSONATAPY_FORCE_TREE_WALKER=1` / bindings-forced
tree-walker):
- `function-abs/case003` (`$abs(nothing)`)
- `function-ceil/case003` (`$ceil(nothing)`)
- `function-floor/case003` (`$floor(nothing)`)
- `function-length/case002` (`$length(missing)`)
- `function-round/case017` (`$round(unknown)`)
- `function-sqrt/case002` (`$sqrt(nothing)`)

## Root cause

`evaluate_function_call`'s dispatch arms for `abs`, `ceil`, `floor`, `round`,
`sqrt`, and `length` checked argument count, then matched on the argument's
concrete type -- but (unlike neighboring `uppercase`/`lowercase`/`number`
arms in the same match) had no explicit `is_undefined()` short-circuit. A
missing path evaluates to `JValue::Undefined`, which fell through to each
arm's catch-all `_ =>` branch and raised a type error instead of propagating
undefined. The bytecode VM's `call_pure_builtin` never had this bug -- it
already special-cases `Null | Undefined` inline for these functions.

## Fix

Added the same one-line guard already used by the working
`uppercase`/`lowercase`/`number` arms (`if evaluated_args[0].is_undefined()
{ return Ok(JValue::Undefined); }`), placed after each arm's arity check and
before its type dispatch, to all 6 affected arms.

This is 6 per-arm patches rather than a single shared guard (which the task
brief suggested as the preferred shape), deliberately: the shared
`UNDEFINED_PROPAGATING_FUNCTIONS` list also feeds the VM's
`call_pure_builtin` dispatch, so extending it would change VM-internal
semantics (`Null` -> `Undefined`) for these functions -- and the brief
requires VM behavior stay untouched. A guard placed before dispatch (rather
than after each arm's arity check) would also skip per-function arity
validation, changing error behavior for calls like `$abs(nothing, 2)`.
Per-arm placement, mirroring the existing convention in this exact match
block, preserves both constraints.

## Known pre-existing divergence (not introduced here, out of scope)

`call_pure_builtin` (VM path) already returned `Null` (not `Undefined`) for
`abs`/`ceil`/`floor`/`round`/`sqrt` on undefined input. Both map to Python
`None` at the top level, so the reference suite doesn't see it, but it's
observable in object construction (undefined-valued keys are dropped,
null-valued keys are kept): `{"x": $abs(nothing)}` -> VM: `{"x": None}`,
tree-walker (post-fix): `{}`. Per project history, `Undefined` is the
spec-correct value here (the same class of bug the earlier null-vs-undefined
path-access migration targeted); the VM's `Null` return for these five
functions is a latent quirk that predates or was missed by that migration.
Reconciling it would require touching `call_pure_builtin`, which is out of
scope for this fix.

## Verification

- Default suite: 1682/1682
- `JSONATAPY_FORCE_TREE_WALKER=1`: 1682/1682 (was 1676/1682 before the fix)
- `cargo test --lib`: 175/175 passed
- `cargo clippy --features python -- -D warnings`: clean
- `cargo fmt --check`: clean
- New regression tests (`tests/python/test_tree_walker_undefined.py`, 19
  cases): pass, covering default path, bindings-forced tree-walker, and
  `JSONATAPY_FORCE_TREE_WALKER=1`

Note: `JSONATAPY_FORCE_TREE_WALKER` also lands in PR #71 (harmless
duplicate -- whichever merges second rebases trivially). This branch's first
commit is a cherry-pick of that toggle from `1221553` (src/lib.rs hunk only;
the doc-spec hunk conflicted with a deleted file on `main` and was dropped).

## Test plan

- [x] `uv run maturin develop --release`
- [x] `uv run pytest tests/python/test_reference_suite.py -q` -> 1682/1682
- [x] `JSONATAPY_FORCE_TREE_WALKER=1 uv run pytest tests/python/test_reference_suite.py -q` -> 1682/1682
- [x] `uv run pytest tests/python/test_tree_walker_undefined.py -q` -> 19/19
- [x] `cargo test --lib` -> 175/175
- [x] `cargo clippy --features python -- -D warnings` -> clean
- [x] `cargo fmt --check` -> clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjPKH8WHqWxrotSoeqv2w6