### PR TITLE
Host-callable custom functions (Phase 1: Rust core + API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Host-callable custom functions (Rust core): `Evaluator::register_fn` and
+  `Evaluator::register_fn_override` let a host register native functions callable
+  from an expression as `$name(...)` — the equivalent of jsonata-js's
+  `registerFunction`. Functions are plain closures
+  (`Fn(&[JValue]) -> Result<JValue, EvaluatorError>`) and resolve after the
+  expression's own bindings/lambdas and before built-ins. `register_fn` rejects
+  collisions with built-ins; `register_fn_override` allows deliberately replacing
+  the impure built-ins (`$now`, `$millis`, `$random`, `$eval`) for determinism
+  injection or sandboxing. Evaluation stays synchronous. See
+  `examples/host_functions.rs` and the Rust crate docs. (Not yet exposed through
+  the Python or C bindings.)
 
 ### Changed
 

--- a/docs/rust-crate.md
+++ b/docs/rust-crate.md
@@ -126,6 +126,51 @@ let mut ev = Evaluator::with_context(ctx);
 let result = ev.evaluate(&ast, &data)?;  // $threshold available in expression
 ```
 
+### Host (custom) functions
+
+Register native Rust functions that an expression can call as `$name(...)` —
+the equivalent of jsonata-js's `registerFunction`. This is how you expose
+enrichment/lookup functions, host-owned formatting, or scoring logic to an
+expression that is otherwise pure. Evaluation stays synchronous: a host function
+that does I/O simply blocks (run evaluations across threads for concurrency).
+
+```rust
+pub trait HostFn { /* blanket-impl'd for Fn(&[JValue]) -> Result<JValue, EvaluatorError> */ }
+
+impl Evaluator {
+    pub fn register_fn(&mut self, name: impl Into<String>, f: impl HostFn + 'static)
+        -> Result<(), EvaluatorError>;
+    pub fn register_fn_override(&mut self, name: impl Into<String>, f: impl HostFn + 'static)
+        -> Result<(), EvaluatorError>;
+}
+```
+
+```rust
+let mut ev = Evaluator::new();
+ev.register_fn("productName", |args: &[JValue]| {
+    let sku = args.first().and_then(|v| v.as_str()).unwrap_or("");
+    Ok(JValue::from(lookup_name(sku)))
+})?;
+
+let ast = parse("items.{ 'sku': sku, 'name': $productName(sku) }")?;
+let out = ev.evaluate(&ast, &data)?;
+```
+
+Resolution and shadowing rules:
+
+- A host function resolves **after** the expression's own `:=` bindings and
+  language-defined functions, and **before** built-ins.
+- `register_fn` **rejects a name that collides with a built-in**. To replace a
+  built-in deliberately — e.g. a frozen `$now`/seeded `$random` for reproducible
+  tests, or a disabled `$eval` for sandboxing — use `register_fn_override`.
+- `register_fn_override` refuses to override a *compilable* built-in (those on
+  the bytecode fast path); the impure built-ins that motivate overriding
+  (`$now`, `$millis`, `$random`, `$eval`) are all overridable.
+- Arguments arrive already evaluated. A host function that does I/O blocks;
+  parallelise across threads (one `Evaluator` per thread).
+
+See `examples/host_functions.rs` for a runnable walkthrough.
+
 ## Performance
 
 Criterion benchmark results (pure Rust, no Python, release build):

--- a/docs/superpowers/specs/2026-07-19-host-callable-functions-design.md
+++ b/docs/superpowers/specs/2026-07-19-host-callable-functions-design.md
@@ -1,0 +1,259 @@
+# Host-callable custom functions
+
+## Context
+
+jsonata-core today has **no way for a host application to register its own function** that a
+JSONata expression can call. The `bindings` argument (Rust `Context::bind`, the Python
+`bindings=` dict, the C ABI) is converted to JSON *data* eagerly — a callable value passed
+in is dropped, not retained as a callable. So an expression can only call:
+
+1. built-in functions (`$sum`, `$map`, …), dispatched by name, and
+2. user-defined functions written **in the JSONata language itself** (`function($x){…}`),
+   which are pure and evaluated entirely inside the engine.
+
+This is the gap versus jsonata-js's `registerFunction`/`assign`. It is invisible in CI
+because the portable reference suite (`tests/jsonata-js/test/test-suite/groups`) can only
+express pure-language cases — a host closure cannot live in a JSON fixture — so nothing in
+the ported suite exercises or requires host functions. Conformance (language) and
+extensibility (host callbacks) are orthogonal axes; we pass the first and don't implement
+the second.
+
+"Custom functions" is two different features and only the language one is tested:
+
+- **Language user-functions** (`function(){}`, and HOF builtins like `$map`/`$filter`/
+  `$reduce` that take a lambda arg) — implemented, `JValue::Lambda` / `StoredLambda`.
+- **Host extension functions** (the app injecting native Rust/Python/C code) — this spec.
+
+### Why this and not async
+
+The recurring question is whether host functions require making the engine async. They do
+not. The motivating case is I/O inside a host function (`$fxRate`, `$productName`,
+`$riskScore`). With a synchronous core the call stack is simply:
+
+```
+caller ─▶ evaluate() ─▶ host_fn(args) ─▶ [blocking I/O] ─▶ value ─▶ … ─▶ result
+```
+
+One thread, blocked top-to-bottom while the I/O is in flight. That is *correct*, not a bug.
+Concurrency is obtained by running N such stacks on N threads (a thread/process pool in
+Python, native threads in Rust). This matches the guidance already in
+`docs/migration-from-js.md` ("replace Promise patterns with threading").
+
+Async is only needed to avoid *occupying a thread while waiting*, which matters in exactly
+one deployment shape: an async-native host (e.g. tokio) doing async I/O inside host
+functions **at high concurrency**, where one blocked thread per in-flight evaluation is too
+many. Even that shape is served *without* touching the core: wrap the whole synchronous
+evaluation in `tokio::task::spawn_blocking` (or the Python event-loop equivalent) and
+`.await` the join handle — the host stays async, jsonata-core stays sync, one blocked
+pool thread per concurrent eval. Only at extreme concurrency (thousands of simultaneous
+I/O-bound evals) would true async-inside-the-core win, and buying that means the
+`Rc → Arc` / `Send + Sync` / boxed-recursion teardown the core has so far avoided. Verdict:
+**sync core + blocking host functions; document the `spawn_blocking` pattern; revisit true
+async only if a concrete extreme-concurrency deployment proves it, and prefer an async
+wrapper over a core rewrite even then.**
+
+This is the reason jsonata-js is async at all: JavaScript has no threads and no blocking
+I/O, so an event loop is its *only* concurrency primitive — async was forced by the host
+language, not by JSONata. Rust and Python have threads, so we do not inherit the constraint.
+
+### What other Rust implementations do
+
+- **`jsonata-rs` (Stedi)** — alpha, "all interfaces unstable." Exposes `register_function`
+  and is **synchronous**; no async `evaluate` variant.
+- **`jsonata`** — incomplete ("panics in unexpected places"), synchronous.
+- **`async_jsonata_rust` (LajaSoft)** — the async-end-to-end project. `evaluate_async`
+  returns a future; runtime-agnostic (tokio / async-std / any executor); **also ships a
+  sync `evaluate` facade**. Custom functions are registered via a `FunctionRegistry` and
+  **may themselves be async** ("awaited cooperatively"). Mature: 1651/1653 on the official
+  suite. Streaming is **not** mentioned in its docs (despite the feature sometimes being
+  attributed to it).
+
+Takeaway for our decision: `async_jsonata_rust` confirms — rather than contradicts — the
+sync-core plan. Its single reason to be async end-to-end is exactly the case analyzed above
+(user functions that do I/O and are awaited); it pays for that with an evaluator where every
+node is a polled (boxed) future — overhead the pure-CPU common case eats on every
+evaluation. That is antithetical to jsonata-core's identity (SIMD-accelerated parse,
+bytecode VM, benchmark focus, PyO3/C bindings). The async niche is therefore already
+occupied and served well; jsonata-core's differentiation is **the fastest *sync* engine with
+real language bindings**. Adding *sync* host functions closes the extensibility gap without
+leaving that lane. A user who genuinely needs awaited async host functions at high
+concurrency already has `async_jsonata_rust` — we neither need to duplicate it nor should
+pay its per-node future cost to do so. (That even the async-first project keeps a sync
+`evaluate` facade underscores that sync is the common path.)
+
+## The reuse seam (confirmed against source)
+
+Host functions are the **builtin analog, not the lambda analog**: they are name-dispatched
+callables that receive already-evaluated arguments. That is exactly how `apply_function`
+resolves a `$foo(...)` call today (`src/evaluator.rs:9660`, the `AstNode::Variable` arm):
+
+```
+lookup_lambda(name)      → StoredLambda        → invoke_stored_lambda
+else lookup(name)        → lambda-valued JValue → invoke_stored_lambda
+else is_builtin_function → call_builtin_with_values(name, values)   ← host fns slot here
+else                     → unknown
+```
+
+`call_builtin_with_values(name, &[JValue])` already receives the **evaluated** argument
+slice — the precise shape of a leaf host callback `Fn(&[JValue]) -> Result<JValue, _>`. So
+the integration is: add a host-function registry and consult it in the same
+`is_builtin_function` / `call_builtin_with_values` seam (and its compiled-`BuiltinCall`
+equivalent at `src/evaluator.rs:1211`). No new `JValue` variant is required for the leaf
+case; the registry is keyed by name exactly like the builtin table.
+
+`Context` (`src/evaluator.rs:2759`) already keeps a `scope_stack` of `Scope { bindings,
+lambdas }`. The host registry lives one level up on the evaluator (it is process/config
+state, not per-scope), or on `Context` alongside the scopes; either way it is consulted
+only at the unresolved-name step, so it cannot shadow user `:=` bindings or builtins unless
+we choose the precedence (see Decisions).
+
+### Reentrancy is a phase-2 widening, not a redesign
+
+The evaluated `values: &[JValue]` handed to a name-dispatched call **can already contain a
+lambda value** — that is how `$map(arr, function($x){…})` works: the builtin invokes the
+lambda via `lookup_lambda_from_value` + `invoke_stored_lambda`. So the machinery for a
+host function to invoke a passed-in lambda already exists in the engine; what a v1 leaf
+callback lacks is a *handle* to reach it. jsonata-js supports exactly this (it wraps every
+function-typed argument in a callable closure before handing it to a native function —
+`apply(arg, params, null, environment)`), enabling host-defined higher-order functions;
+it does **not** expose a public API for arbitrary re-evaluation (issue #259).
+
+We match that split by choosing a **forward-compatible callback type now** so re-entry is
+an additive change later:
+
+```rust
+pub trait HostFn {
+    fn call(&self, args: &[JValue], ctx: &mut HostCtx) -> Result<JValue, EvaluatorError>;
+}
+
+// Ergonomic blanket impl: leaf closures never touch ctx.
+impl<F> HostFn for F where F: Fn(&[JValue]) -> Result<JValue, EvaluatorError> { … }
+```
+
+- **v1:** `HostCtx` is opaque (maybe read-only options). Simple closures use the blanket
+  `Fn` impl and ignore it entirely.
+- **phase 2:** add `HostCtx::apply(&mut self, f: &JValue, args: &[JValue]) -> Result<JValue,
+  _>` that routes back through `apply_function`/`invoke_stored_lambda`. Because re-entry
+  goes through the existing guarded path, the recursion/stack-depth guards (`stacker`,
+  `max_stack_depth`, `D1011`) are preserved automatically — a re-entering host fn cannot
+  bypass them. No signature change for existing callers.
+
+## Python surface specifics
+
+Extending to Python (Phase 2) is confirmed intent, not new scope, but Python — unlike the
+Rust-only competitor — has `asyncio`, so it is where the async temptation actually has
+teeth. It does not change the sync-core decision; it adds three realities to bake in.
+
+- **The GIL matches the sync core, and there is precedent.** The core is `Rc`
+  single-threaded; Python is GIL single-threaded — same shape. The evaluator *already*
+  re-enters Python mid-evaluation with the GIL held, to materialize lazy dict views
+  (`JValue::LazyPyDict`, `src/lazy.rs`, spec `2026-07-12-lazy-python-views-design.md`). A
+  Python host function is the same move, so the GIL-handling patterns already exist. This is
+  a point in favor.
+- **`async def` is the wrinkle.** Python devs reach for `async def` for I/O; the sync core
+  **cannot await** a returned coroutine. v1 **rejects a coroutine return with a clear
+  error**. The documented pattern for async-Python users is *do the async I/O outside
+  jsonata* — `await` lookups in the host, pass results in as `bindings`, then run the sync
+  transform — or run the sync `evaluate()` in `loop.run_in_executor(...)` with sync-blocking
+  host fns inside (the Python `spawn_blocking`). Making the Python `evaluate` truly async
+  would require the sync core to suspend at a host-fn call, i.e. making the core async (the
+  jsonata-js generator/trampoline path) — rejected: a Python-only benefit for the full core
+  teardown. Note there is **no async-Python JSONata to punt to** (`async_jsonata_rust` is
+  Rust), but the gap is narrow (next point) and is closed with a pattern, not a rewrite.
+- **The GIL caps the async payoff anyway.** A blocking Python host fn holds the GIL and
+  stalls all Python threads, so "threads for concurrency" is weaker in Python than Rust —
+  but async would not rescue CPU-bound work either (GIL serializes it). The slice where
+  async-Python host fns would truly win (thousands of concurrent I/O-bound `async def`
+  callbacks) is narrow; gather-then-bind covers most of it.
+- **Boundary cost → coarse-grained only.** Each call crosses Rust↔Python (marshal args →
+  call → marshal result → GIL). Cheap once, expensive 100k times. Python host fns are for a
+  handful of enrichment lookups, **not** per-element callbacks inside a `$map` over a large
+  array. Document this; the existing lazy-view work shows the codebase already minimizes
+  Py-boundary crossings.
+
+## Scope
+
+In scope (v1):
+- A host-function registry consulted in the `apply_function` name-resolution seam and the
+  compiled `BuiltinCall` path.
+- The `HostFn` trait + `Fn(&[JValue]) -> Result<JValue, EvaluatorError>` blanket impl,
+  typed so phase-2 reentrancy is additive.
+- **Rust crate API**: `register_fn(name, closure)` — the reference implementation.
+- **Python (PyO3) API**: register a Python callable; marshal args via the existing
+  `json_to_python` / `python_to_json` (`src/lib.rs`); map a Python exception →
+  `EvaluatorError`; detect an `async def` (coroutine return) and reject with a clear error.
+- Bespoke unit tests per binding (nothing in the portable suite covers this).
+
+Out of scope (later phases / explicitly not v1):
+- **Reentrancy / host-defined higher-order functions** — phase 2; the callback type is
+  chosen now so this does not break API.
+- **C ABI registration** (function pointer + `void* userdata`) — phase 3.
+- **Signature strings** for host fns (reusing `signature.rs`) — optional; v1 host fns
+  validate their own arity/types.
+- **VM support** — v1 forces the tree-walker fallback for any expression containing a
+  host-fn call (the engine already falls back for some lambda cases); teach the bytecode
+  compiler later only if profiling warrants.
+- **Async anything** — see "Why this and not async."
+
+## Phasing & estimate
+
+- **Phase 1 — core registry + dispatch + Rust API (usable MVP): IMPLEMENTED.**
+  `Evaluator::register_fn` / `register_fn_override`, a `HostFn` trait with an
+  `Fn(&[JValue]) -> Result<JValue, EvaluatorError>` blanket impl, and an opaque `HostCtx`
+  reserved for phase-2 reentrancy (`src/evaluator.rs`). Dispatch is hooked in
+  `evaluate_function_call` (direct `$name(...)` calls, resolving after the expression's own
+  bindings/lambdas and before built-ins) and defensively in `call_builtin_with_values`
+  (so a host *override* also wins in value position, e.g. `$f := $now; $f()`). Tests:
+  `tests/host_functions_test.rs` (12 cases). Notes from implementation:
+  - **Tree-walker fallback is automatic** for novel host-fn names: `try_compile_hof_expr`
+    already returns `None` for any non-`map`/`filter`/`reduce` name, so every compile site
+    bails to the tree-walker with no compiler change.
+  - **Overriding a *compilable* built-in is rejected at registration** (the bytecode path
+    can't see the registry). The impure targets that motivate overriding — `$now`,
+    `$millis`, `$random`, `$eval` — are all non-compilable, so this never blocks a
+    legitimate use.
+  - **Deferred from v1:** host-fn-as-first-class-value (`$map(arr, $greet)`,
+    `$f := $greet`) — pairs with reentrancy in a later phase; direct calls cover every
+    practical use case enumerated in this design.
+- **Phase 2 — Python (PyO3) binding:** ~1–2 days. Highest-value surface here; marshalling
+  helpers already exist. → ~1 week for Rust + Python end-to-end.
+- **Phase 3 — C ABI + signatures + docs polish:** ~1 week more. → ~2 weeks fully polished.
+- **Reentrancy** is folded into whichever later phase needs host-defined HOFs; not on the
+  critical path.
+
+## Decisions
+
+- **Host fns are the builtin analog** (name-dispatched, pre-evaluated args), not lambdas
+  bound into a scope. Registry keyed by name, consulted at the unresolved-name step.
+- **Precedence & shadowing.** User `:=` bindings and language lambdas win over host fns
+  (avoid surprising capture). For builtins, **do not** silently resolve host fns "after
+  builtins" — that turns a registered `$now` into a silent no-op. Instead: **a host name
+  colliding with a builtin is a registration-time error by default**, with an explicit
+  opt-in override API (`register_fn_override(name, …)` / `.allow_override()`). Rationale:
+  the only legitimate shadow cases cluster into two deliberate, small-set categories, and
+  both want a loud, self-documenting opt-in rather than default-allow (which is a
+  portability landmine) or a blanket ban (which forecloses real needs):
+  - **(A) Determinism injection** for impure builtins that exist here — `$now`
+    (`evaluator.rs:9542`), `$millis` (`:9551`), `$random` (`:10797`): frozen clock / seeded
+    RNG for reproducible tests, golden files, replay, or event/logical time in prod.
+  - **(B) Sandboxing/hardening** — override `$eval` (`evaluator.rs:9479`, dynamic
+    string-eval, the riskiest builtin) to disable it, or wrap a builtin to add
+    auditing/limits when running semi-trusted expressions.
+  Overriding *pure* builtins (`$sum`, `$map`, string/array ops) has no legitimate case and
+  should use a differently-named function instead. This default is safer than jsonata-js,
+  where a user binding can silently shadow a builtin.
+- **Sync, blocking host fns.** Blocking is the intended model; threads provide concurrency;
+  `spawn_blocking` bridges async hosts without touching the core.
+- **Forward-compatible `HostFn` trait now**, ergonomic `Fn` blanket impl, so phase-2
+  reentrancy adds `HostCtx::apply` without an API break.
+- **Tree-walker only in v1**; host-fn presence forces fallback.
+
+## Open questions
+
+- Precedence vs. builtins: **resolved** — collision is an error unless the explicit override
+  API is used (see Decisions). Remaining detail: override granularity (per-call
+  `register_fn_override` vs. a builder-wide `.allow_override()` flag).
+- Python: reject `async def` outright, or accept and run it to completion on a private loop?
+  (Lean reject in v1 — clearer, no hidden event loop.)
+- Whether to expose read-only `options`/context to leaf host fns in v1 (`HostCtx` non-opaque
+  from day one) or keep it fully opaque until phase 2.

--- a/examples/host_functions.rs
+++ b/examples/host_functions.rs
@@ -1,0 +1,113 @@
+// Host-callable custom functions
+//
+// Shows how a host application registers native Rust functions that a JSONata
+// expression can call as `$name(...)`:
+//   - enrichment/lookup functions (the canonical use case)
+//   - determinism injection: overriding an impure built-in ($now) with a frozen
+//     implementation for reproducible output
+//   - sandboxing: overriding a powerful built-in ($eval) to disable it
+//
+// Run with: cargo run --example host_functions
+
+use jsonata_core::value::JValue;
+use jsonata_core::{evaluator::Evaluator, parser::parse};
+use serde_json::json;
+
+fn main() {
+    demo_enrichment_lookup();
+    demo_multi_arg();
+    demo_override_now();
+    demo_sandbox_eval();
+    demo_collision_is_rejected();
+}
+
+fn eval(ev: &mut Evaluator, expr: &str, data: serde_json::Value) -> JValue {
+    let ast = parse(expr).expect("expression parses");
+    ev.evaluate(&ast, &JValue::from(data))
+        .expect("evaluation succeeds")
+}
+
+/// The canonical use case: a lookup backed by host-owned data. The expression
+/// stays a clean artifact; the host owns the (here trivial) data source.
+fn demo_enrichment_lookup() {
+    let mut ev = Evaluator::new();
+    ev.register_fn("productName", |args: &[JValue]| {
+        let sku = args.first().and_then(|v| v.as_str()).unwrap_or("");
+        let name = match sku {
+            "A-1" => "Widget",
+            "B-2" => "Gadget",
+            _ => "Unknown",
+        };
+        Ok(JValue::from(name))
+    })
+    .unwrap();
+
+    let out = eval(
+        &mut ev,
+        "items.{ 'sku': sku, 'name': $productName(sku) }",
+        json!({ "items": [ { "sku": "A-1" }, { "sku": "B-2" } ] }),
+    );
+    println!("enrichment lookup: {}", out.to_json_string().unwrap());
+}
+
+/// Host functions receive all arguments already evaluated.
+fn demo_multi_arg() {
+    let mut ev = Evaluator::new();
+    ev.register_fn("convert", |args: &[JValue]| {
+        let amount = args.first().and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let rate = match args.get(1).and_then(|v| v.as_str()) {
+            Some("EUR") => 1.1,
+            _ => 1.0,
+        };
+        Ok(JValue::from_f64(amount * rate))
+    })
+    .unwrap();
+
+    let out = eval(
+        &mut ev,
+        "$convert(amount, currency)",
+        json!({ "amount": 10, "currency": "EUR" }),
+    );
+    println!("multi-arg convert: {}", out.to_json_string().unwrap());
+}
+
+/// Determinism injection: freeze `$now()` so output is reproducible in tests.
+/// `$now` is a non-compilable (impure) built-in, so overriding it is allowed.
+fn demo_override_now() {
+    let mut ev = Evaluator::new();
+    ev.register_fn_override("now", |_args: &[JValue]| {
+        Ok(JValue::from("2020-01-01T00:00:00.000Z"))
+    })
+    .unwrap();
+
+    let out = eval(&mut ev, "{ 'generatedAt': $now() }", json!(null));
+    println!("frozen $now: {}", out.to_json_string().unwrap());
+}
+
+/// Sandboxing: disable the dynamic-evaluation built-in `$eval` when running
+/// semi-trusted expressions.
+fn demo_sandbox_eval() {
+    let mut ev = Evaluator::new();
+    ev.register_fn_override("eval", |_args: &[JValue]| {
+        Err(jsonata_core::evaluator::EvaluatorError::EvaluationError(
+            "$eval is disabled in this environment".to_string(),
+        ))
+    })
+    .unwrap();
+
+    let ast = parse("$eval('1 + 1')").unwrap();
+    match ev.evaluate(&ast, &JValue::Null) {
+        Ok(v) => println!("sandbox $eval: unexpectedly returned {v:?}"),
+        Err(e) => println!("sandbox $eval: blocked as expected -> {e}"),
+    }
+}
+
+/// Registering a name that collides with a built-in is refused; use
+/// `register_fn_override` to replace a built-in deliberately.
+fn demo_collision_is_rejected() {
+    let mut ev = Evaluator::new();
+    match ev.register_fn("sum", |_args: &[JValue]| Ok(JValue::Null)) {
+        Ok(()) => println!("collision: unexpectedly accepted"),
+        Err(e) => println!("collision: rejected as expected -> {e}"),
+    }
+}

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3177,6 +3177,25 @@ impl Evaluator {
     /// Returns an error if `name` collides with a built-in function; to replace
     /// a built-in deliberately (e.g. a frozen `$now`), use
     /// [`register_fn_override`](Self::register_fn_override).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use jsonata_core::evaluator::Evaluator;
+    /// use jsonata_core::parser::parse;
+    /// use jsonata_core::value::JValue;
+    ///
+    /// let mut ev = Evaluator::new();
+    /// ev.register_fn("shout", |args: &[JValue]| {
+    ///     let s = args.first().and_then(|v| v.as_str()).unwrap_or("");
+    ///     Ok(JValue::from(s.to_uppercase()))
+    /// })
+    /// .expect("`shout` does not collide with a built-in");
+    ///
+    /// let ast = parse("$shout(greeting)").unwrap();
+    /// let data = JValue::from_json_str(r#"{"greeting": "hi"}"#).unwrap();
+    /// assert_eq!(ev.evaluate(&ast, &data).unwrap(), JValue::from("HI"));
+    /// ```
     pub fn register_fn(
         &mut self,
         name: impl Into<String>,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3042,6 +3042,47 @@ pub(crate) fn check_loop_timeout(
     Ok(())
 }
 
+/// Result type returned by a host-registered function.
+pub type HostFnResult = Result<JValue, EvaluatorError>;
+
+/// Per-call context handed to a host function.
+///
+/// In v1 this is intentionally opaque: a host function takes data and returns
+/// data. It exists so a later phase can add re-entrancy (invoking a JSONata
+/// lambda passed as an argument) by widening this type, without changing the
+/// [`HostFn`] signature or breaking existing callers.
+#[non_exhaustive]
+pub struct HostCtx {
+    _private: (),
+}
+
+impl HostCtx {
+    fn new() -> Self {
+        HostCtx { _private: () }
+    }
+}
+
+/// A function implemented by the host and callable from an expression as
+/// `$name(...)`.
+///
+/// Most host functions are pure leaves: write them as a plain closure
+/// `Fn(&[JValue]) -> Result<JValue, EvaluatorError>` (the blanket impl below
+/// applies) and ignore the [`HostCtx`]. The trait form exists so a later phase
+/// can hand the function a re-entrancy handle through [`HostCtx`] without an
+/// API break.
+pub trait HostFn {
+    fn call(&self, args: &[JValue], ctx: &mut HostCtx) -> HostFnResult;
+}
+
+impl<F> HostFn for F
+where
+    F: Fn(&[JValue]) -> HostFnResult,
+{
+    fn call(&self, args: &[JValue], _ctx: &mut HostCtx) -> HostFnResult {
+        self(args)
+    }
+}
+
 /// Evaluator for JSONata expressions
 pub struct Evaluator {
     context: Context,
@@ -3073,6 +3114,10 @@ pub struct Evaluator {
     /// Set in `evaluate()` (only when `options.timeout_ms` is configured) and
     /// checked in `evaluate_internal`'s per-node checkpoint for D1012.
     start_time: Option<Instant>,
+    /// Host-registered custom functions, dispatched by name from the call
+    /// position (`$name(...)`). Empty for the overwhelming majority of
+    /// evaluators, which pay nothing. See `register_fn`/`register_fn_override`.
+    host_fns: HashMap<String, Rc<dyn HostFn>>,
 }
 
 impl Evaluator {
@@ -3088,6 +3133,7 @@ impl Evaluator {
             keep_tuple_stream: false,
             options: EvaluatorOptions::default(),
             start_time: None,
+            host_fns: HashMap::new(),
         }
     }
 
@@ -3101,6 +3147,7 @@ impl Evaluator {
             keep_tuple_stream: false,
             options: EvaluatorOptions::default(),
             start_time: None,
+            host_fns: HashMap::new(),
         }
     }
 
@@ -3116,7 +3163,60 @@ impl Evaluator {
             keep_tuple_stream: false,
             options,
             start_time: None,
+            host_fns: HashMap::new(),
         }
+    }
+
+    /// Register a host function callable from an expression as `$name(...)`.
+    ///
+    /// `f` may be any plain closure `Fn(&[JValue]) -> Result<JValue,
+    /// EvaluatorError>` (via the blanket [`HostFn`] impl) or any [`HostFn`]
+    /// implementor. Host functions resolve *after* the expression's own `:=`
+    /// bindings and language-defined functions, and *before* built-ins.
+    ///
+    /// Returns an error if `name` collides with a built-in function; to replace
+    /// a built-in deliberately (e.g. a frozen `$now`), use
+    /// [`register_fn_override`](Self::register_fn_override).
+    pub fn register_fn(
+        &mut self,
+        name: impl Into<String>,
+        f: impl HostFn + 'static,
+    ) -> Result<(), EvaluatorError> {
+        let name = name.into();
+        if self.is_builtin_function(&name) {
+            return Err(EvaluatorError::EvaluationError(format!(
+                "cannot register host function '{name}': it shadows a built-in; \
+                 use register_fn_override to replace a built-in deliberately"
+            )));
+        }
+        self.host_fns.insert(name, Rc::new(f));
+        Ok(())
+    }
+
+    /// Register a host function that deliberately replaces a built-in of the same
+    /// name — the two legitimate cases being determinism injection for the impure
+    /// built-ins (`$now`, `$millis`, `$random`) and sandboxing/hardening (e.g.
+    /// disabling `$eval`).
+    ///
+    /// Overriding a *compilable* built-in is rejected: those names can be folded
+    /// into the bytecode fast path, which has no visibility into the host
+    /// registry, so the override could be silently bypassed. The impure built-ins
+    /// that motivate overriding are all non-compilable, so this restriction never
+    /// blocks a legitimate use.
+    pub fn register_fn_override(
+        &mut self,
+        name: impl Into<String>,
+        f: impl HostFn + 'static,
+    ) -> Result<(), EvaluatorError> {
+        let name = name.into();
+        if is_compilable_builtin(&name) {
+            return Err(EvaluatorError::EvaluationError(format!(
+                "cannot override built-in '{name}': it participates in the compiled \
+                 fast path and cannot be safely shadowed in this version"
+            )));
+        }
+        self.host_fns.insert(name, Rc::new(f));
+        Ok(())
     }
 
     /// Allocate a fresh, process-unique-per-Evaluator id for a new lambda instance.
@@ -7092,6 +7192,23 @@ impl Evaluator {
             return self.invoke_stored_lambda(&stored_lambda, &evaluated_args, data);
         }
 
+        // THEN a host-registered custom function (register_fn / register_fn_override).
+        // Resolves after the expression's own bindings and lambdas (checked above)
+        // and before built-ins, so an explicit override replaces the built-in in
+        // call position. Non-override names never collide with a built-in
+        // (register_fn rejects that), so the ordering is only observable for
+        // overrides. The `is_empty` guard keeps the common (no host fns) path free.
+        if !self.host_fns.is_empty() {
+            if let Some(f) = self.host_fns.get(name).cloned() {
+                let mut evaluated_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    evaluated_args.push(self.evaluate_internal(arg, data)?);
+                }
+                let mut ctx = HostCtx::new();
+                return f.call(&evaluated_args, &mut ctx);
+            }
+        }
+
         // If the function was called without $ prefix and it's not a stored lambda,
         // it's an error (unknown function without $ prefix)
         if !is_builtin && name != "__lambda__" {
@@ -10824,6 +10941,18 @@ impl Evaluator {
         values: &[JValue],
     ) -> Result<JValue, EvaluatorError> {
         use crate::functions;
+
+        // A host override applied in value position (e.g. `$f := $now; $f()`) or
+        // passed to a higher-order function reaches dispatch here rather than
+        // through `evaluate_function_call`. Check the registry first so the
+        // override is honoured consistently in both positions. Runs before the
+        // arity guard below so a zero-arg override (`$now`/`$uuid`) is allowed.
+        if !self.host_fns.is_empty() {
+            if let Some(f) = self.host_fns.get(name).cloned() {
+                let mut ctx = HostCtx::new();
+                return f.call(values, &mut ctx);
+            }
+        }
 
         if values.is_empty() {
             return Err(EvaluatorError::EvaluationError(format!(

--- a/tests/host_functions_test.rs
+++ b/tests/host_functions_test.rs
@@ -1,0 +1,188 @@
+// Phase 1 tests for host-callable custom functions (register_fn /
+// register_fn_override). Design: docs/superpowers/specs/
+// 2026-07-19-host-callable-functions-design.md
+//
+// v1 scope: direct calls `$name(args)`. Host-fn-as-first-class-value passed to
+// a higher-order function is phase 2; overrides applied in value position
+// (`$f := $now; $f()`) are covered here because they route through the same
+// value-dispatch seam.
+
+use jsonata_core::evaluator::{Evaluator, EvaluatorError};
+use jsonata_core::parser::parse;
+use jsonata_core::value::JValue;
+use serde_json::json;
+
+fn eval_with<F>(expr: &str, data: serde_json::Value, register: F) -> Result<JValue, EvaluatorError>
+where
+    F: FnOnce(&mut Evaluator),
+{
+    let ast = parse(expr).unwrap();
+    let mut ev = Evaluator::new();
+    register(&mut ev);
+    ev.evaluate(&ast, &JValue::from(data))
+}
+
+#[test]
+fn direct_call_single_string_arg() {
+    let out = eval_with("$greet(name)", json!({ "name": "Ada" }), |ev| {
+        ev.register_fn("greet", |args: &[JValue]| {
+            let n = args.first().and_then(|v| v.as_str()).unwrap_or("world");
+            Ok(JValue::from(format!("hello {n}")))
+        })
+        .unwrap();
+    })
+    .unwrap();
+    assert_eq!(out, JValue::from("hello Ada"));
+}
+
+#[test]
+fn direct_call_computes_over_multiple_args() {
+    // $fxRate(amount, "USD") style: host multiplies by a looked-up rate.
+    let out = eval_with(
+        "$convert(amount, currency)",
+        json!({ "amount": 10, "currency": "EUR" }),
+        |ev| {
+            ev.register_fn("convert", |args: &[JValue]| {
+                let amount = args.first().and_then(|v| v.as_f64()).unwrap_or(0.0);
+                let rate = match args.get(1).and_then(|v| v.as_str()) {
+                    Some("EUR") => 1.1,
+                    _ => 1.0,
+                };
+                Ok(JValue::from_f64(amount * rate))
+            })
+            .unwrap();
+        },
+    )
+    .unwrap();
+    assert_eq!(out, JValue::from_f64(11.0));
+}
+
+#[test]
+fn zero_arg_host_fn() {
+    let out = eval_with("$token()", json!(null), |ev| {
+        ev.register_fn("token", |_args: &[JValue]| Ok(JValue::from("abc-123")))
+            .unwrap();
+    })
+    .unwrap();
+    assert_eq!(out, JValue::from("abc-123"));
+}
+
+#[test]
+fn host_fn_maps_over_a_sequence() {
+    // `items.$double(qty)` maps the host fn across each item's context.
+    let out = eval_with(
+        "items.$double(qty)",
+        json!({ "items": [ { "qty": 2 }, { "qty": 5 } ] }),
+        |ev| {
+            ev.register_fn("double", |args: &[JValue]| {
+                let q = args.first().and_then(|v| v.as_f64()).unwrap_or(0.0);
+                Ok(JValue::from_f64(q * 2.0))
+            })
+            .unwrap();
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        out,
+        JValue::from(vec![JValue::from_f64(4.0), JValue::from_f64(10.0)])
+    );
+}
+
+#[test]
+fn host_fn_error_propagates() {
+    let err = eval_with("$boom(1)", json!(null), |ev| {
+        ev.register_fn("boom", |_args: &[JValue]| {
+            Err(EvaluatorError::EvaluationError("host blew up".into()))
+        })
+        .unwrap();
+    })
+    .unwrap_err();
+    assert!(format!("{err}").contains("host blew up"), "got: {err}");
+}
+
+#[test]
+fn register_fn_rejects_builtin_collision() {
+    let mut ev = Evaluator::new();
+    let err = ev
+        .register_fn("sum", |_args: &[JValue]| Ok(JValue::from_f64(0.0)))
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("shadows a built-in"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn override_rejects_compilable_builtin() {
+    // `round` is on the compiled fast path — overriding it is refused in v1.
+    let mut ev = Evaluator::new();
+    let err = ev
+        .register_fn_override("round", |_args: &[JValue]| Ok(JValue::from_f64(0.0)))
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("compiled fast path"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn override_impure_builtin_now_direct() {
+    // Determinism injection: freeze $now() for reproducible output.
+    let out = eval_with("$now()", json!(null), |ev| {
+        ev.register_fn_override("now", |_args: &[JValue]| {
+            Ok(JValue::from("2020-01-01T00:00:00.000Z"))
+        })
+        .unwrap();
+    })
+    .unwrap();
+    assert_eq!(out, JValue::from("2020-01-01T00:00:00.000Z"));
+}
+
+#[test]
+fn override_applies_in_value_position() {
+    // `$f := $now; $f()` routes through the value-dispatch seam; the override
+    // must still win there.
+    let out = eval_with("($f := $now; $f())", json!(null), |ev| {
+        ev.register_fn_override("now", |_args: &[JValue]| {
+            Ok(JValue::from("2020-01-01T00:00:00.000Z"))
+        })
+        .unwrap();
+    })
+    .unwrap();
+    assert_eq!(out, JValue::from("2020-01-01T00:00:00.000Z"));
+}
+
+#[test]
+fn in_expression_lambda_shadows_host_fn() {
+    // A function defined in the expression wins over a host fn of the same name
+    // (host fns resolve after the expression's own bindings/lambdas).
+    let out = eval_with(
+        "($greet := function($n){ 'local ' & $n }; $greet('x'))",
+        json!(null),
+        |ev| {
+            ev.register_fn("greet", |_args: &[JValue]| Ok(JValue::from("HOST")))
+                .unwrap();
+        },
+    )
+    .unwrap();
+    assert_eq!(out, JValue::from("local x"));
+}
+
+#[test]
+fn unregistered_function_still_errors() {
+    // Registering one host fn must not swallow the unknown-function error for a
+    // different, unregistered name.
+    let err = eval_with("$nope(1)", json!(null), |ev| {
+        ev.register_fn("greet", |_args: &[JValue]| Ok(JValue::from("hi")))
+            .unwrap();
+    })
+    .unwrap_err();
+    assert!(format!("{err}").contains("nope"), "got: {err}");
+}
+
+#[test]
+fn no_host_fns_leaves_builtins_intact() {
+    // Sanity: an evaluator with no host fns behaves exactly as before.
+    let out = eval_with("$sum([1,2,3])", json!(null), |_ev| {}).unwrap();
+    assert_eq!(out, JValue::from_f64(6.0));
+}


### PR DESCRIPTION
## Description

Adds host-callable custom functions to the Rust core: a host application can register native functions that a JSONata expression calls as `$name(...)`. This closes the `registerFunction`/`assign` extensibility gap versus jsonata-js — **without making the core async**. The evaluator stays synchronous and `Rc`-based; a host function that does I/O simply blocks (concurrency comes from threads), which is the right model given Rust/Python have real threads (unlike JavaScript's event-loop-only runtime, the reason jsonata-js had to go async).

This is **Phase 1** of a phased design (`docs/superpowers/specs/2026-07-19-host-callable-functions-design.md`): the Rust core + Rust API. Python (PyO3) and C bindings are later phases.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

Purely additive: a new struct field and new methods. Existing behavior is unchanged, and evaluators with no host functions pay nothing (guarded by an `is_empty()` check).

## Related Issues

N/A — originated from a design discussion; the design doc is included in the PR.

## Changes Made

- `Evaluator::register_fn(name, f)` and `Evaluator::register_fn_override(name, f)`.
- A `HostFn` trait with a blanket impl for `Fn(&[JValue]) -> Result<JValue, EvaluatorError>`, so plain closures work; plus an opaque `HostCtx` reserved so phase-2 reentrancy can be added without an API break.
- Dispatch hooked in `evaluate_function_call` for direct `$name(...)` calls — resolving **after** the expression's own `:=` bindings and language lambdas, and **before** built-ins.
- Defensive hook in `call_builtin_with_values` so a host **override** also wins when applied in value position (e.g. `$f := $now; $f()`).
- Registration guards: `register_fn` rejects collisions with a built-in; `register_fn_override` rejects *compilable* built-ins (the bytecode fast path can't see the registry, so a compilable override could be silently bypassed). The impure built-ins that motivate overriding — `$now`, `$millis`, `$random`, `$eval` — are all non-compilable, so this never blocks a legitimate use.
- The compiled path needs no change: novel host-fn names already cause the compiler to bail to the (always-correct) tree-walker.
- Design spec added under `docs/superpowers/specs/`.

## Testing

### Test Environment

- Rust: stable toolchain, `cargo test`
- Scope: Rust-only change; Python (`pytest`) sections of this template are **N/A** for this PR (no Python surface touched yet).

### Test Checklist

- [x] All existing Rust tests pass (`cargo test`): 175 lib + 72 integration
- [x] New tests added for the feature (`tests/host_functions_test.rs`, 12 cases)
- [x] Reference test suite targets still pass (`parent_and_focus_binding_suite`, `datetime_picture_suite`)
- [x] Edge cases considered and tested
- [ ] `pytest` — N/A (no Python changes in this phase)

### Test Cases

`tests/host_functions_test.rs` covers: single/multi-arg direct calls, zero-arg calls, mapping a host fn over a sequence, error propagation, both registration rejections (builtin collision; compilable-builtin override), override in both direct and value position, an in-expression lambda shadowing a host fn, and the unregistered-name-still-errors case.

```rust
let mut ev = Evaluator::new();
ev.register_fn("convert", |args: &[JValue]| {
    let amount = args[0].as_f64().unwrap_or(0.0);
    let rate = if args.get(1).and_then(|v| v.as_str()) == Some("EUR") { 1.1 } else { 1.0 };
    Ok(JValue::from_f64(amount * rate))
})?;
let out = ev.evaluate(&parse("$convert(amount, currency)")?, &data)?;
```

## Documentation

- [x] Rustdoc comments added for the public API (`register_fn`, `register_fn_override`, `HostFn`, `HostCtx`)
- [x] Design spec added (`docs/superpowers/specs/2026-07-19-host-callable-functions-design.md`)
- [ ] README/CHANGELOG — deferred until the feature is exposed through a binding (Python phase)

## Compatibility

- [x] No breaking changes to the public API (additive only)
- [x] Backward compatible: evaluators without host functions are unaffected and pay no runtime cost

Note on JSONata conformance: host functions are a host-side extensibility feature, not a language change, so they are orthogonal to the reference conformance suite (a host closure can't be expressed in a JSON fixture). Existing conformance is unchanged.

## Breaking Changes

- [ ] This PR introduces breaking changes — no.

## Performance Impact

- [x] No regression for the common path: host-fn dispatch is behind an `if !self.host_fns.is_empty()` guard, so evaluators without host functions do no extra work.

## Code Quality

- [x] `cargo fmt` applied
- [x] No new compiler warnings; new code is clippy-clean (note: the crate has pre-existing `vm.rs` warnings unrelated to this change, so a crate-wide `clippy -- -D warnings` is not green independent of this PR)
- [x] Self-reviewed
- [x] No debug/print statements

## Additional Notes

**Deferred by design (not missing):** host-fn-as-first-class-value (`$map(arr, $greet)`, `$f := $greet`) is a later phase — it pairs naturally with reentrancy, and every practical use case for v1 is a direct call. The `HostCtx` type is deliberately opaque now so that reentrancy can be added later without changing the `HostFn` signature.

## Reviewer Guidelines

**Focus areas for review:**
- The two dispatch hooks in `evaluate_function_call` and `call_builtin_with_values` — precedence (bindings/lambdas > host fns > built-ins) and the value-position override path.
- The `register_fn_override` restriction to non-compilable built-ins — is the trade-off (correctness now vs. lifting it when the compiled path becomes registry-aware) acceptable?

**Questions for reviewers:**
- Any objection to the "collision is a registration error; overrides need an explicit method" policy for shadowing built-ins?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018myqZqco6k9udkNVg4bqEY)_