### PR TITLE
fix(vm): propagate undefined through VM math builtins

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2502,6 +2502,11 @@ const UNDEFINED_PROPAGATING_FUNCTIONS: &[&str] = &[
     "substringBefore",
     "substringAfter",
     "string",
+    "abs",
+    "ceil",
+    "floor",
+    "round",
+    "sqrt",
 ];
 
 /// Check whether a function propagates undefined values

--- a/tests/python/test_vm_math_undefined.py
+++ b/tests/python/test_vm_math_undefined.py
@@ -1,0 +1,118 @@
+"""
+Regression tests: math builtins must propagate undefined through the bytecode
+VM's `call_pure_builtin` (src/evaluator.rs), not silently downgrade it to
+`JValue::Null`, matching the tree-walker fix landed in PR #72
+(commit c679fbb, "fix(evaluator): propagate undefined through tree-walker
+math builtins") and jsonata-js's oracle behavior.
+
+Root cause: `call_pure_builtin`'s per-arm match statements for `abs`, `ceil`,
+`floor`, `round`, and `sqrt` had a combined pattern
+`Some(JValue::Null | JValue::Undefined) | None => Ok(JValue::Null)` --
+collapsing "missing field" (Undefined) and "explicit null" (Null) into the
+same Null result. `JValue::Null` and `JValue::Undefined` both surface as
+Python `None` at the top level, so this divergence from the tree-walker was
+invisible there. It becomes observable in object construction: object keys
+with an `Undefined` value are dropped, but keys with an explicit `Null`
+value are kept. So `{"x": $abs(nothing)}` (nothing = missing field) produced
+`{"x": None}` on the VM (default) path but the spec-correct `{}` on the
+tree-walker path (`JSONATAPY_FORCE_TREE_WALKER=1`) -- and per the jsonata-js
+oracle, `{}` is correct.
+
+Fix: add "abs", "ceil", "floor", "round", "sqrt" to the shared
+`UNDEFINED_PROPAGATING_FUNCTIONS` list (src/evaluator.rs), which the VM's
+`call_pure_builtin` already consults via an early-return guard (`if
+effective_args.first().is_some_and(JValue::is_undefined) &&
+propagates_undefined(name) { return Ok(JValue::Undefined); }`) placed before
+the per-arm match. Verified this doesn't regress the tree-walker: bare
+identifiers always parse as `AstNode::Path` (never a bare top-level
+`AstNode::Name`), so the tree-walker's legacy `AstNode::Name`-based
+undefined-propagation pre-check never fires for real expressions like
+`nothing`; and the parallel `AstNode::Path` pre-check pattern-matches on
+`Ok(JValue::Null)`, which no longer matches post the null-vs-undefined path
+migration (missing-field paths already evaluate to `Undefined`, not
+`Null`). Also verified the arity-error case
+(`$abs(nothing, 2)`) is unaffected: the compiler's max-args guard rejects
+compilation for too-many-args calls before the VM ever runs, so both paths
+fall back to the tree-walker and raise the identical arity error.
+"""
+
+import os
+
+import jsonatapy
+import pytest
+
+# Each of these references a field ("nothing") that does not exist in the
+# (non-empty) input data, so the builtin's argument evaluates to Undefined,
+# not Null.
+MATH_FUNCTIONS = ["abs", "ceil", "floor", "round", "sqrt"]
+
+DATA = {"a": 1}
+
+
+@pytest.mark.parametrize("fn", MATH_FUNCTIONS)
+def test_default_vm_path_drops_undefined_key(fn):
+    """Default (VM-preferred) path: undefined-valued key must be dropped, not kept as null."""
+    expr = jsonatapy.compile(f'{{"x": ${fn}(nothing)}}')
+    result = expr.evaluate(DATA)
+    assert result == {}, f"${fn}(nothing) in object construction should drop key 'x', got {result}"
+
+
+@pytest.mark.parametrize("fn", MATH_FUNCTIONS)
+def test_default_matches_forced_tree_walker(fn, monkeypatch):
+    """Default (VM) path and forced-tree-walker path must agree on object construction."""
+    expr_src = f'{{"x": ${fn}(nothing)}}'
+    expr = jsonatapy.compile(expr_src)
+
+    default_result = expr.evaluate(DATA)
+
+    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    tree_walker_result = expr.evaluate(DATA)
+    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER")
+
+    assert default_result == tree_walker_result == {}
+
+
+@pytest.mark.parametrize("fn", MATH_FUNCTIONS)
+def test_top_level_undefined_result_is_none(fn):
+    """Top-level call still surfaces as Python None (unaffected by this fix, sanity check)."""
+    result = jsonatapy.evaluate(f"${fn}(nothing)", DATA)
+    assert result is None
+
+
+@pytest.mark.parametrize("fn", MATH_FUNCTIONS)
+def test_explicit_null_argument_still_passes_through_as_null(fn):
+    """Explicit null (not a missing field) must still be kept as an explicit null key,
+    on both the default (VM) and forced-tree-walker paths -- this fix must not
+    change that pre-existing behavior."""
+    expr = jsonatapy.compile(f'{{"x": ${fn}(v)}}')
+    data = {"v": None}
+
+    default_result = expr.evaluate(data)
+    assert default_result == {"x": None}
+
+    os.environ["JSONATAPY_FORCE_TREE_WALKER"] = "1"
+    try:
+        tw_result = expr.evaluate(data)
+    finally:
+        del os.environ["JSONATAPY_FORCE_TREE_WALKER"]
+    assert tw_result == {"x": None}
+
+
+@pytest.mark.parametrize("fn", MATH_FUNCTIONS)
+def test_arity_error_unaffected_by_undefined_first_arg(fn, monkeypatch):
+    """Calling with too many args and an undefined first arg must still raise the
+    arity error identically on both paths (not short-circuit to undefined).
+    round() accepts an optional precision arg, so it needs 3 args to overflow;
+    the other four accept exactly 1, so 2 args overflows."""
+    expr_src = f"${fn}(nothing, 2, 3)" if fn == "round" else f"${fn}(nothing, 2)"
+    expr = jsonatapy.compile(expr_src)
+
+    with pytest.raises(Exception) as default_exc_info:
+        expr.evaluate(DATA)
+
+    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    with pytest.raises(Exception) as tw_exc_info:
+        expr.evaluate(DATA)
+    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER")
+
+    assert str(default_exc_info.value) == str(tw_exc_info.value)


