### PR TITLE
feat(capi): C ABI — jsonata.h, bind_var, error codes, panic guard, smoke test, docs

### DIFF
--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -41,7 +41,7 @@ jobs:
           key: capi
 
       - name: Rust unit tests (capi feature)
-        run: cargo test --features capi capi::
+        run: 'cargo test --features capi capi::'
 
       - name: Build shared library
         run: cargo build --release --features capi

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # lib-target #[cfg(test)] modules include_str! reference-suite
+          # datasets from the jsonata-js submodule
+          submodules: true
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -1,0 +1,59 @@
+name: C ABI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'src/capi.rs'
+      - 'bindings/c/**'
+      - 'Cargo.toml'
+      - '.github/workflows/capi.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'src/capi.rs'
+      - 'bindings/c/**'
+      - 'Cargo.toml'
+      - '.github/workflows/capi.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: capi-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  capi-smoke:
+    name: C ABI tests + smoke (C and C++)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: capi
+
+      - name: Rust unit tests (capi feature)
+        run: cargo test --features capi capi::
+
+      - name: Build shared library
+        run: cargo build --release --features capi
+
+      - name: Compile and run smoke test (C)
+        run: |
+          gcc -Wall -Wextra -Werror -o smoke bindings/c/examples/smoke.c \
+              -Ltarget/release -ljsonata_core
+          LD_LIBRARY_PATH=target/release ./smoke
+
+      - name: Compile and run smoke test (C++)
+        run: |
+          g++ -Wall -Wextra -Werror -x c++ -o smoke_cpp bindings/c/examples/smoke.c \
+              -Ltarget/release -ljsonata_core
+          LD_LIBRARY_PATH=target/release ./smoke_cpp

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -41,7 +41,10 @@ jobs:
           key: capi
 
       - name: Rust unit tests (capi feature)
-        run: 'cargo test --features capi capi::'
+        # --lib: the capi tests live in the lib target; integration-test
+        # binaries include_str! the jsonata-js submodule, which this job
+        # deliberately doesn't check out
+        run: 'cargo test --lib --features capi capi::'
 
       - name: Build shared library
         run: cargo build --release --features capi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ simd = ["dep:simd-json"]
 python = ["dep:pyo3"]
 cli = ["dep:clap"]
 bench = []   # exposes _bench facade for Criterion benchmarks
+capi = []
 
 [dev-dependencies]
 criterion = "0.8"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ echo '{"orders":[{"product":"Laptop","price":1200}]}' | jsonatapy 'orders[price 
 
 See [CLI Reference](docs/cli.md) for the full flag/exit-code contract.
 
