### PR TITLE
perf: replace per-call env read in force_tree_walker with atomic toggle

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system -e ".[dev]" || uv pip install --system pytest ruff mypy
+          # Audit-environment tool, not a project dependency: the runner image
+          # ships an older setuptools flagged by PYSEC-2026-3447 (fixed in 83.0.0)
+          uv pip install --system --upgrade "setuptools>=83.0.0"
 
       - name: Run pip-audit
         id: pip_audit

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -28,6 +28,11 @@ from ._jsonatapy import (
     __jsonata_version__,
     __version__,
 )
+
+# Private test hooks (not public API): runtime toggle forcing the
+# tree-walking evaluator; seeded from JSONATAPY_FORCE_TREE_WALKER at import.
+from ._jsonatapy import _get_force_tree_walker as _get_force_tree_walker
+from ._jsonatapy import _set_force_tree_walker as _set_force_tree_walker
 from ._jsonatapy import (
     compile as _compile,
 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,13 +165,37 @@ struct JsonataExpression {
     default_options: evaluator::EvaluatorOptions,
 }
 
-/// Test-support toggle: set JSONATAPY_FORCE_TREE_WALKER=1 to bypass the
-/// bytecode VM and exercise the tree-walking evaluator on every call.
-/// Read per-call (not cached) so tests can flip it via monkeypatch.setenv;
-/// the ~100ns env read is noise next to a µs-scale evaluation.
+/// Test-support toggle: bypass the bytecode VM and exercise the tree-walking
+/// evaluator on every call. Seeded once at module import from the
+/// JSONATAPY_FORCE_TREE_WALKER env var (whole-process forcing, e.g. the CI
+/// tree-walker reference-suite job), and flippable at runtime through the
+/// private `_set_force_tree_walker` pyfunction (what the Python tests use).
+///
+/// This was previously a per-call `env::var_os` read (~100-200ns), which is
+/// NOT noise next to a sub-microsecond evaluation: it showed up as a 10-30%
+/// regression on tiny expressions in v2.2.4 (issue #74). A relaxed atomic
+/// load is ~1ns and preserves the flip-mid-test capability.
+#[cfg(feature = "python")]
+static FORCE_TREE_WALKER: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 #[cfg(feature = "python")]
 fn force_tree_walker() -> bool {
-    std::env::var_os("JSONATAPY_FORCE_TREE_WALKER").is_some_and(|v| !v.is_empty() && v != "0")
+    FORCE_TREE_WALKER.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Private test hook: force (or unforce) the tree-walking evaluator for all
+/// subsequent evaluations in this process. Not part of the public API.
+#[cfg(feature = "python")]
+#[pyfunction]
+fn _set_force_tree_walker(on: bool) {
+    FORCE_TREE_WALKER.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Private test hook: current state of the tree-walker toggle.
+#[cfg(feature = "python")]
+#[pyfunction]
+fn _get_force_tree_walker() -> bool {
+    force_tree_walker()
 }
 
 #[cfg(feature = "python")]
@@ -640,8 +664,15 @@ fn parser_error_to_py(e: parser::ParserError) -> PyErr {
 #[cfg(feature = "python")]
 #[pymodule]
 fn _jsonatapy(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Seed the tree-walker toggle from the environment once, at import time.
+    FORCE_TREE_WALKER.store(
+        std::env::var_os("JSONATAPY_FORCE_TREE_WALKER").is_some_and(|v| !v.is_empty() && v != "0"),
+        std::sync::atomic::Ordering::Relaxed,
+    );
     m.add_function(wrap_pyfunction!(compile, m)?)?;
     m.add_function(wrap_pyfunction!(evaluate, m)?)?;
+    m.add_function(wrap_pyfunction!(_set_force_tree_walker, m)?)?;
+    m.add_function(wrap_pyfunction!(_get_force_tree_walker, m)?)?;
     m.add_class::<JsonataExpression>()?;
     m.add_class::<JsonataData>()?;
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -188,3 +188,13 @@ def jsonatapy():
     import jsonatapy
 
     return jsonatapy
+
+
+@pytest.fixture()
+def force_tree_walker_toggle():
+    """Yields jsonatapy's private tree-walker toggle setter; always resets to
+    off at teardown (including on test failure)."""
+    import jsonatapy
+
+    yield jsonatapy._set_force_tree_walker
+    jsonatapy._set_force_tree_walker(False)

--- a/tests/python/test_lazy_views.py
+++ b/tests/python/test_lazy_views.py
@@ -49,8 +49,10 @@ def test_lazy_missing_field_is_undefined():
 
 
 @pytest.fixture()
-def force_tree_walker(monkeypatch):
-    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+def force_tree_walker():
+    jsonatapy._set_force_tree_walker(True)
+    yield
+    jsonatapy._set_force_tree_walker(False)
 
 
 # Activated in Task 5 (were deferred pending whole-object/whole-stream
@@ -111,10 +113,10 @@ OBJ = {"a": 1, "b": {"c": 2}, "d": [1, 2]}
 
 
 @pytest.fixture(params=["vm", "tree"])
-def engine(request, monkeypatch):
-    if request.param == "tree":
-        monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
-    return request.param
+def engine(request):
+    jsonatapy._set_force_tree_walker(request.param == "tree")
+    yield request.param
+    jsonatapy._set_force_tree_walker(False)
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_tree_walker_undefined.py
+++ b/tests/python/test_tree_walker_undefined.py
@@ -16,15 +16,19 @@ it already special-cased `Null | Undefined` inline for these functions.
 
 Two ways to force the tree-walker are exercised here:
   1. Passing a non-empty `bindings` dict to `evaluate()` (works on any build).
-  2. The `JSONATAPY_FORCE_TREE_WALKER=1` env toggle (src/lib.rs), which
-     bypasses the bytecode VM on every call including `evaluate()` with no
-     bindings. Read per-call, so it can be flipped via monkeypatch.setenv.
+  2. The tree-walker toggle (src/lib.rs), which bypasses the bytecode VM on
+     every call including `evaluate()` with no bindings. Seeded from the
+     JSONATAPY_FORCE_TREE_WALKER env var at import time and flipped at
+     runtime via the private `jsonatapy._set_force_tree_walker` hook
+     (a relaxed atomic, so it costs nothing per evaluation -- issue #74).
 
 Both must agree with the default (VM) path: the result is undefined, i.e.
 `None` at the Python boundary.
 """
 
 import os
+import subprocess
+import sys
 
 import jsonatapy
 import pytest
@@ -57,23 +61,34 @@ def test_bindings_forced_tree_walker_propagates_undefined(expr):
 
 
 @pytest.mark.parametrize("expr", UNDEFINED_INPUT_CASES)
-def test_env_forced_tree_walker_propagates_undefined(expr, monkeypatch):
-    """JSONATAPY_FORCE_TREE_WALKER=1 forces the tree-walker even with bindings=None."""
-    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+def test_toggle_forced_tree_walker_propagates_undefined(expr, force_tree_walker_toggle):
+    """The runtime toggle forces the tree-walker even with bindings=None."""
+    force_tree_walker_toggle(True)
     compiled = jsonatapy.compile(expr)
     result = compiled.evaluate(None)
     assert result is None
 
 
-def test_force_tree_walker_env_var_is_read_per_call(monkeypatch):
-    """The toggle isn't cached at compile time -- flipping it mid-test takes effect."""
-    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER", raising=False)
+def test_force_toggle_takes_effect_without_recompiling(force_tree_walker_toggle):
+    """The toggle isn't cached per expression -- flipping it mid-test affects an
+    already-compiled expression's subsequent evaluations (the property every
+    compare-both-paths-on-one-expression test in this suite relies on)."""
     compiled = jsonatapy.compile("$abs(nothing)")
+    assert jsonatapy._get_force_tree_walker() is False
     assert compiled.evaluate(None) is None
 
-    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    force_tree_walker_toggle(True)
+    assert jsonatapy._get_force_tree_walker() is True
     assert compiled.evaluate(None) is None
 
-    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER")
-    assert os.environ.get("JSONATAPY_FORCE_TREE_WALKER") is None
-    assert compiled.evaluate(None) is None
+
+def test_env_var_seeds_toggle_at_import():
+    """JSONATAPY_FORCE_TREE_WALKER=1 in the process environment turns the
+    toggle on from import time -- how the CI tree-walker suite job forces the
+    whole process. (Runs in a subprocess: the toggle is seeded once at module
+    import, so it can't be tested by mutating os.environ in this process.)"""
+    code = "import jsonatapy; print(jsonatapy._get_force_tree_walker())"
+    for env_val, expected in (("1", "True"), ("", "False"), ("0", "False")):
+        env = dict(os.environ, JSONATAPY_FORCE_TREE_WALKER=env_val)
+        out = subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, text=True)
+        assert out.stdout.strip() == expected, (env_val, out.stdout, out.stderr)

--- a/tests/python/test_vm_math_undefined.py
+++ b/tests/python/test_vm_math_undefined.py
@@ -15,7 +15,7 @@ invisible there. It becomes observable in object construction: object keys
 with an `Undefined` value are dropped, but keys with an explicit `Null`
 value are kept. So `{"x": $abs(nothing)}` (nothing = missing field) produced
 `{"x": None}` on the VM (default) path but the spec-correct `{}` on the
-tree-walker path (`JSONATAPY_FORCE_TREE_WALKER=1`) -- and per the jsonata-js
+tree-walker path (via the private `_set_force_tree_walker` toggle) -- and per the jsonata-js
 oracle, `{}` is correct.
 
 Fix: add "abs", "ceil", "floor", "round", "sqrt" to the shared
@@ -35,8 +35,6 @@ migration (missing-field paths already evaluate to `Undefined`, not
 compilation for too-many-args calls before the VM ever runs, so both paths
 fall back to the tree-walker and raise the identical arity error.
 """
-
-import os
 
 import jsonatapy
 import pytest
@@ -58,16 +56,16 @@ def test_default_vm_path_drops_undefined_key(fn):
 
 
 @pytest.mark.parametrize("fn", MATH_FUNCTIONS)
-def test_default_matches_forced_tree_walker(fn, monkeypatch):
+def test_default_matches_forced_tree_walker(fn, force_tree_walker_toggle):
     """Default (VM) path and forced-tree-walker path must agree on object construction."""
     expr_src = f'{{"x": ${fn}(nothing)}}'
     expr = jsonatapy.compile(expr_src)
 
     default_result = expr.evaluate(DATA)
 
-    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    force_tree_walker_toggle(True)
     tree_walker_result = expr.evaluate(DATA)
-    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER")
+    force_tree_walker_toggle(False)
 
     assert default_result == tree_walker_result == {}
 
@@ -90,16 +88,16 @@ def test_explicit_null_argument_still_passes_through_as_null(fn):
     default_result = expr.evaluate(data)
     assert default_result == {"x": None}
 
-    os.environ["JSONATAPY_FORCE_TREE_WALKER"] = "1"
+    jsonatapy._set_force_tree_walker(True)
     try:
         tw_result = expr.evaluate(data)
     finally:
-        del os.environ["JSONATAPY_FORCE_TREE_WALKER"]
+        jsonatapy._set_force_tree_walker(False)
     assert tw_result == {"x": None}
 
 
 @pytest.mark.parametrize("fn", MATH_FUNCTIONS)
-def test_arity_error_unaffected_by_undefined_first_arg(fn, monkeypatch):
+def test_arity_error_unaffected_by_undefined_first_arg(fn, force_tree_walker_toggle):
     """Calling with too many args and an undefined first arg must still raise the
     arity error identically on both paths (not short-circuit to undefined).
     round() accepts an optional precision arg, so it needs 3 args to overflow;
@@ -110,9 +108,9 @@ def test_arity_error_unaffected_by_undefined_first_arg(fn, monkeypatch):
     with pytest.raises(Exception) as default_exc_info:
         expr.evaluate(DATA)
 
-    monkeypatch.setenv("JSONATAPY_FORCE_TREE_WALKER", "1")
+    force_tree_walker_toggle(True)
     with pytest.raises(Exception) as tw_exc_info:
         expr.evaluate(DATA)
-    monkeypatch.delenv("JSONATAPY_FORCE_TREE_WALKER")
+    force_tree_walker_toggle(False)
 
     assert str(default_exc_info.value) == str(tw_exc_info.value)


### PR DESCRIPTION
## Summary

Fixes the primary cause of #74 (v2.2.4 tiny-scenario performance regression).

**Root cause:** v2.2.4's `JSONATAPY_FORCE_TREE_WALKER` test toggle read the env var via `std::env::var_os` on **every** `run_eval` call — on both `evaluate(dict)` and `evaluate_json()`. At ~100–200ns per read, that's 10–30% of a sub-microsecond evaluation. Confirmed by A/B: a v2.2.4 build with only the read stubbed recovered 5–16% on exactly the regressed scenarios, on both paths.

**Fix:** process-wide `AtomicBool`, seeded once at module import from the env var (the CI tree-walker reference-suite job works unchanged) and flippable at runtime via private `_set_force_tree_walker` / `_get_force_tree_walker` hooks. Relaxed atomic load per call (~1ns), and the flip-mid-test capability the undefined-parity tests rely on is preserved — tests switch from `monkeypatch.setenv` to the hook via a shared auto-resetting fixture.

**Measured** (compile-once `evaluate(dict)` loops, min-of-trials, ABBA-bracketed): all regressed tiny scenarios improve 5–16% vs stock 2.2.4 wheels (quiet machine; 5–8% in a noisier window), no scenario regresses. The remaining delta vs 2.2.3 on tiny payloads (~5–10%, plus per-element lambda cost in `$map`/`$reduce`) is the documented lazy-views boundary tradeoff — the same release is up to **48% faster** on realistic workloads (e.g. Filter by category).

## Testing

- The 3 affected test files: 131/131 (includes new pinning tests: toggle takes effect without recompiling; env var seeds at import — subprocess-tested for `1`/empty/`0`)
- Reference suite: 1682/1682 default mode, 1682/1682 with `JSONATAPY_FORCE_TREE_WALKER=1` (env-seeded process, replicating the CI job)
- `cargo test --lib` 175/175, `cargo clippy --all-targets --all-features -D warnings` clean, `cargo fmt --check` clean, ruff clean; mypy findings are the pre-existing advisory native-module-stub class

🤖 Generated with [Claude Code](https://claude.com/claude-code)