### PR DESCRIPTION
## Bug

The bytecode VM's `call_pure_builtin` (`src/evaluator.rs`) returned `JValue::Null` (not `JValue::Undefined`) for `$abs`/`$ceil`/`$floor`/`$round`/`$sqrt` when the argument was undefined (e.g. a missing field, `$abs(nothing)`). This was documented as a known latent divergence in PR #72 (which fixed the equivalent tree-walker bug).

Both `Null` and `Undefined` surface as Python `None` at the top level, so the divergence was invisible there — but observable in object construction, since `Undefined`-valued keys are dropped while explicit `Null`-valued keys are kept:

- `{"x": $abs(nothing)}` on `{"a": 1}`: VM (default path) → `{"x": None}`; tree-walker (`JSONATAPY_FORCE_TREE_WALKER=1`) → `{}`.

**jsonata-js oracle (verified via reference-suite `undefinedResult` cases and manual node checks)**: `{}` for all five functions — the tree-walker was correct, the VM was not.

## Root cause

`call_pure_builtin`'s per-arm match statements for `abs`/`ceil`/`floor`/`round`/`sqrt` had a combined pattern `Some(JValue::Null | JValue::Undefined) | None => Ok(JValue::Null)`, collapsing "missing field" (`Undefined`) and "explicit null" (`Null`) into the same `Null` result.

## Fix

Added `"abs"`, `"ceil"`, `"floor"`, `"round"`, `"sqrt"` to the shared `UNDEFINED_PROPAGATING_FUNCTIONS` list, which `call_pure_builtin` already consults via an early-return guard (`if effective_args.first().is_some_and(JValue::is_undefined) && propagates_undefined(name) { return Ok(JValue::Undefined); }`) placed *before* the per-arm match.

PR #72 deliberately avoided this shared-list approach for the tree-walker fix, citing two concerns. Both were checked here and ruled out:

1. *"Changes VM-internal semantics (Null → Undefined)"* — that's the intended fix now.
2. *"Guard runs before arity validation, e.g. `$abs(nothing, 2)`"* — verified empirically both the default (VM) and forced-tree-walker paths raise the identical arity error for `$abs(nothing, 2)` / `$round(nothing, 2, 3)` / etc. The compiler's max-args guard rejects compilation for too-many-args calls, falling back to the tree-walker before the VM's guard is ever reached.

Also verified no tree-walker regression from touching the shared list: bare identifiers always parse as `AstNode::Path` (never a bare top-level `AstNode::Name`), so the tree-walker's legacy `AstNode::Name`-based undefined pre-check never fires for real expressions like `nothing`; the parallel `AstNode::Path` pre-check pattern-matches on `Ok(JValue::Null)`, which no longer matches post the null-vs-undefined path migration (missing-field paths already evaluate to `Undefined`, not `Null`).

Explicit-null semantics are unchanged: `{"x": $abs(v)}` with `v: null` still returns `{"x": None}` on both paths (verified).

## Verification

- Default suite: 1682/1682
- `JSONATAPY_FORCE_TREE_WALKER=1` suite: 1682/1682
- Full python suite: 1998 passed, 4 skipped
- `cargo test --lib`: 175/175
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `uvx ruff format --check python/ tests/ benchmarks/`: clean
- `uvx ruff check python/ tests/ benchmarks/`: clean

New test file `tests/python/test_vm_math_undefined.py` follows TDD: confirmed red pre-fix (10 failures on the object-construction cases via `git stash`), green post-fix.

## Test plan

- [x] `uv run pytest tests/python/test_vm_math_undefined.py tests/python/test_tree_walker_undefined.py -q`
- [x] `uv run pytest tests/python/test_reference_suite.py -q` (default and `JSONATAPY_FORCE_TREE_WALKER=1`)
- [x] `cargo test --lib`
- [x] Lint gates (clippy/fmt/ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjPKH8WHqWxrotSoeqv2w6