+## C / C++ quick start
+
+The engine exposes a small C ABI (8 functions, JSON text in/out), usable
+from C, C++, or any language with C interop:
+
+```c
+JsonataExpr *expr = jsonata_compile("$sum(items.price)");
+char *result = jsonata_evaluate(expr, "{\"items\":[{\"price\":2},{\"price\":3}]}");
+// result: "5"
+jsonata_free_string(result);
+jsonata_free_expr(expr);
+```
+
+Build with `cargo build --release --features capi` and include
+[`bindings/c/jsonata.h`](bindings/c/jsonata.h). See the
+[C API guide](bindings/c/README.md) for linking (gcc/clang, Makefile,
+CMake), the memory/threading contract, and error handling.
+
 ---
 
 ## What is JSONata?

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -1,0 +1,160 @@
+# jsonata-core C API
+
+Use [JSONata](https://jsonata.org) — the JSON query and transformation
+language — from C, C++, or any language with C interop, backed by
+[jsonata-core](https://github.com/txjmb/jsonata-core), a high-performance
+Rust implementation with 100% reference-suite compatibility against
+jsonata-js.
+
+The API is deliberately small: JSON text in, JSON text out, eight
+functions. See [`jsonata.h`](jsonata.h) for the authoritative contract.
+
+```c
+#include "jsonata.h"
+#include <stdio.h>
+
+int main(void) {
+    JsonataExpr *expr = jsonata_compile("$sum(order.items.(price * qty))");
+    if (!expr) {
+        char *err = jsonata_last_error_message();
+        fprintf(stderr, "compile failed: %s\n", err);
+        jsonata_free_string(err);
+        return 1;
+    }
+
+    char *result = jsonata_evaluate(expr,
+        "{\"order\":{\"items\":[{\"price\":9.99,\"qty\":2},{\"price\":5,\"qty\":1}]}}");
+    if (result) {
+        printf("total: %s\n", result);   /* total: 24.98 */
+        jsonata_free_string(result);
+    } else {
+        char *err = jsonata_last_error_message();
+        if (err) {                        /* error */
+            fprintf(stderr, "evaluate failed: %s\n", err);
+            jsonata_free_string(err);
+        } else {                          /* JSONata "undefined" — no match */
+            printf("no result\n");
+        }
+    }
+
+    jsonata_free_expr(expr);
+    return 0;
+}
+```
+
+## Building the shared library
+
+Requires a Rust toolchain (rustc 1.70+, [rustup.rs](https://rustup.rs)):
+
+```sh
+git clone https://github.com/txjmb/jsonata-core
+cd jsonata-core
+cargo build --release --features capi
+```
+
+This produces the shared library in `target/release/`:
+
+| Platform | Library |
+|---|---|
+| Linux | `libjsonata_core.so` |
+| macOS | `libjsonata_core.dylib` |
+| Windows | `jsonata_core.dll` (+ `jsonata_core.dll.lib` import lib) |
+
+The only header you need is `bindings/c/jsonata.h`.
+
+## Compiling and linking
+
+**C** (gcc/clang):
+
+```sh
+gcc -Wall -o myapp myapp.c -I/path/to/jsonata-core/bindings/c \
+    -L/path/to/jsonata-core/target/release -ljsonata_core
+LD_LIBRARY_PATH=/path/to/jsonata-core/target/release ./myapp
+```
+
+**C++**: the header is C++-safe (`extern "C"` guarded); compile and link
+exactly as above with `g++`/`clang++`.
+
+For deployment, install the library somewhere on the loader path (or set
+`rpath`): `-Wl,-rpath,/opt/myapp/lib` at link time avoids
+`LD_LIBRARY_PATH` at run time.
+
+**Makefile snippet:**
+
+```make
+JSONATA_DIR := /path/to/jsonata-core
+CFLAGS  += -I$(JSONATA_DIR)/bindings/c
+LDFLAGS += -L$(JSONATA_DIR)/target/release -Wl,-rpath,$(JSONATA_DIR)/target/release
+LDLIBS  += -ljsonata_core
+
+myapp: myapp.o
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+```
+
+**CMake snippet:**
+
+```cmake
+set(JSONATA_DIR /path/to/jsonata-core)
+
+add_library(jsonata_core SHARED IMPORTED)
+set_target_properties(jsonata_core PROPERTIES
+    IMPORTED_LOCATION ${JSONATA_DIR}/target/release/libjsonata_core.so
+    INTERFACE_INCLUDE_DIRECTORIES ${JSONATA_DIR}/bindings/c)
+
+target_link_libraries(myapp PRIVATE jsonata_core)
+```
+
+(Optionally wrap the `cargo build` in a CMake `add_custom_command` so the
+Rust library rebuilds with your project.)
+
+## API rules (the short version)
+
+1. **Ownership:** every `char*` the library returns is yours — free it with
+   `jsonata_free_string()`. The single exception is `jsonata_version()`
+   (static; never free). Never free library strings with your own
+   `free()` — allocators may differ.
+2. **NULL from `jsonata_evaluate` is ambiguous by design:** check
+   `jsonata_last_error_message()`. Non-NULL → error. NULL → the JSONata
+   result was *undefined* (a normal outcome — e.g. a path that matched
+   nothing). This mirrors JSONata semantics, where `undefined` and `null`
+   are distinct.
+3. **Error codes:** `jsonata_last_error_code()` returns the JSONata spec
+   code (`"T2002"`, `"S0201"`, `"D3030"`, …) when the failure has one,
+   NULL otherwise. Error source positions are not exposed (the engine
+   does not currently track them).
+4. **Threading:** one `JsonataExpr*` per thread — create, use, and free a
+   handle on the same thread. Handles are cheap; compile per thread rather
+   than sharing. Different threads with their own handles are fine, and
+   the error slot is thread-local.
+5. **Reuse handles:** `jsonata_compile` once, `jsonata_evaluate` many
+   times — the expression is JIT-compiled to bytecode on first evaluation
+   and reused. Compilation is the expensive step.
+6. **Variables:** `jsonata_bind_var(expr, "x", "[1,2,3]")` binds `$x` for
+   all subsequent evaluations on that handle (values are JSON text;
+   re-binding replaces).
+7. **Panics:** internal engine panics are caught at the boundary and
+   surface as errors prefixed `internal error:` — they will not abort
+   your process.
+
+## Smoke test
+
+[`examples/smoke.c`](examples/smoke.c) exercises the full API surface and
+doubles as usage documentation. Build and run it from the repo root:
+
+```sh
+cargo build --release --features capi
+gcc -Wall -Wextra -Werror -o smoke bindings/c/examples/smoke.c \
+    -Ltarget/release -ljsonata_core
+LD_LIBRARY_PATH=target/release ./smoke
+```
+
+CI compiles and runs it (as both C and C++) on every change to the C ABI.
+
+## Related
+
+- [jsonatapy](https://pypi.org/project/jsonatapy/) — the Python binding of
+  this engine (PyPI, zero runtime dependencies).
+- [`jsonata` CLI](../../docs/) — a jq-style command-line interface to the
+  same engine.
+- [jsonata-js](https://github.com/jsonata-js/jsonata) — the reference
+  implementation this engine tracks (1682/1682 reference tests passing).

--- a/bindings/c/examples/smoke.c
+++ b/bindings/c/examples/smoke.c
@@ -1,0 +1,133 @@
+/*
+ * smoke.c — compile-and-run smoke test for the jsonata-core C ABI.
+ *
+ * Exercises every function in jsonata.h against the real library and exits
+ * non-zero on the first failure. CI builds and runs this on every PR that
+ * touches the C ABI; see bindings/c/README.md for the manual build/run
+ * commands.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../jsonata.h"
+
+static int failures = 0;
+
+#define CHECK(cond, name)                                                    \
+    do {                                                                     \
+        if (cond) {                                                          \
+            printf("PASS  %s\n", name);                                      \
+        } else {                                                             \
+            printf("FAIL  %s (line %d)\n", name, __LINE__);                  \
+            failures++;                                                      \
+        }                                                                    \
+    } while (0)
+
+static char *take_error(void) { return jsonata_last_error_message(); }
+
+int main(void) {
+    /* version */
+    const char *v = jsonata_version();
+    CHECK(v != NULL && strlen(v) > 0, "version non-empty");
+
+    /* simple path */
+    {
+        JsonataExpr *e = jsonata_compile("user.name");
+        CHECK(e != NULL, "compile simple path");
+        char *r = jsonata_evaluate(e, "{\"user\":{\"name\":\"Alice\"}}");
+        CHECK(r != NULL && strcmp(r, "\"Alice\"") == 0, "evaluate simple path");
+        jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* object construction + arithmetic */
+    {
+        JsonataExpr *e = jsonata_compile("{\"n\": a + b}");
+        char *r = jsonata_evaluate(e, "{\"a\":1,\"b\":2}");
+        CHECK(r != NULL && strcmp(r, "{\"n\":3}") == 0, "object result");
+        jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* undefined result: NULL with EMPTY error slot */
+    {
+        JsonataExpr *e = jsonata_compile("missing.path");
+        char *r = jsonata_evaluate(e, "{\"a\":1}");
+        char *err = take_error();
+        CHECK(r == NULL && err == NULL, "undefined -> NULL + empty error");
+        jsonata_free_string(err);
+        jsonata_free_expr(e);
+    }
+
+    /* parse error: NULL handle + message */
+    {
+        JsonataExpr *e = jsonata_compile("a.b[");
+        char *err = take_error();
+        CHECK(e == NULL && err != NULL && strlen(err) > 0,
+              "parse error -> NULL + message");
+        jsonata_free_string(err);
+    }
+
+    /* coded evaluation error: message + spec code */
+    {
+        JsonataExpr *e = jsonata_compile("$number(b)");
+        char *r = jsonata_evaluate(e, "{\"b\":[1]}");
+        char *err = take_error();
+        char *code = jsonata_last_error_code();
+        CHECK(r == NULL && err != NULL, "eval error -> NULL + message");
+        CHECK(code != NULL && strcmp(code, "D3030") == 0,
+              "eval error -> spec code D3030");
+        jsonata_free_string(err);
+        jsonata_free_string(code);
+        jsonata_free_expr(e);
+    }
+
+    /* variable binding */
+    {
+        JsonataExpr *e = jsonata_compile("$sum($xs) + n");
+        int rc = jsonata_bind_var(e, "$xs", "[1,2,3]");
+        CHECK(rc == 0, "bind_var succeeds");
+        char *r = jsonata_evaluate(e, "{\"n\":10}");
+        CHECK(r != NULL && strcmp(r, "16") == 0, "evaluate with bound var");
+        jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* invalid input JSON: NULL + uncoded message */
+    {
+        JsonataExpr *e = jsonata_compile("a");
+        char *r = jsonata_evaluate(e, "{not json");
+        char *err = take_error();
+        char *code = jsonata_last_error_code();
+        CHECK(r == NULL && err != NULL && strstr(err, "invalid input JSON") != NULL,
+              "invalid input JSON -> message");
+        CHECK(code == NULL, "invalid input JSON -> no spec code");
+        jsonata_free_string(err);
+        jsonata_free_string(code);
+        jsonata_free_expr(e);
+    }
+
+    /* multibyte UTF-8 round trip */
+    {
+        JsonataExpr *e = jsonata_compile("$uppercase(name)");
+        char *r = jsonata_evaluate(e, "{\"name\":\"h\xC3\xA9llo \xE2\x9C\x93\"}");
+        CHECK(r != NULL && strcmp(r, "\"H\xC3\x89LLO \xE2\x9C\x93\"") == 0,
+              "multibyte UTF-8 round trip");
+        jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* NULL tolerance of free functions */
+    jsonata_free_expr(NULL);
+    jsonata_free_string(NULL);
+    CHECK(1, "free(NULL) is a no-op");
+
+    if (failures == 0) {
+        printf("SMOKE OK (jsonata-core %s)\n", v);
+        return 0;
+    }
+    printf("SMOKE FAILED: %d failure(s)\n", failures);
+    return 1;
+}

--- a/bindings/c/jsonata.h
+++ b/bindings/c/jsonata.h
@@ -1,0 +1,104 @@
+/*
+ * jsonata.h — C API for jsonata-core, a high-performance Rust implementation
+ * of the JSONata query and transformation language (https://jsonata.org).
+ *
+ * Implemented by src/capi.rs (build with `cargo build --release --features
+ * capi`, link against the produced libjsonata_core.{so,dylib} /
+ * jsonata_core.dll). This header is hand-maintained; CI compiles
+ * bindings/c/examples/smoke.c against it to keep the two in sync.
+ *
+ * ── Contract ────────────────────────────────────────────────────────────
+ *
+ * Strings.  All strings crossing the boundary are UTF-8, NUL-terminated.
+ * JSON documents and results cross as JSON text; there is no C-visible
+ * structured value model. Every char* RETURNED by this library is owned by
+ * the caller and must be released with jsonata_free_string() — except
+ * jsonata_version(), which returns a static string that must never be
+ * freed.
+ *
+ * Errors.  Failures are reported through a thread-local "last error" slot:
+ *   - jsonata_compile() returns NULL and sets the slot on failure.
+ *   - jsonata_evaluate() returns NULL in TWO cases, disambiguated by the
+ *     slot: if jsonata_last_error_message() returns non-NULL it was an
+ *     error; if it returns NULL the JSONata result was *undefined* (a
+ *     legitimate result — e.g. a path that matched nothing).
+ *   - jsonata_bind_var() returns 0 on success, -1 on failure (slot set).
+ * Successful calls clear the slot. jsonata_last_error_code() additionally
+ * extracts the JSONata specification error code ("T2002", "S0201",
+ * "D3030", ...) when the failure has one; errors without a spec code
+ * (e.g. invalid input JSON) yield NULL. Error source positions are not
+ * available — the engine does not currently track them.
+ *
+ * Threading.  A JsonataExpr* must be created, used, and freed on a single
+ * thread (the engine's value model is reference-counted without atomics).
+ * Different threads may each use their own handles concurrently; the error
+ * slot is thread-local, so per-thread error reporting never races.
+ *
+ * Panics.  Internal engine panics are caught at this boundary and reported
+ * as errors (message prefixed "internal error:"); they neither unwind into
+ * the caller nor abort the host process.
+ */
+
+#ifndef JSONATA_CORE_H
+#define JSONATA_CORE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* An opaque compiled-expression handle. Not thread-safe; see header notes. */
+typedef struct JsonataExpr JsonataExpr;
+
+/*
+ * Compile a JSONata expression (UTF-8).
+ * Returns a handle, or NULL on failure (check jsonata_last_error_message).
+ * Free with jsonata_free_expr().
+ */
+JsonataExpr *jsonata_compile(const char *expr_utf8);
+
+/*
+ * Evaluate the compiled expression against a JSON document (UTF-8 JSON
+ * text). Returns the result as JSON text (caller frees with
+ * jsonata_free_string), or NULL — meaning *undefined* if
+ * jsonata_last_error_message() is NULL, otherwise an error.
+ * The handle may be reused for any number of evaluations; the expression
+ * is compiled to bytecode lazily on first use.
+ */
+char *jsonata_evaluate(JsonataExpr *expr, const char *json_utf8);
+
+/*
+ * Bind a variable ($name) on the expression from a JSON value (UTF-8 JSON
+ * text). Applies to every subsequent jsonata_evaluate() on this handle.
+ * A leading '$' in name is accepted and stripped; re-binding an existing
+ * name replaces its value. Returns 0 on success, -1 on error (slot set).
+ */
+int jsonata_bind_var(JsonataExpr *expr, const char *name,
+                     const char *json_value_utf8);
+
+/* Free a handle returned by jsonata_compile(). NULL is a no-op. */
+void jsonata_free_expr(JsonataExpr *expr);
+
+/* Free a string returned by this library. NULL is a no-op. */
+void jsonata_free_string(char *s);
+
+/*
+ * The last error message on this thread, as a fresh copy (caller frees
+ * with jsonata_free_string), or NULL if the last call succeeded.
+ */
+char *jsonata_last_error_message(void);
+
+/*
+ * The JSONata spec code of the last error on this thread ("T2002", ...),
+ * as a fresh copy (caller frees with jsonata_free_string), or NULL when
+ * there is no error or the error carries no spec code.
+ */
+char *jsonata_last_error_code(void);
+
+/* The jsonata-core version, e.g. "2.2.4". Static string — do NOT free. */
+const char *jsonata_version(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* JSONATA_CORE_H */

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,13 +1,31 @@
-//! Minimal C ABI over the engine (spike scope — see
-//! docs/superpowers/specs/2026-07-13-java-dotnet-ffi-benchmark-experiment-design.md).
+//! C ABI for jsonata-core (the `capi` feature).
 //!
-//! JSON crosses the boundary as UTF-8 C strings in both directions. Errors go
-//! through a thread-local slot: a NULL return from `jsonata_evaluate` with an
-//! EMPTY slot means the JSONata result was undefined (not an error). Handles
-//! are not Send — one `JsonataExpr*` per thread.
+//! Design: docs/superpowers/specs/2026-07-09-multi-language-and-agentic-study-design.md
+//! (Phase 4), validated by the 2026-07-13 Java/.NET FFI benchmark experiment.
+//! The hand-written public header lives at `bindings/c/jsonata.h`; keep the
+//! two in sync (CI compiles `bindings/c/examples/smoke.c` against both).
+//!
+//! Contract summary (full details in `bindings/c/README.md`):
+//! - JSON crosses the boundary as UTF-8, NUL-terminated C strings in both
+//!   directions. There is no C-visible structured value model.
+//! - Errors go through a thread-local slot: a NULL return from
+//!   `jsonata_evaluate` with an EMPTY slot means the JSONata result was
+//!   *undefined* (not an error). `jsonata_last_error_message()` reads the
+//!   slot; `jsonata_last_error_code()` extracts the JSONata error code
+//!   (e.g. "T2002") when the message carries one.
+//! - Strings returned by this library are owned by the caller and must be
+//!   released with `jsonata_free_string` — except `jsonata_version()`,
+//!   which returns a static string that must never be freed.
+//! - Handles are NOT thread-safe (the engine is `Rc`-based): create and use
+//!   a `JsonataExpr*` on one thread only. The error slot is thread-local,
+//!   so different threads using their own handles never race on errors.
+//! - Engine panics are caught at the boundary and reported as errors
+//!   (message prefixed "internal error:"); they do not unwind into the
+//!   caller or abort the host process.
 
 use std::cell::{OnceCell, RefCell};
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{c_char, c_int, CStr, CString};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::evaluator::{self, EvaluatorOptions};
 use crate::value::JValue;
@@ -16,6 +34,11 @@ use crate::{compiler, parser, vm};
 pub struct JsonataExpr {
     ast: crate::ast::AstNode,
     bytecode: OnceCell<Option<vm::BytecodeProgram>>,
+    /// Variables registered via `jsonata_bind_var`, applied on every
+    /// subsequent `jsonata_evaluate`. Non-empty bindings force the
+    /// tree-walker (the VM path takes no user context), mirroring the
+    /// Python bindings' behavior in `lib.rs::run_eval`.
+    bindings: Vec<(String, JValue)>,
 }
 
 thread_local! {
@@ -23,12 +46,31 @@ thread_local! {
 }
 
 fn set_error(msg: String) {
-    let c = CString::new(msg).unwrap_or_else(|_| CString::new("error message contained NUL").unwrap());
+    let c =
+        CString::new(msg).unwrap_or_else(|_| CString::new("error message contained NUL").unwrap());
     LAST_ERROR.with(|e| *e.borrow_mut() = Some(c));
 }
 
 fn clear_error() {
     LAST_ERROR.with(|e| *e.borrow_mut() = None);
+}
+
+/// Runs `f` with panics converted to an error-slot entry + `default`.
+/// Engine panics must never unwind across the `extern "C"` boundary
+/// (undefined behavior) nor abort the host process.
+fn guard<T>(default: T, f: impl FnOnce() -> T) -> T {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(v) => v,
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            set_error(format!("internal error: {}", msg));
+            default
+        }
+    }
 }
 
 /// # Safety
@@ -46,16 +88,67 @@ pub unsafe extern "C" fn jsonata_compile(expr_utf8: *const c_char) -> *mut Jsona
             return std::ptr::null_mut();
         }
     };
-    match parser::parse(expr) {
+    guard(std::ptr::null_mut(), || match parser::parse(expr) {
         Ok(ast) => {
             clear_error();
-            Box::into_raw(Box::new(JsonataExpr { ast, bytecode: OnceCell::new() }))
+            Box::into_raw(Box::new(JsonataExpr {
+                ast,
+                bytecode: OnceCell::new(),
+                bindings: Vec::new(),
+            }))
         }
         Err(e) => {
             set_error(e.display_message());
             std::ptr::null_mut()
         }
+    })
+}
+
+/// Registers a variable binding (`$name`) on the expression, from a JSON
+/// value. Applies to every subsequent `jsonata_evaluate` on this handle.
+/// Returns 0 on success, -1 on error (error slot set). Re-binding an
+/// existing name replaces its value. A leading `$` on `name` is accepted
+/// and stripped.
+///
+/// # Safety
+/// `expr` must be a live pointer from `jsonata_compile`; `name` and
+/// `json_value_utf8` must be valid NUL-terminated C strings or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_bind_var(
+    expr: *mut JsonataExpr,
+    name: *const c_char,
+    json_value_utf8: *const c_char,
+) -> c_int {
+    if expr.is_null() || name.is_null() || json_value_utf8.is_null() {
+        set_error("jsonata_bind_var: NULL argument".to_string());
+        return -1;
     }
+    let (name, json) = match (
+        CStr::from_ptr(name).to_str(),
+        CStr::from_ptr(json_value_utf8).to_str(),
+    ) {
+        (Ok(n), Ok(j)) => (n, j),
+        _ => {
+            set_error("jsonata_bind_var: argument is not valid UTF-8".to_string());
+            return -1;
+        }
+    };
+    let value = match JValue::from_json_str(json) {
+        Ok(v) => v,
+        Err(e) => {
+            set_error(format!("invalid JSON for variable ${}: {}", name, e));
+            return -1;
+        }
+    };
+    let expr = &mut *expr;
+    let name = name.strip_prefix('$').unwrap_or(name).to_string();
+    if let Some(slot) = expr.bindings.iter_mut().find(|(n, _)| *n == name) {
+        slot.1 = value;
+    } else {
+        expr.bindings.push((name, value));
+    }
+    clear_error();
+    0
 }
 
 /// # Safety
@@ -83,52 +176,65 @@ pub unsafe extern "C" fn jsonata_evaluate(
             return std::ptr::null_mut();
         }
     };
-    let data = match JValue::from_json_str(json) {
-        Ok(v) => v,
-        Err(e) => {
-            set_error(format!("invalid input JSON: {}", e));
-            return std::ptr::null_mut();
-        }
-    };
-    // Same pattern as JsonataExpression::run_eval in lib.rs: VM when the
-    // expression compiles to bytecode, tree-walker otherwise.
-    let bytecode = expr.bytecode.get_or_init(|| {
-        evaluator::try_compile_expr(&expr.ast).map(|ce| compiler::BytecodeCompiler::compile(&ce))
-    });
-    let result = if let Some(bc) = bytecode {
-        vm::Vm::with_options(bc, EvaluatorOptions::default()).run(&data, None)
-    } else {
-        let mut ev = evaluator::Evaluator::with_options(
-            evaluator::Context::new(),
-            EvaluatorOptions::default(),
-        );
-        ev.evaluate(&expr.ast, &data)
-    };
-    match result {
-        Ok(v) => {
-            clear_error();
-            if v.is_undefined() {
-                return std::ptr::null_mut(); // undefined: NULL + empty error slot
+    guard(std::ptr::null_mut(), || {
+        let data = match JValue::from_json_str(json) {
+            Ok(v) => v,
+            Err(e) => {
+                set_error(format!("invalid input JSON: {}", e));
+                return std::ptr::null_mut();
             }
-            match v.to_json_string() {
-                Ok(s) => match CString::new(s) {
-                    Ok(c) => c.into_raw(),
-                    Err(_) => {
-                        set_error("result contained interior NUL".to_string());
+        };
+        // Same dispatch as JsonataExpression::run_eval in lib.rs: VM when the
+        // expression compiles to bytecode AND no user bindings exist,
+        // tree-walker otherwise.
+        let result = if expr.bindings.is_empty() {
+            let bytecode = expr.bytecode.get_or_init(|| {
+                evaluator::try_compile_expr(&expr.ast)
+                    .map(|ce| compiler::BytecodeCompiler::compile(&ce))
+            });
+            if let Some(bc) = bytecode {
+                vm::Vm::with_options(bc, EvaluatorOptions::default()).run(&data, None)
+            } else {
+                let mut ev = evaluator::Evaluator::with_options(
+                    evaluator::Context::new(),
+                    EvaluatorOptions::default(),
+                );
+                ev.evaluate(&expr.ast, &data)
+            }
+        } else {
+            let mut context = evaluator::Context::new();
+            for (name, value) in &expr.bindings {
+                context.bind(name.clone(), value.clone());
+            }
+            let mut ev = evaluator::Evaluator::with_options(context, EvaluatorOptions::default());
+            ev.evaluate(&expr.ast, &data)
+        };
+        match result {
+            Ok(v) => {
+                clear_error();
+                if v.is_undefined() {
+                    return std::ptr::null_mut(); // undefined: NULL + empty error slot
+                }
+                match v.to_json_string() {
+                    Ok(s) => match CString::new(s) {
+                        Ok(c) => c.into_raw(),
+                        Err(_) => {
+                            set_error("result contained interior NUL".to_string());
+                            std::ptr::null_mut()
+                        }
+                    },
+                    Err(e) => {
+                        set_error(format!("could not serialize result: {}", e));
                         std::ptr::null_mut()
                     }
-                },
-                Err(e) => {
-                    set_error(format!("could not serialize result: {}", e));
-                    std::ptr::null_mut()
                 }
             }
+            Err(e) => {
+                set_error(e.message().to_string());
+                std::ptr::null_mut()
+            }
         }
-        Err(e) => {
-            set_error(e.message().to_string());
-            std::ptr::null_mut()
-        }
-    }
+    })
 }
 
 /// # Safety
@@ -157,6 +263,51 @@ pub extern "C" fn jsonata_last_error_message() -> *mut c_char {
         Some(c) => c.clone().into_raw(),
         None => std::ptr::null_mut(),
     })
+}
+
+/// Returns the JSONata error code (e.g. "T2002", "S0201", "D1012") of the
+/// last error, when its message carries one, or NULL when there is no error
+/// or the error has no spec code (I/O-shaped errors like invalid input
+/// JSON). Caller frees with `jsonata_free_string`.
+///
+/// jsonata-core stores spec codes at the START of the message ("T2002: ...")
+/// rather than as a structured field; this extracts that prefix. There is no
+/// `jsonata_last_error_position` — the engine does not currently track error
+/// positions.
+#[no_mangle]
+pub extern "C" fn jsonata_last_error_code() -> *mut c_char {
+    LAST_ERROR.with(|e| {
+        let borrow = e.borrow();
+        let Some(c) = &*borrow else {
+            return std::ptr::null_mut();
+        };
+        let msg = c.to_string_lossy();
+        match extract_error_code(&msg) {
+            Some(code) => CString::new(code).unwrap().into_raw(),
+            None => std::ptr::null_mut(),
+        }
+    })
+}
+
+/// A JSONata spec code is one uppercase ASCII letter followed by exactly
+/// four digits, terminated by ':' (e.g. "T2002: ..."). The engine sometimes
+/// stores it at the start of the message and sometimes behind a prose
+/// prefix ("Runtime error: D3030: ..."), so scan for the first
+/// token-boundary occurrence. Uncoded prose ("Parse error: something",
+/// "invalid input JSON: ...") yields None.
+fn extract_error_code(msg: &str) -> Option<String> {
+    let bytes = msg.as_bytes();
+    for i in 0..bytes.len().saturating_sub(5) {
+        let at_boundary = i == 0 || bytes[i - 1] == b' ';
+        if at_boundary
+            && bytes[i].is_ascii_uppercase()
+            && bytes[i + 1..i + 5].iter().all(|b| b.is_ascii_digit())
+            && bytes[i + 5] == b':'
+        {
+            return Some(msg[i..i + 5].to_string());
+        }
+    }
+    None
 }
 
 #[no_mangle]
@@ -197,6 +348,18 @@ mod tests {
         }
     }
 
+    fn last_code() -> Option<String> {
+        let p = jsonata_last_error_code();
+        if p.is_null() {
+            return None;
+        }
+        unsafe {
+            let s = CStr::from_ptr(p).to_str().unwrap().to_string();
+            jsonata_free_string(p);
+            Some(s)
+        }
+    }
+
     #[test]
     fn round_trip_simple_path() {
         let out = unsafe { eval_str("user.name", r#"{"user":{"name":"Alice"}}"#) };
@@ -226,8 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn eval_error_sets_message() {
-        // "a" + string is a type error (T2002-family) at evaluation time
+    fn eval_error_sets_message_and_code() {
         let ce = CString::new(r#"a + b"#).unwrap();
         let cd = CString::new(r#"{"a":1,"b":"x"}"#).unwrap();
         let h = unsafe { jsonata_compile(ce.as_ptr()) };
@@ -237,6 +399,32 @@ mod tests {
         let msg = last_error().expect("eval error should set message");
         assert!(!msg.is_empty());
         unsafe { jsonata_free_expr(h) };
+
+        // $number on an array raises a spec-coded error (D3030) — this
+        // engine stores the code at the start of the message
+        let ce2 = CString::new("$number(b)").unwrap();
+        let cd2 = CString::new(r#"{"b":[1]}"#).unwrap();
+        let h2 = unsafe { jsonata_compile(ce2.as_ptr()) };
+        let r2 = unsafe { jsonata_evaluate(h2, cd2.as_ptr()) };
+        assert!(r2.is_null());
+        assert_eq!(last_code().as_deref(), Some("D3030"));
+        unsafe { jsonata_free_expr(h2) };
+    }
+
+    #[test]
+    fn uncoded_error_has_null_code() {
+        unsafe {
+            let ce = CString::new("a").unwrap();
+            let cd = CString::new("{not json").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(r.is_null());
+            assert!(last_error().unwrap().contains("invalid input JSON"));
+            let r2 = jsonata_evaluate(h, cd.as_ptr());
+            assert!(r2.is_null());
+            assert_eq!(last_code(), None);
+            jsonata_free_expr(h);
+        }
     }
 
     #[test]
@@ -255,7 +443,8 @@ mod tests {
 
     #[test]
     fn multibyte_utf8_round_trip() {
-        let out = unsafe { eval_str("$uppercase(name)", r#"{"name":"héllo wörld ✓ 日本語"}"#) };
+        let out =
+            unsafe { eval_str("$uppercase(name)", r#"{"name":"héllo wörld ✓ 日本語"}"#) };
         assert_eq!(out.as_deref(), Some(r#""HÉLLO WÖRLD ✓ 日本語""#));
     }
 
@@ -263,5 +452,92 @@ mod tests {
     fn version_is_crate_version() {
         let v = unsafe { CStr::from_ptr(jsonata_version()).to_str().unwrap() };
         assert_eq!(v, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn null_pointer_guards() {
+        unsafe {
+            assert!(jsonata_compile(std::ptr::null()).is_null());
+            assert!(last_error().unwrap().contains("NULL"));
+
+            assert!(jsonata_evaluate(std::ptr::null_mut(), std::ptr::null()).is_null());
+            assert!(last_error().unwrap().contains("NULL"));
+
+            let ce = CString::new("a").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            assert!(jsonata_evaluate(h, std::ptr::null()).is_null());
+            assert!(last_error().unwrap().contains("NULL"));
+
+            assert_eq!(jsonata_bind_var(h, std::ptr::null(), std::ptr::null()), -1);
+            assert!(last_error().unwrap().contains("NULL"));
+
+            // free fns accept NULL without crashing
+            jsonata_free_expr(std::ptr::null_mut());
+            jsonata_free_string(std::ptr::null_mut());
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn bind_var_round_trip() {
+        unsafe {
+            let ce = CString::new("$x + n").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            assert!(!h.is_null());
+
+            let name = CString::new("x").unwrap();
+            let val = CString::new("40").unwrap();
+            assert_eq!(jsonata_bind_var(h, name.as_ptr(), val.as_ptr()), 0);
+
+            let cd = CString::new(r#"{"n":2}"#).unwrap();
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(!r.is_null(), "evaluate failed: {:?}", last_error());
+            assert_eq!(CStr::from_ptr(r).to_str().unwrap(), "42");
+            jsonata_free_string(r);
+            jsonata_free_expr(h);
+
+            // "$"-prefixed name accepted; structured JSON value binds
+            let ce2 = CString::new("$sum($x.deep) + n").unwrap();
+            let h2 = jsonata_compile(ce2.as_ptr());
+            let name2 = CString::new("$x").unwrap();
+            let val2 = CString::new(r#"{"deep": [1,2,3]}"#).unwrap();
+            assert_eq!(jsonata_bind_var(h2, name2.as_ptr(), val2.as_ptr()), 0);
+            let r2 = jsonata_evaluate(h2, cd.as_ptr());
+            assert!(!r2.is_null(), "evaluate failed: {:?}", last_error());
+            assert_eq!(CStr::from_ptr(r2).to_str().unwrap(), "8");
+            jsonata_free_string(r2);
+
+            // re-binding replaces the value
+            let val3 = CString::new(r#"{"deep": [10]}"#).unwrap();
+            assert_eq!(jsonata_bind_var(h2, name2.as_ptr(), val3.as_ptr()), 0);
+            let r3 = jsonata_evaluate(h2, cd.as_ptr());
+            assert!(!r3.is_null(), "evaluate failed: {:?}", last_error());
+            assert_eq!(CStr::from_ptr(r3).to_str().unwrap(), "12");
+            jsonata_free_string(r3);
+
+            // invalid JSON value -> -1 + message
+            let bad = CString::new("{nope").unwrap();
+            assert_eq!(jsonata_bind_var(h2, name2.as_ptr(), bad.as_ptr()), -1);
+            assert!(last_error().unwrap().contains("invalid JSON"));
+
+            jsonata_free_expr(h2);
+        }
+    }
+
+    #[test]
+    fn extract_error_code_shapes() {
+        assert_eq!(
+            extract_error_code("T2002: not a number").as_deref(),
+            Some("T2002")
+        );
+        assert_eq!(extract_error_code("S0214: bad %").as_deref(), Some("S0214"));
+        assert_eq!(
+            extract_error_code("Runtime error: D3030: Cannot convert").as_deref(),
+            Some("D3030")
+        );
+        assert_eq!(extract_error_code("Parse error: something"), None);
+        assert_eq!(extract_error_code("invalid input JSON: x"), None);
+        assert_eq!(extract_error_code("T20: short"), None);
+        assert_eq!(extract_error_code(""), None);
     }
 }

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,0 +1,267 @@
+//! Minimal C ABI over the engine (spike scope — see
+//! docs/superpowers/specs/2026-07-13-java-dotnet-ffi-benchmark-experiment-design.md).
+//!
+//! JSON crosses the boundary as UTF-8 C strings in both directions. Errors go
+//! through a thread-local slot: a NULL return from `jsonata_evaluate` with an
+//! EMPTY slot means the JSONata result was undefined (not an error). Handles
+//! are not Send — one `JsonataExpr*` per thread.
+
+use std::cell::{OnceCell, RefCell};
+use std::ffi::{c_char, CStr, CString};
+
+use crate::evaluator::{self, EvaluatorOptions};
+use crate::value::JValue;
+use crate::{compiler, parser, vm};
+
+pub struct JsonataExpr {
+    ast: crate::ast::AstNode,
+    bytecode: OnceCell<Option<vm::BytecodeProgram>>,
+}
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
+}
+
+fn set_error(msg: String) {
+    let c = CString::new(msg).unwrap_or_else(|_| CString::new("error message contained NUL").unwrap());
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(c));
+}
+
+fn clear_error() {
+    LAST_ERROR.with(|e| *e.borrow_mut() = None);
+}
+
+/// # Safety
+/// `expr_utf8` must be a valid NUL-terminated C string pointer or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_compile(expr_utf8: *const c_char) -> *mut JsonataExpr {
+    if expr_utf8.is_null() {
+        set_error("expression pointer is NULL".to_string());
+        return std::ptr::null_mut();
+    }
+    let expr = match CStr::from_ptr(expr_utf8).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_error("expression is not valid UTF-8".to_string());
+            return std::ptr::null_mut();
+        }
+    };
+    match parser::parse(expr) {
+        Ok(ast) => {
+            clear_error();
+            Box::into_raw(Box::new(JsonataExpr { ast, bytecode: OnceCell::new() }))
+        }
+        Err(e) => {
+            set_error(e.display_message());
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// # Safety
+/// `expr` must be a pointer returned by `jsonata_compile` (not yet freed);
+/// `json_utf8` must be a valid NUL-terminated C string pointer or NULL.
+/// Returned string must be released with `jsonata_free_string`.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_evaluate(
+    expr: *mut JsonataExpr,
+    json_utf8: *const c_char,
+) -> *mut c_char {
+    if expr.is_null() {
+        set_error("expression handle is NULL".to_string());
+        return std::ptr::null_mut();
+    }
+    if json_utf8.is_null() {
+        set_error("input JSON pointer is NULL".to_string());
+        return std::ptr::null_mut();
+    }
+    let expr = &*expr;
+    let json = match CStr::from_ptr(json_utf8).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_error("input JSON is not valid UTF-8".to_string());
+            return std::ptr::null_mut();
+        }
+    };
+    let data = match JValue::from_json_str(json) {
+        Ok(v) => v,
+        Err(e) => {
+            set_error(format!("invalid input JSON: {}", e));
+            return std::ptr::null_mut();
+        }
+    };
+    // Same pattern as JsonataExpression::run_eval in lib.rs: VM when the
+    // expression compiles to bytecode, tree-walker otherwise.
+    let bytecode = expr.bytecode.get_or_init(|| {
+        evaluator::try_compile_expr(&expr.ast).map(|ce| compiler::BytecodeCompiler::compile(&ce))
+    });
+    let result = if let Some(bc) = bytecode {
+        vm::Vm::with_options(bc, EvaluatorOptions::default()).run(&data, None)
+    } else {
+        let mut ev = evaluator::Evaluator::with_options(
+            evaluator::Context::new(),
+            EvaluatorOptions::default(),
+        );
+        ev.evaluate(&expr.ast, &data)
+    };
+    match result {
+        Ok(v) => {
+            clear_error();
+            if v.is_undefined() {
+                return std::ptr::null_mut(); // undefined: NULL + empty error slot
+            }
+            match v.to_json_string() {
+                Ok(s) => match CString::new(s) {
+                    Ok(c) => c.into_raw(),
+                    Err(_) => {
+                        set_error("result contained interior NUL".to_string());
+                        std::ptr::null_mut()
+                    }
+                },
+                Err(e) => {
+                    set_error(format!("could not serialize result: {}", e));
+                    std::ptr::null_mut()
+                }
+            }
+        }
+        Err(e) => {
+            set_error(e.message().to_string());
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// # Safety
+/// `expr` must be NULL or a pointer returned by `jsonata_compile`, freed at most once.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_free_expr(expr: *mut JsonataExpr) {
+    if !expr.is_null() {
+        drop(Box::from_raw(expr));
+    }
+}
+
+/// # Safety
+/// `s` must be NULL or a pointer returned by this library, freed at most once.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_free_string(s: *mut c_char) {
+    if !s.is_null() {
+        drop(CString::from_raw(s));
+    }
+}
+
+/// Returns a copy of the thread-local error message (caller frees with
+/// `jsonata_free_string`), or NULL if the slot is empty.
+#[no_mangle]
+pub extern "C" fn jsonata_last_error_message() -> *mut c_char {
+    LAST_ERROR.with(|e| match &*e.borrow() {
+        Some(c) => c.clone().into_raw(),
+        None => std::ptr::null_mut(),
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn jsonata_version() -> *const c_char {
+    concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as *const c_char
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    unsafe fn eval_str(expr: &str, data: &str) -> Option<String> {
+        let ce = CString::new(expr).unwrap();
+        let cd = CString::new(data).unwrap();
+        let h = jsonata_compile(ce.as_ptr());
+        assert!(!h.is_null(), "compile failed: {:?}", last_error());
+        let r = jsonata_evaluate(h, cd.as_ptr());
+        let out = if r.is_null() {
+            None
+        } else {
+            let s = CStr::from_ptr(r).to_str().unwrap().to_string();
+            jsonata_free_string(r);
+            Some(s)
+        };
+        jsonata_free_expr(h);
+        out
+    }
+
+    fn last_error() -> Option<String> {
+        let p = jsonata_last_error_message();
+        if p.is_null() {
+            return None;
+        }
+        unsafe {
+            let s = CStr::from_ptr(p).to_str().unwrap().to_string();
+            jsonata_free_string(p);
+            Some(s)
+        }
+    }
+
+    #[test]
+    fn round_trip_simple_path() {
+        let out = unsafe { eval_str("user.name", r#"{"user":{"name":"Alice"}}"#) };
+        assert_eq!(out.as_deref(), Some(r#""Alice""#));
+    }
+
+    #[test]
+    fn round_trip_object_result() {
+        let out = unsafe { eval_str(r#"{"n": a + b}"#, r#"{"a":1,"b":2}"#) };
+        assert_eq!(out.as_deref(), Some(r#"{"n":3}"#));
+    }
+
+    #[test]
+    fn undefined_result_is_null_with_empty_error() {
+        let out = unsafe { eval_str("missing.path", r#"{"a":1}"#) };
+        assert_eq!(out, None);
+        assert_eq!(last_error(), None);
+    }
+
+    #[test]
+    fn parse_error_sets_message() {
+        let ce = CString::new("a.b[").unwrap();
+        let h = unsafe { jsonata_compile(ce.as_ptr()) };
+        assert!(h.is_null());
+        let msg = last_error().expect("parse error should set message");
+        assert!(!msg.is_empty());
+    }
+
+    #[test]
+    fn eval_error_sets_message() {
+        // "a" + string is a type error (T2002-family) at evaluation time
+        let ce = CString::new(r#"a + b"#).unwrap();
+        let cd = CString::new(r#"{"a":1,"b":"x"}"#).unwrap();
+        let h = unsafe { jsonata_compile(ce.as_ptr()) };
+        assert!(!h.is_null());
+        let r = unsafe { jsonata_evaluate(h, cd.as_ptr()) };
+        assert!(r.is_null());
+        let msg = last_error().expect("eval error should set message");
+        assert!(!msg.is_empty());
+        unsafe { jsonata_free_expr(h) };
+    }
+
+    #[test]
+    fn invalid_input_json_sets_message() {
+        let out_err = unsafe {
+            let ce = CString::new("a").unwrap();
+            let cd = CString::new("{not json").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(r.is_null());
+            jsonata_free_expr(h);
+            last_error()
+        };
+        assert!(out_err.unwrap().contains("invalid input JSON"));
+    }
+
+    #[test]
+    fn multibyte_utf8_round_trip() {
+        let out = unsafe { eval_str("$uppercase(name)", r#"{"name":"héllo wörld ✓ 日本語"}"#) };
+        assert_eq!(out.as_deref(), Some(r#""HÉLLO WÖRLD ✓ 日本語""#));
+    }
+
+    #[test]
+    fn version_is_crate_version() {
+        let v = unsafe { CStr::from_ptr(jsonata_version()).to_str().unwrap() };
+        assert_eq!(v, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub mod parser;
 mod signature;
 pub mod value;
 mod vm;
+#[cfg(feature = "capi")]
+pub mod capi;
 
 // ── Benchmarking facade (only when the "bench" feature is enabled) ────────────
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 
 pub mod ast;
 pub mod ast_transform;
+#[cfg(feature = "capi")]
+pub mod capi;
 mod compiler;
 mod datetime;
 pub mod evaluator;
@@ -41,8 +43,6 @@ pub mod parser;
 mod signature;
 pub mod value;
 mod vm;
-#[cfg(feature = "capi")]
-pub mod capi;
 
 // ── Benchmarking facade (only when the "bench" feature is enabled) ────────────
 //


### PR DESCRIPTION
## Summary

Promotes the C ABI validated by the Java/.NET FFI benchmark experiment (branch `experiment/java-dotnet-bindings`) to the full **Phase 4 C deliverable** from the [multi-language design](docs/superpowers/specs/2026-07-09-multi-language-and-agentic-study-design.md): use JSONata from C, C++, or anything with C interop.

- **`capi` cargo feature** (`src/capi.rs`, additive, off by default): 8 functions, JSON text in/out, thread-local error slot. Evaluation uses the same VM-with-tree-walker-fallback dispatch as the Python bindings.
- **`jsonata_bind_var`**: JSON-valued `$variables` per handle (forces the tree-walker path, mirroring `lib.rs::run_eval`).
- **`jsonata_last_error_code`**: extracts JSONata spec codes (`T2002`, `D3030`, …) from error messages at token boundaries. Deviation from the original spec sketch: no `jsonata_last_error_position` (the engine doesn't track positions) and the error slot is thread-local rather than per-handle (validated by two real consumers in the FFI experiment).
- **Panic hardening**: `catch_unwind` at the boundary — engine panics surface as `internal error:` messages instead of unwinding into or aborting the host process.
- **`bindings/c/jsonata.h`**: hand-written, C++-safe public header with the full ownership/threading/undefined-vs-error contract.
- **`bindings/c/examples/smoke.c`**: 14-assertion smoke test; the new path-gated `capi.yml` workflow builds the `.so` and compiles+runs it as both C **and** C++ on every relevant change.
- **`bindings/c/README.md`**: build + link instructions (gcc/clang, Makefile, CMake snippets), API rules, and a worked example; main README gains a C/C++ quick start.

## Testing

- `cargo test --features capi capi::` — 12/12 (round trips, undefined-vs-error disambiguation, coded/uncoded errors, NULL guards, bind_var incl. rebinding + `$`-prefix, multibyte UTF-8, code extraction shapes)
- `cargo test` (no feature) — all suites green, capi not compiled
- smoke.c compiled `-Wall -Wextra -Werror` with gcc and g++, 14/14 PASS against the release `.so`
- `cargo clippy --all-targets --all-features -- -D warnings` — clean; `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)