### PR TITLE
Host-callable custom functions (Phase 2 + 3: Python and C bindings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collisions with built-ins; `register_fn_override` allows deliberately replacing
   the impure built-ins (`$now`, `$millis`, `$random`, `$eval`) for determinism
   injection or sandboxing. Evaluation stays synchronous. See
-  `examples/host_functions.rs` and the Rust crate docs. (Not yet exposed through
-  the Python or C bindings.)
+  `examples/host_functions.rs` and the Rust crate docs.
+- Host-callable custom functions (Python binding): `JsonataExpression.register(name,
+  func)` and `.register_override(name, func)` expose the above to Python. The callable
+  receives already-evaluated positional arguments and must return a JSON-compatible
+  value synchronously; an `async def` (coroutine) is rejected at call time with
+  guidance to await I/O outside jsonata and pass results via `bindings`. Collision and
+  compilable-builtin-override rules are validated at `register()` time. (Not yet
+  exposed through the C binding.)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   receives already-evaluated positional arguments and must return a JSON-compatible
   value synchronously; an `async def` (coroutine) is rejected at call time with
   guidance to await I/O outside jsonata and pass results via `bindings`. Collision and
-  compilable-builtin-override rules are validated at `register()` time. (Not yet
-  exposed through the C binding.)
+  compilable-builtin-override rules are validated at `register()` time.
+- Host-callable custom functions (C ABI): `jsonata_register_fn(expr, name, fn, user_data)`
+  and `jsonata_register_fn_override(...)` expose the feature to C and any language with C
+  interop. The callback receives its arguments as a JSON array string and returns a JSON
+  result string (jsonata copies it; the host retains ownership), or NULL to signal an error.
+  See `bindings/c/jsonata.h`, `bindings/c/README.md`, and `bindings/c/examples/smoke.c`.
 
 ### Changed
 

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -132,7 +132,16 @@ Rust library rebuilds with your project.)
 6. **Variables:** `jsonata_bind_var(expr, "x", "[1,2,3]")` binds `$x` for
    all subsequent evaluations on that handle (values are JSON text;
    re-binding replaces).
-7. **Panics:** internal engine panics are caught at the boundary and
+7. **Host functions:** `jsonata_register_fn(expr, "name", fn, user_data)`
+   exposes a C callback to the expression as `$name(...)`. The callback
+   receives its arguments as a JSON array string and returns a JSON result
+   string that jsonata copies (you keep ownership — do not expect jsonata to
+   free it); returning NULL signals an error. A name colliding with a
+   built-in is rejected; `jsonata_register_fn_override` replaces a built-in
+   deliberately (e.g. a frozen `$now`, or a disabled `$eval`). `user_data`
+   must outlive the handle. Registering a host function routes evaluation
+   through the tree-walker, like variable bindings.
+8. **Panics:** internal engine panics are caught at the boundary and
    surface as errors prefixed `internal error:` — they will not abort
    your process.
 

--- a/bindings/c/examples/smoke.c
+++ b/bindings/c/examples/smoke.c
@@ -27,6 +27,31 @@ static int failures = 0;
 
 static char *take_error(void) { return jsonata_last_error_message(); }
 
+/*
+ * Host function: given the JSON array ["<name>"], returns "hello <name>".
+ * Uses a static buffer — valid until the next call, which is all jsonata needs
+ * (it copies the result before returning to the expression).
+ */
+static char host_buf[256];
+static const char *greet_cb(void *user_data, const char *args_json) {
+    (void)user_data;
+    const char *open = strchr(args_json, '"');
+    if (!open) return NULL;
+    const char *start = open + 1;
+    const char *end = strchr(start, '"');
+    if (!end) return NULL;
+    int len = (int)(end - start);
+    snprintf(host_buf, sizeof(host_buf), "\"hello %.*s\"", len, start);
+    return host_buf;
+}
+
+/* Host override for $now(): a frozen timestamp (static string, always valid). */
+static const char *frozen_now_cb(void *user_data, const char *args_json) {
+    (void)user_data;
+    (void)args_json;
+    return "\"2020-01-01T00:00:00.000Z\"";
+}
+
 int main(void) {
     /* version */
     const char *v = jsonata_version();
@@ -116,6 +141,39 @@ int main(void) {
         CHECK(r != NULL && strcmp(r, "\"H\xC3\x89LLO \xE2\x9C\x93\"") == 0,
               "multibyte UTF-8 round trip");
         jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* host function registration + call */
+    {
+        JsonataExpr *e = jsonata_compile("$greet(name)");
+        int rc = jsonata_register_fn(e, "greet", greet_cb, NULL);
+        CHECK(rc == 0, "register_fn succeeds");
+        char *r = jsonata_evaluate(e, "{\"name\":\"Ada\"}");
+        CHECK(r != NULL && strcmp(r, "\"hello Ada\"") == 0, "host function call");
+        jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* host function override of an impure built-in ($now) */
+    {
+        JsonataExpr *e = jsonata_compile("$now()");
+        int rc = jsonata_register_fn_override(e, "now", frozen_now_cb, NULL);
+        CHECK(rc == 0, "register_fn_override succeeds");
+        char *r = jsonata_evaluate(e, "null");
+        CHECK(r != NULL && strcmp(r, "\"2020-01-01T00:00:00.000Z\"") == 0,
+              "override $now");
+        jsonata_free_string(r);
+        jsonata_free_expr(e);
+    }
+
+    /* collision with a built-in is rejected */
+    {
+        JsonataExpr *e = jsonata_compile("$sum(x)");
+        int rc = jsonata_register_fn(e, "sum", greet_cb, NULL);
+        char *err = take_error();
+        CHECK(rc == -1 && err != NULL, "register_fn collision rejected");
+        jsonata_free_string(err);
         jsonata_free_expr(e);
     }
 

--- a/bindings/c/jsonata.h
+++ b/bindings/c/jsonata.h
@@ -75,6 +75,41 @@ char *jsonata_evaluate(JsonataExpr *expr, const char *json_utf8);
 int jsonata_bind_var(JsonataExpr *expr, const char *name,
                      const char *json_value_utf8);
 
+/*
+ * A host function callback, callable from the expression as $name(...).
+ *   user_data: the pointer supplied at registration (opaque to jsonata).
+ *   args_json: a NUL-terminated UTF-8 JSON ARRAY of the (already evaluated)
+ *              arguments.
+ * Returns a NUL-terminated UTF-8 JSON string with the result, which must stay
+ * valid until the call returns — jsonata COPIES it and does NOT free it — or
+ * NULL to signal an error.
+ */
+typedef const char *(*jsonata_host_fn)(void *user_data, const char *args_json);
+
+/*
+ * Register a host function callable from the expression as $name(...) — the
+ * C equivalent of jsonata-js's registerFunction. Applies to every subsequent
+ * jsonata_evaluate() on this handle. A leading '$' in name is accepted and
+ * stripped; re-registering a name replaces it. Host functions resolve after
+ * the expression's own bindings/lambdas and before built-ins.
+ *
+ * user_data is passed back to the callback unchanged and must remain valid for
+ * the lifetime of the handle. Returns 0 on success, -1 on error (slot set) —
+ * including when name collides with a built-in (use
+ * jsonata_register_fn_override to replace a built-in deliberately).
+ */
+int jsonata_register_fn(JsonataExpr *expr, const char *name,
+                        jsonata_host_fn fn, void *user_data);
+
+/*
+ * Like jsonata_register_fn, but deliberately replaces a built-in of the same
+ * name — for determinism injection (a frozen $now, seeded $random) or
+ * sandboxing (disabling $eval). Overriding a built-in that participates in the
+ * compiled fast path returns -1 with an error.
+ */
+int jsonata_register_fn_override(JsonataExpr *expr, const char *name,
+                                 jsonata_host_fn fn, void *user_data);
+
 /* Free a handle returned by jsonata_compile(). NULL is a no-op. */
 void jsonata_free_expr(JsonataExpr *expr);
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -217,6 +217,51 @@ result_str = expr.evaluate_data_to_json(data)
 result = json.loads(result_str)
 ```
 
+### `register(name, func)` / `register_override(name, func)`
+
+Register a Python callable that the expression can invoke as `$name(...)` — the
+equivalent of jsonata-js's `registerFunction`. Use it to expose enrichment/lookup,
+formatting, or scoring logic to an otherwise-pure expression. Both methods return the
+expression, so calls can be chained.
+
+**Parameters:**
+- `name` (str): The function name, called as `$name(...)` in the expression.
+- `func` (Callable): Receives the already-evaluated arguments as positional Python
+  values and must return a JSON-compatible value **synchronously**.
+
+**Returns:** the `JsonataExpression` (for chaining)
+
+**Raises:**
+- `TypeError` — if `func` is not callable.
+- `ValueError` — if `name` collides with a built-in (`register`), or if the built-in
+  cannot be safely overridden (`register_override`).
+
+**Behavior:**
+- Host functions resolve **after** the expression's own `:=` bindings and lambdas, and
+  **before** built-ins.
+- `register` rejects a name that collides with a built-in; `register_override` replaces
+  one deliberately — the intended uses being determinism injection for the impure
+  built-ins (`$now`, `$millis`, `$random`) and sandboxing (disabling `$eval`).
+- Evaluation is synchronous, so an `async def` (which returns a coroutine) is rejected
+  at call time. For async I/O, await it outside jsonata and pass the result via
+  `bindings`.
+
+**Example:**
+```python
+# Enrichment lookup backed by host-owned data
+catalog = {"A-1": "Widget", "B-2": "Gadget"}
+expr = jsonatapy.compile("items.{ 'sku': sku, 'name': $productName(sku) }")
+expr.register("productName", lambda sku: catalog.get(sku, "Unknown"))
+expr.evaluate({"items": [{"sku": "A-1"}, {"sku": "B-2"}]})
+# [{'sku': 'A-1', 'name': 'Widget'}, {'sku': 'B-2', 'name': 'Gadget'}]
+
+# Determinism injection: freeze $now() for reproducible output
+expr = jsonatapy.compile("{ 'generatedAt': $now() }")
+expr.register_override("now", lambda: "2020-01-01T00:00:00.000Z")
+expr.evaluate(None)
+# {'generatedAt': '2020-01-01T00:00:00.000Z'}
+```
+
 ## JsonataData Class
 
 Pre-converted data handle for efficient repeated evaluation. Convert Python data

--- a/docs/api.md
+++ b/docs/api.md
@@ -262,6 +262,8 @@ expr.evaluate(None)
 # {'generatedAt': '2020-01-01T00:00:00.000Z'}
 ```
 
+See `examples/host_functions.py` for a runnable walkthrough.
+
 ## JsonataData Class
 
 Pre-converted data handle for efficient repeated evaluation. Convert Python data

--- a/docs/api.md
+++ b/docs/api.md
@@ -264,6 +264,30 @@ expr.evaluate(None)
 
 See `examples/host_functions.py` for a runnable walkthrough.
 
+#### Why host functions are synchronous
+
+Host functions run synchronously: the callable is invoked mid-evaluation, and if
+it does I/O it simply blocks until it returns. This is a deliberate design choice,
+not a limitation. The evaluator is a synchronous, single-threaded engine — that is
+where its speed comes from — and a blocking call stack (your code → `evaluate()` →
+your host function → I/O) is a correct, ordinary way to run it. Concurrency comes
+from running independent evaluations across threads or processes, exactly as you
+would parallelize any other CPU-bound work. This is why an `async def` is rejected:
+the synchronous core has no event loop to await a coroutine on, so a coroutine
+return has no meaningful value. (jsonata-js is async only because JavaScript has no
+threads and no blocking I/O — its event loop is the *only* concurrency primitive
+available, so it had no choice. Python has real threads, so it does not inherit that
+constraint.)
+
+If a host function genuinely needs async I/O, do the I/O **outside** the expression
+rather than inside a callback. Gather what the transform needs with `asyncio` up
+front, then pass the results in through `bindings` (or bake them into small
+synchronous lookups closed over that data) and run `evaluate()` normally. If you are
+inside an event loop and don't want to block it, run the whole `evaluate()` call in a
+thread with `loop.run_in_executor(...)`. Both patterns keep the fast synchronous core
+intact while letting the async work live where it belongs — in your application, not
+in the expression engine.
+
 ## JsonataData Class
 
 Pre-converted data handle for efficient repeated evaluation. Convert Python data

--- a/docs/api.md
+++ b/docs/api.md
@@ -288,6 +288,11 @@ thread with `loop.run_in_executor(...)`. Both patterns keep the fast synchronous
 intact while letting the async work live where it belongs — in your application, not
 in the expression engine.
 
+Synchronous execution was chosen for speed on the majority of use cases, which are
+CPU-bound data transformations that never touch I/O. If enough users need genuinely
+asynchronous host functions, we will consider adding that capability — but it would be
+an opt-in path alongside the synchronous default, not a replacement for it.
+
 ## JsonataData Class
 
 Pre-converted data handle for efficient repeated evaluation. Convert Python data

--- a/docs/api.md
+++ b/docs/api.md
@@ -272,7 +272,11 @@ not a limitation. The evaluator is a synchronous, single-threaded engine — tha
 where its speed comes from — and a blocking call stack (your code → `evaluate()` →
 your host function → I/O) is a correct, ordinary way to run it. Concurrency comes
 from running independent evaluations across threads or processes, exactly as you
-would parallelize any other CPU-bound work. This is why an `async def` is rejected:
+would parallelize any other CPU-bound work. Async would only ever help a host
+function that is *I/O-bound* — a CPU-bound one gains nothing from it — and even an
+I/O-bound host function can run concurrently by dispatching evaluations to a thread
+pool (a blocked thread waiting on I/O lets others proceed), so blocking is rarely a
+real constraint. This is why an `async def` is rejected:
 the synchronous core has no event loop to await a coroutine on, so a coroutine
 return has no meaningful value. (jsonata-js is async only because JavaScript has no
 threads and no blocking I/O — its event loop is the *only* concurrency primitive

--- a/examples/host_functions.py
+++ b/examples/host_functions.py
@@ -1,0 +1,78 @@
+"""
+Host-callable custom functions (Python binding)
+
+Register Python callables that a JSONata expression can invoke as ``$name(...)``:
+  - enrichment/lookup functions (the canonical use case)
+  - determinism injection: overriding an impure built-in ($now) with a frozen
+    implementation for reproducible output
+  - sandboxing: overriding a powerful built-in ($eval) to disable it
+
+Run this after building the extension with: maturin develop
+"""
+
+import jsonatapy
+
+print("=" * 60)
+print("JSONataPy - Host Functions")
+print("=" * 60)
+
+# Example 1: enrichment lookup backed by host-owned data.
+# The expression stays a clean artifact; the host owns the data source.
+print("\n1. Enrichment lookup")
+print("-" * 40)
+catalog = {"A-1": "Widget", "B-2": "Gadget"}
+expr = jsonatapy.compile("items.{ 'sku': sku, 'name': $productName(sku) }")
+expr.register("productName", lambda sku: catalog.get(sku, "Unknown"))
+result = expr.evaluate({"items": [{"sku": "A-1"}, {"sku": "B-2"}]})
+print(result)
+
+# Example 2: multi-argument enrichment. Arguments arrive already evaluated.
+print("\n2. Multi-argument function")
+print("-" * 40)
+rates = {"EUR": 1.1, "GBP": 1.27}
+expr = jsonatapy.compile("$convert(amount, currency)")
+expr.register("convert", lambda amount, currency: amount * rates.get(currency, 1.0))
+print(expr.evaluate({"amount": 10, "currency": "EUR"}))
+
+# Example 3: determinism injection — freeze $now() for reproducible output.
+print("\n3. Override $now (determinism)")
+print("-" * 40)
+expr = jsonatapy.compile("{ 'generatedAt': $now() }")
+expr.register_override("now", lambda: "2020-01-01T00:00:00.000Z")
+print(expr.evaluate(None))
+
+# Example 4: sandboxing — disable $eval for semi-trusted expressions.
+print("\n4. Sandbox $eval")
+print("-" * 40)
+
+
+def blocked(*_args):
+    raise ValueError("$eval is disabled in this environment")
+
+
+expr = jsonatapy.compile("$eval('1 + 1')")
+expr.register_override("eval", blocked)
+try:
+    expr.evaluate(None)
+except ValueError as exc:
+    print(f"blocked as expected -> {exc}")
+
+# Example 5: async def is rejected — do async I/O outside jsonata instead.
+print("\n5. async def is rejected")
+print("-" * 40)
+
+
+async def fetch(_key):
+    return "value"
+
+
+expr = jsonatapy.compile("$fetch(key)")
+expr.register("fetch", fetch)
+try:
+    expr.evaluate({"key": "k"})
+except ValueError as exc:
+    print(f"rejected as expected -> {exc}")
+
+print("\n" + "=" * 60)
+print("Done")
+print("=" * 60)

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -16,6 +16,7 @@ Example:
 """
 
 import json as _json
+from collections.abc import Callable
 from typing import Any
 
 from ._jsonatapy import (
@@ -184,6 +185,73 @@ class JsonataExpression:
             1
         """
         return self._expr.evaluate(data, bindings, timeout, max_stack_depth, max_sequence_length)
+
+    def register(self, name: str, func: Callable[..., Any]) -> "JsonataExpression":
+        """
+        Register a Python function callable from the expression as ``$name(...)``.
+
+        The function receives the (already-evaluated) arguments as positional
+        Python values and must return a JSON-compatible value **synchronously**.
+        This is the equivalent of jsonata-js's ``registerFunction`` — use it to
+        expose enrichment/lookup, formatting, or scoring logic to an expression.
+
+        Host functions resolve after the expression's own bindings/lambdas and
+        before built-ins. A name that collides with a built-in is rejected; use
+        :meth:`register_override` to replace a built-in deliberately.
+
+        Note:
+            The evaluator is synchronous, so an ``async def`` (which returns a
+            coroutine) is rejected at call time. For async I/O, await it outside
+            jsonata and pass the result in via ``bindings``.
+
+        Args:
+            name: The function name, called as ``$name(...)`` in the expression.
+            func: A callable ``(*args) -> JSON-compatible value``.
+
+        Returns:
+            self, to allow chaining.
+
+        Raises:
+            TypeError: If ``func`` is not callable.
+            ValueError: If ``name`` collides with a built-in function.
+
+        Example:
+            >>> expr = compile("$greet(name)")
+            >>> expr.register("greet", lambda n: f"hello {n}")
+            >>> expr.evaluate({"name": "Ada"})
+            'hello Ada'
+        """
+        self._expr.register(name, func)
+        return self
+
+    def register_override(self, name: str, func: Callable[..., Any]) -> "JsonataExpression":
+        """
+        Register a Python function that deliberately replaces a built-in.
+
+        The two legitimate uses are determinism injection for the impure
+        built-ins (``$now``, ``$millis``, ``$random``) — e.g. a frozen clock for
+        reproducible output — and sandboxing (disabling ``$eval``). Overriding a
+        built-in that participates in the compiled fast path is rejected.
+
+        Args:
+            name: The built-in name to replace (e.g. ``"now"``).
+            func: A callable ``(*args) -> JSON-compatible value``.
+
+        Returns:
+            self, to allow chaining.
+
+        Raises:
+            TypeError: If ``func`` is not callable.
+            ValueError: If the built-in cannot be safely overridden.
+
+        Example:
+            >>> expr = compile("$now()")
+            >>> expr.register_override("now", lambda: "2020-01-01T00:00:00.000Z")
+            >>> expr.evaluate(None)
+            '2020-01-01T00:00:00.000Z'
+        """
+        self._expr.register_override(name, func)
+        return self
 
     def evaluate_json(
         self,

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -24,7 +24,7 @@
 //!   caller or abort the host process.
 
 use std::cell::{OnceCell, RefCell};
-use std::ffi::{c_char, c_int, CStr, CString};
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::evaluator::{self, EvaluatorOptions};
@@ -39,6 +39,65 @@ pub struct JsonataExpr {
     /// tree-walker (the VM path takes no user context), mirroring the
     /// Python bindings' behavior in `lib.rs::run_eval`.
     bindings: Vec<(String, JValue)>,
+    /// Host functions registered via `jsonata_register_fn`, applied on every
+    /// subsequent `jsonata_evaluate`. Like bindings, a non-empty list forces
+    /// the tree-walker (the VM has no host registry).
+    host_fns: Vec<CHostFnReg>,
+}
+
+/// A host function callback.
+///
+/// - `user_data` is the pointer supplied at registration, opaque to jsonata.
+/// - `args_json` is a NUL-terminated UTF-8 JSON *array* of the (already
+///   evaluated) arguments.
+///
+/// It returns a NUL-terminated UTF-8 JSON string with the result — which must
+/// stay valid until the call returns (jsonata copies it and does **not** free
+/// it) — or NULL to signal an error.
+pub type JsonataHostFn = unsafe extern "C" fn(*mut c_void, *const c_char) -> *const c_char;
+
+/// A registered C host function stored on the expression.
+struct CHostFnReg {
+    name: String,
+    func: JsonataHostFn,
+    user_data: *mut c_void,
+    is_override: bool,
+}
+
+/// Bridges a C function pointer to the core [`evaluator::HostFn`] trait: it
+/// serializes the arguments to a JSON array, invokes the callback, and parses
+/// the returned JSON string.
+struct CHostFn {
+    func: JsonataHostFn,
+    user_data: *mut c_void,
+}
+
+impl evaluator::HostFn for CHostFn {
+    fn call(
+        &self,
+        args: &[JValue],
+        _ctx: &mut evaluator::HostCtx,
+    ) -> Result<JValue, evaluator::EvaluatorError> {
+        let err = |m: String| evaluator::EvaluatorError::EvaluationError(m);
+        let args_json = JValue::from(args.to_vec())
+            .to_json_string()
+            .map_err(|e| err(format!("could not serialize host function arguments: {e}")))?;
+        let args_c = CString::new(args_json)
+            .map_err(|_| err("host function arguments contained interior NUL".to_string()))?;
+
+        // SAFETY: `func`/`user_data` came from `jsonata_register_fn`; the caller
+        // guarantees the pointer stays valid for the expression's lifetime. The
+        // returned pointer is borrowed (copied below), never freed by us.
+        let ret = unsafe { (self.func)(self.user_data, args_c.as_ptr()) };
+        if ret.is_null() {
+            return Err(err("host function returned an error (NULL)".to_string()));
+        }
+        let ret_str = unsafe { CStr::from_ptr(ret) }
+            .to_str()
+            .map_err(|_| err("host function result is not valid UTF-8".to_string()))?;
+        JValue::from_json_str(ret_str)
+            .map_err(|e| err(format!("host function returned invalid JSON: {e}")))
+    }
 }
 
 thread_local! {
@@ -95,6 +154,7 @@ pub unsafe extern "C" fn jsonata_compile(expr_utf8: *const c_char) -> *mut Jsona
                 ast,
                 bytecode: OnceCell::new(),
                 bindings: Vec::new(),
+                host_fns: Vec::new(),
             }))
         }
         Err(e) => {
@@ -151,6 +211,105 @@ pub unsafe extern "C" fn jsonata_bind_var(
     0
 }
 
+/// Register a host function callable from the expression as `$name(...)`.
+/// Applies to every subsequent `jsonata_evaluate` on this handle. A leading
+/// `$` on `name` is accepted and stripped; re-registering a name replaces it.
+/// Returns 0 on success, -1 on error (error slot set) — including when `name`
+/// collides with a built-in (use `jsonata_register_fn_override` to replace a
+/// built-in deliberately).
+///
+/// `user_data` is passed back to the callback unchanged and must remain valid
+/// for the lifetime of the expression handle. See [`JsonataHostFn`] for the
+/// callback contract.
+///
+/// # Safety
+/// `expr` must be a live pointer from `jsonata_compile`; `name` must be a valid
+/// NUL-terminated C string or NULL; `func` must be a valid function pointer or
+/// NULL.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_register_fn(
+    expr: *mut JsonataExpr,
+    name: *const c_char,
+    func: Option<JsonataHostFn>,
+    user_data: *mut c_void,
+) -> c_int {
+    register_host_fn(expr, name, func, user_data, false)
+}
+
+/// Like [`jsonata_register_fn`], but deliberately replaces a built-in of the
+/// same name — the intended uses being determinism injection for the impure
+/// built-ins (`$now`, `$millis`, `$random`) and sandboxing (disabling `$eval`).
+/// Overriding a built-in on the compiled fast path returns -1 with an error.
+///
+/// # Safety
+/// Same as [`jsonata_register_fn`].
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_register_fn_override(
+    expr: *mut JsonataExpr,
+    name: *const c_char,
+    func: Option<JsonataHostFn>,
+    user_data: *mut c_void,
+) -> c_int {
+    register_host_fn(expr, name, func, user_data, true)
+}
+
+/// Shared body for the two registration entry points.
+///
+/// # Safety
+/// See [`jsonata_register_fn`].
+unsafe fn register_host_fn(
+    expr: *mut JsonataExpr,
+    name: *const c_char,
+    func: Option<JsonataHostFn>,
+    user_data: *mut c_void,
+    is_override: bool,
+) -> c_int {
+    if expr.is_null() || name.is_null() {
+        set_error("jsonata_register_fn: NULL argument".to_string());
+        return -1;
+    }
+    let Some(func) = func else {
+        set_error("jsonata_register_fn: function pointer is NULL".to_string());
+        return -1;
+    };
+    let name = match CStr::from_ptr(name).to_str() {
+        Ok(n) => n,
+        Err(_) => {
+            set_error("jsonata_register_fn: name is not valid UTF-8".to_string());
+            return -1;
+        }
+    };
+    let name = name.strip_prefix('$').unwrap_or(name).to_string();
+
+    guard(-1, || {
+        // Validate the collision/override rules now (fail at register-time, not
+        // evaluate-time) by exercising the same core registration on a
+        // throwaway evaluator.
+        let mut probe = evaluator::Evaluator::new();
+        let probed = CHostFn { func, user_data };
+        let res = if is_override {
+            probe.register_fn_override(name.clone(), probed)
+        } else {
+            probe.register_fn(name.clone(), probed)
+        };
+        if let Err(e) = res {
+            set_error(e.message().to_string());
+            return -1;
+        }
+
+        let expr = &mut *expr;
+        expr.host_fns.retain(|r| r.name != name);
+        expr.host_fns.push(CHostFnReg {
+            name,
+            func,
+            user_data,
+            is_override,
+        });
+        clear_error();
+        0
+    })
+}
+
 /// # Safety
 /// `expr` must be a pointer returned by `jsonata_compile` (not yet freed);
 /// `json_utf8` must be a valid NUL-terminated C string pointer or NULL.
@@ -185,9 +344,10 @@ pub unsafe extern "C" fn jsonata_evaluate(
             }
         };
         // Same dispatch as JsonataExpression::run_eval in lib.rs: VM when the
-        // expression compiles to bytecode AND no user bindings exist,
-        // tree-walker otherwise.
-        let result = if expr.bindings.is_empty() {
+        // expression compiles to bytecode AND no user bindings or host
+        // functions exist, tree-walker otherwise (the VM takes no host
+        // registry).
+        let result = if expr.bindings.is_empty() && expr.host_fns.is_empty() {
             let bytecode = expr.bytecode.get_or_init(|| {
                 evaluator::try_compile_expr(&expr.ast)
                     .map(|ce| compiler::BytecodeCompiler::compile(&ce))
@@ -207,6 +367,21 @@ pub unsafe extern "C" fn jsonata_evaluate(
                 context.bind(name.clone(), value.clone());
             }
             let mut ev = evaluator::Evaluator::with_options(context, EvaluatorOptions::default());
+            for reg in &expr.host_fns {
+                let hf = CHostFn {
+                    func: reg.func,
+                    user_data: reg.user_data,
+                };
+                let res = if reg.is_override {
+                    ev.register_fn_override(reg.name.clone(), hf)
+                } else {
+                    ev.register_fn(reg.name.clone(), hf)
+                };
+                if let Err(e) = res {
+                    set_error(e.message().to_string());
+                    return std::ptr::null_mut();
+                }
+            }
             ev.evaluate(&expr.ast, &data)
         };
         match result {
@@ -539,5 +714,178 @@ mod tests {
         assert_eq!(extract_error_code("invalid input JSON: x"), None);
         assert_eq!(extract_error_code("T20: short"), None);
         assert_eq!(extract_error_code(""), None);
+    }
+
+    // ── Host functions ──────────────────────────────────────────────────────
+
+    thread_local! {
+        // Holds the most recent callback result so the returned pointer stays
+        // valid until jsonata copies it (jsonata never frees host results).
+        static CB_RESULT: RefCell<CString> = RefCell::new(CString::new("").unwrap());
+    }
+
+    unsafe fn store_result(json: String) -> *const c_char {
+        CB_RESULT.with(|r| {
+            *r.borrow_mut() = CString::new(json).unwrap();
+            r.borrow().as_ptr()
+        })
+    }
+
+    fn arg0(args_json: *const c_char) -> serde_json::Value {
+        let s = unsafe { CStr::from_ptr(args_json) }.to_str().unwrap();
+        let v: serde_json::Value = serde_json::from_str(s).unwrap();
+        v.get(0).cloned().unwrap_or(serde_json::Value::Null)
+    }
+
+    unsafe extern "C" fn greet_cb(_ud: *mut c_void, args: *const c_char) -> *const c_char {
+        let name = arg0(args);
+        let name = name.as_str().unwrap_or("world");
+        store_result(format!("\"hello {name}\""))
+    }
+
+    unsafe extern "C" fn double_cb(_ud: *mut c_void, args: *const c_char) -> *const c_char {
+        let n = arg0(args).as_f64().unwrap_or(0.0);
+        store_result(format!("{}", n * 2.0))
+    }
+
+    unsafe extern "C" fn frozen_now_cb(_ud: *mut c_void, _args: *const c_char) -> *const c_char {
+        store_result("\"2020-01-01T00:00:00.000Z\"".to_string())
+    }
+
+    unsafe extern "C" fn boom_cb(_ud: *mut c_void, _args: *const c_char) -> *const c_char {
+        std::ptr::null()
+    }
+
+    #[test]
+    fn host_fn_round_trip() {
+        unsafe {
+            let ce = CString::new("$greet(name)").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("greet").unwrap();
+            assert_eq!(
+                jsonata_register_fn(h, name.as_ptr(), Some(greet_cb), std::ptr::null_mut()),
+                0
+            );
+            let cd = CString::new(r#"{"name":"Ada"}"#).unwrap();
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(!r.is_null(), "evaluate failed: {:?}", last_error());
+            assert_eq!(CStr::from_ptr(r).to_str().unwrap(), r#""hello Ada""#);
+            jsonata_free_string(r);
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn host_fn_maps_over_sequence() {
+        unsafe {
+            let ce = CString::new("items.$double(qty)").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("double").unwrap();
+            assert_eq!(
+                jsonata_register_fn(h, name.as_ptr(), Some(double_cb), std::ptr::null_mut()),
+                0
+            );
+            let cd = CString::new(r#"{"items":[{"qty":2},{"qty":5}]}"#).unwrap();
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(!r.is_null(), "evaluate failed: {:?}", last_error());
+            assert_eq!(CStr::from_ptr(r).to_str().unwrap(), "[4,10]");
+            jsonata_free_string(r);
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn host_fn_override_now() {
+        unsafe {
+            let ce = CString::new("$now()").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("now").unwrap();
+            assert_eq!(
+                jsonata_register_fn_override(
+                    h,
+                    name.as_ptr(),
+                    Some(frozen_now_cb),
+                    std::ptr::null_mut()
+                ),
+                0
+            );
+            let cd = CString::new("null").unwrap();
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(!r.is_null(), "evaluate failed: {:?}", last_error());
+            assert_eq!(
+                CStr::from_ptr(r).to_str().unwrap(),
+                r#""2020-01-01T00:00:00.000Z""#
+            );
+            jsonata_free_string(r);
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn host_fn_collision_rejected() {
+        unsafe {
+            let ce = CString::new("$sum(x)").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("sum").unwrap();
+            assert_eq!(
+                jsonata_register_fn(h, name.as_ptr(), Some(greet_cb), std::ptr::null_mut()),
+                -1
+            );
+            assert!(last_error().unwrap().contains("shadows a built-in"));
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn host_fn_override_compilable_rejected() {
+        unsafe {
+            let ce = CString::new("$round(x)").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("round").unwrap();
+            assert_eq!(
+                jsonata_register_fn_override(
+                    h,
+                    name.as_ptr(),
+                    Some(double_cb),
+                    std::ptr::null_mut()
+                ),
+                -1
+            );
+            assert!(last_error().unwrap().contains("compiled fast path"));
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn host_fn_null_return_is_error() {
+        unsafe {
+            let ce = CString::new("$boom()").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("boom").unwrap();
+            assert_eq!(
+                jsonata_register_fn(h, name.as_ptr(), Some(boom_cb), std::ptr::null_mut()),
+                0
+            );
+            let cd = CString::new("null").unwrap();
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(r.is_null());
+            assert!(last_error().unwrap().contains("host function"));
+            jsonata_free_expr(h);
+        }
+    }
+
+    #[test]
+    fn host_fn_null_func_rejected() {
+        unsafe {
+            let ce = CString::new("$x()").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            let name = CString::new("x").unwrap();
+            assert_eq!(
+                jsonata_register_fn(h, name.as_ptr(), None, std::ptr::null_mut()),
+                -1
+            );
+            assert!(last_error().unwrap().contains("NULL"));
+            jsonata_free_expr(h);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 #[cfg(feature = "python")]
-use pyo3::types::{PyDict, PyList, PyString};
+use pyo3::types::{PyDict, PyList, PyString, PyTuple};
 
 /// Pre-converted data handle for efficient repeated evaluation.
 ///
@@ -165,6 +165,11 @@ struct JsonataExpression {
     /// kwargs override these on a field-by-field basis (see the `.or(...)` merges
     /// in the `#[pymethods]` impl below).
     default_options: evaluator::EvaluatorOptions,
+    /// Python callables registered via `register`/`register_override`, callable
+    /// from the expression as `$name(...)`. Empty by default; when non-empty,
+    /// evaluation is routed through the tree-walker (the bytecode VM has no host
+    /// registry) and these are registered onto the per-call evaluator.
+    host_fns: Vec<HostFnReg>,
 }
 
 /// Test-support toggle: bypass the bytecode VM and exercise the tree-walking
@@ -211,7 +216,10 @@ impl JsonataExpression {
         bindings: Option<Py<PyAny>>,
         options: evaluator::EvaluatorOptions,
     ) -> PyResult<JValue> {
-        if bindings.is_none() && !force_tree_walker() {
+        // Host functions, like bindings, require the tree-walker: the bytecode VM
+        // has no view of the host registry. Take the fast path only when neither
+        // is in play.
+        if bindings.is_none() && self.host_fns.is_empty() && !force_tree_walker() {
             let bytecode = self.bytecode.get_or_init(|| {
                 evaluator::try_compile_expr(&self.ast)
                     .map(|ce| compiler::BytecodeCompiler::compile(&ce))
@@ -226,8 +234,28 @@ impl JsonataExpression {
             }
         } else {
             let mut ev = create_evaluator(py, bindings, options)?;
+            self.register_host_fns(py, &mut ev)?;
             ev.evaluate(&self.ast, data).map_err(evaluator_error_to_py)
         }
+    }
+
+    /// Register the stored Python callables onto a freshly built evaluator.
+    /// The collision/override rules were already validated at `register()` time,
+    /// so these calls are not expected to fail; any error is still surfaced.
+    fn register_host_fns(&self, py: Python, ev: &mut evaluator::Evaluator) -> PyResult<()> {
+        for reg in &self.host_fns {
+            let hf = PyHostFn {
+                func: reg.func.clone_ref(py),
+            };
+            if reg.is_override {
+                ev.register_fn_override(reg.name.clone(), hf)
+                    .map_err(evaluator_error_to_py)?;
+            } else {
+                ev.register_fn(reg.name.clone(), hf)
+                    .map_err(evaluator_error_to_py)?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -253,6 +281,67 @@ impl JsonataExpression {
             max_sequence_length: max_sequence_length.or(self.default_options.max_sequence_length),
         };
         json_to_python(py, &self.run_eval(py, &json_data, bindings, options)?)
+    }
+
+    /// Register a Python callable, callable from the expression as `$name(...)`.
+    ///
+    /// The callable receives the (already-evaluated) arguments as positional
+    /// Python values and must return a JSON-compatible value synchronously. An
+    /// `async def` (which returns a coroutine) is rejected at call time. Raises
+    /// ValueError if `name` collides with a built-in — use `register_override`
+    /// to replace a built-in deliberately.
+    fn register(&mut self, py: Python, name: String, func: Py<PyAny>) -> PyResult<()> {
+        if !func.bind(py).is_callable() {
+            return Err(PyTypeError::new_err(format!(
+                "host function '{name}' must be callable"
+            )));
+        }
+        // Validate the collision rule now (fail at register-time, not evaluate-time)
+        // by exercising the same core registration on a throwaway evaluator.
+        let mut probe = evaluator::Evaluator::new();
+        probe
+            .register_fn(
+                name.clone(),
+                PyHostFn {
+                    func: func.clone_ref(py),
+                },
+            )
+            .map_err(evaluator_error_to_py)?;
+        self.host_fns.retain(|r| r.name != name);
+        self.host_fns.push(HostFnReg {
+            name,
+            func,
+            is_override: false,
+        });
+        Ok(())
+    }
+
+    /// Register a Python callable that deliberately replaces a built-in of the
+    /// same name — for determinism injection (a frozen `$now`, seeded `$random`)
+    /// or sandboxing (a disabled `$eval`). Raises ValueError when the built-in is
+    /// on the compiled fast path and cannot be safely overridden.
+    fn register_override(&mut self, py: Python, name: String, func: Py<PyAny>) -> PyResult<()> {
+        if !func.bind(py).is_callable() {
+            return Err(PyTypeError::new_err(format!(
+                "host function '{name}' must be callable"
+            )));
+        }
+        let mut probe = evaluator::Evaluator::new();
+        probe
+            .register_fn_override(
+                name.clone(),
+                PyHostFn {
+                    func: func.clone_ref(py),
+                },
+            )
+            .map_err(evaluator_error_to_py)?;
+        self.host_fns.retain(|r| r.name != name);
+        self.host_fns.push(HostFnReg {
+            name,
+            func,
+            is_override: true,
+        });
+        Ok(())
     }
 
     /// Evaluate with a pre-converted data handle (fastest for repeated evaluation).
@@ -441,6 +530,7 @@ fn compile(
         ast,
         bytecode: std::cell::OnceCell::new(),
         default_options: build_evaluator_options(timeout, max_stack_depth, max_sequence_length),
+        host_fns: Vec::new(),
     })
 }
 
@@ -623,6 +713,67 @@ fn build_evaluator_options(
         timeout_ms: timeout,
         max_stack_depth,
         max_sequence_length,
+    }
+}
+
+/// A Python callable registered as a host function (see
+/// `JsonataExpression.register`). Stored on the expression and re-registered
+/// onto the fresh evaluator built for each `evaluate*()` call.
+#[cfg(feature = "python")]
+struct HostFnReg {
+    name: String,
+    func: Py<PyAny>,
+    is_override: bool,
+}
+
+/// Bridges a Python callable to the core [`evaluator::HostFn`] trait. On each
+/// call it re-acquires the GIL, marshals the JSONata arguments to Python,
+/// invokes the callable, and marshals the result back.
+#[cfg(feature = "python")]
+struct PyHostFn {
+    func: Py<PyAny>,
+}
+
+#[cfg(feature = "python")]
+fn pyerr_to_evaluator_error(e: PyErr) -> evaluator::EvaluatorError {
+    evaluator::EvaluatorError::EvaluationError(format!("host function raised {e}"))
+}
+
+#[cfg(feature = "python")]
+impl evaluator::HostFn for PyHostFn {
+    fn call(
+        &self,
+        args: &[JValue],
+        _ctx: &mut evaluator::HostCtx,
+    ) -> Result<JValue, evaluator::EvaluatorError> {
+        Python::attach(|py| {
+            let py_args: Vec<Bound<'_, PyAny>> = args
+                .iter()
+                .map(|a| json_to_python(py, a).map(|o| o.into_bound(py)))
+                .collect::<PyResult<_>>()
+                .map_err(pyerr_to_evaluator_error)?;
+            let args_tuple = PyTuple::new(py, &py_args).map_err(pyerr_to_evaluator_error)?;
+
+            let result = self
+                .func
+                .bind(py)
+                .call1(&args_tuple)
+                .map_err(pyerr_to_evaluator_error)?;
+
+            // The synchronous core cannot await, so an `async def` (which returns
+            // a coroutine) has no meaningful result. Reject it with actionable
+            // guidance rather than silently converting the coroutine object.
+            if result.hasattr("__await__").unwrap_or(false) {
+                return Err(evaluator::EvaluatorError::EvaluationError(
+                    "host function returned a coroutine; async functions are not \
+                     supported. Use a synchronous function, or perform the async I/O \
+                     outside jsonata and pass the result in via bindings."
+                        .to_string(),
+                ));
+            }
+
+            python_to_json_bound(&result).map_err(pyerr_to_evaluator_error)
+        })
     }
 }
 

--- a/tests/python/test_host_functions.py
+++ b/tests/python/test_host_functions.py
@@ -1,0 +1,117 @@
+"""Tests for host-callable custom functions (register / register_override).
+
+These exercise the Python (PyO3) binding of the Rust host-function feature:
+a Python callable registered on a compiled expression is callable from the
+expression as ``$name(...)``. See docs/superpowers/specs/
+2026-07-19-host-callable-functions-design.md.
+"""
+
+import jsonatapy
+import pytest
+
+
+class TestRegister:
+    def test_direct_call(self):
+        expr = jsonatapy.compile("$greet(name)")
+        expr.register("greet", lambda n: f"hello {n}")
+        assert expr.evaluate({"name": "Ada"}) == "hello Ada"
+
+    def test_multiple_args(self):
+        expr = jsonatapy.compile("$convert(amount, currency)")
+        expr.register("convert", lambda amt, cur: amt * (1.1 if cur == "EUR" else 1.0))
+        assert expr.evaluate({"amount": 10, "currency": "EUR"}) == pytest.approx(11.0)
+
+    def test_zero_args(self):
+        expr = jsonatapy.compile("$token()")
+        expr.register("token", lambda: "abc-123")
+        assert expr.evaluate(None) == "abc-123"
+
+    def test_maps_over_sequence(self):
+        expr = jsonatapy.compile("items.$double(qty)")
+        expr.register("double", lambda q: q * 2)
+        assert expr.evaluate({"items": [{"qty": 2}, {"qty": 5}]}) == [4, 10]
+
+    def test_returns_structured_value(self):
+        expr = jsonatapy.compile("$wrap(x)")
+        expr.register("wrap", lambda x: {"value": x, "doubled": x * 2})
+        assert expr.evaluate({"x": 21}) == {"value": 21, "doubled": 42}
+
+    def test_works_via_evaluate_json(self):
+        expr = jsonatapy.compile("$double(n)")
+        expr.register("double", lambda n: n * 2)
+        assert expr.evaluate_json('{"n": 21}') == "42"
+
+    def test_register_returns_self_for_chaining(self):
+        expr = jsonatapy.compile("$a() & $b()")
+        result = expr.register("a", lambda: "x").register("b", lambda: "y")
+        assert result is expr
+        assert expr.evaluate(None) == "xy"
+
+    def test_in_expression_function_shadows_host_fn(self):
+        expr = jsonatapy.compile("($greet := function($n){ 'local ' & $n }; $greet('x'))")
+        expr.register("greet", lambda n: "HOST")
+        assert expr.evaluate(None) == "local x"
+
+
+class TestRegisterErrors:
+    def test_collision_with_builtin_rejected(self):
+        expr = jsonatapy.compile("$sum(x)")
+        with pytest.raises(ValueError, match="shadows a built-in"):
+            expr.register("sum", lambda x: 0)
+
+    def test_non_callable_rejected(self):
+        expr = jsonatapy.compile("$x()")
+        with pytest.raises(TypeError, match="must be callable"):
+            expr.register("x", 42)
+
+    def test_host_exception_propagates(self):
+        expr = jsonatapy.compile("$boom()")
+
+        def boom():
+            raise KeyError("nope")
+
+        expr.register("boom", boom)
+        with pytest.raises(ValueError, match="nope"):
+            expr.evaluate(None)
+
+    def test_async_function_rejected(self):
+        async def afn():
+            return 1
+
+        expr = jsonatapy.compile("$a()")
+        expr.register("a", afn)
+        with pytest.raises(ValueError, match="coroutine"):
+            expr.evaluate(None)
+
+
+class TestOverride:
+    def test_override_now_for_determinism(self):
+        expr = jsonatapy.compile("$now()")
+        expr.register_override("now", lambda: "2020-01-01T00:00:00.000Z")
+        assert expr.evaluate(None) == "2020-01-01T00:00:00.000Z"
+
+    def test_override_eval_for_sandboxing(self):
+        expr = jsonatapy.compile("$eval('1+1')")
+
+        def blocked(*_args):
+            raise ValueError("$eval is disabled")
+
+        expr.register_override("eval", blocked)
+        with pytest.raises(ValueError, match="disabled"):
+            expr.evaluate(None)
+
+    def test_override_compilable_builtin_rejected(self):
+        expr = jsonatapy.compile("$round(x)")
+        with pytest.raises(ValueError, match="compiled fast path"):
+            expr.register_override("round", lambda x: 0)
+
+
+class TestNoImpact:
+    def test_no_host_fns_unchanged(self):
+        # Sanity: an expression with no host fns is unaffected.
+        assert jsonatapy.evaluate("$sum([1,2,3])", None) == 6
+
+    def test_host_fn_alongside_bindings(self):
+        expr = jsonatapy.compile("$scale(base * $factor)")
+        expr.register("scale", lambda v: v + 1)
+        assert expr.evaluate({"base": 10}, {"factor": 2}) == 21


### PR DESCRIPTION
## Description

Exposes the host-callable custom functions feature (Rust core merged in #79) to the **Python binding** and the **C ABI**. A host-registered callable is invocable from the expression as `$name(...)` — the equivalent of jsonata-js's `registerFunction`. Evaluation stays synchronous in every binding; concurrency comes from threads, and an async host function (Python `async def`) is rejected with guidance to do async I/O outside jsonata.

This lands **Phase 2 (Python)** and **Phase 3 (C ABI)** of the design (`docs/superpowers/specs/2026-07-19-host-callable-functions-design.md`). With this, host functions are available in all three surfaces: Rust crate, Python, and C. Reentrancy (host-defined higher-order functions) remains a future phase.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

Purely additive in both bindings: new methods / new C functions. Expressions with no host functions are unaffected and take the same fast path.

## Related Issues

Follow-up to #79 (Phase 1: Rust core + API).

## Changes Made

**Python (PyO3):**
- `JsonataExpression.register(name, func)` and `.register_override(name, func)` (chainable), on both the Rust `_JsonataExpression` and the Python wrapper.
- A `PyHostFn` bridge implementing the core `HostFn` trait: re-acquires the GIL, marshals arguments to Python via `json_to_python`, invokes the callable, marshals the result back via `python_to_json`.
- `async def` (coroutine) returns are rejected at call time with actionable guidance.

**C ABI:**
- `jsonata_register_fn(expr, name, fn, user_data)` and `jsonata_register_fn_override(...)`.
- A `CHostFn` bridge: serializes the arguments to a JSON array string, invokes the C callback, and parses the returned JSON string. The host retains ownership of the returned string (jsonata copies it); NULL signals an error. `user_data` is passed through unchanged and must outlive the handle.
- `bindings/c/jsonata.h`, `bindings/c/README.md`, and `bindings/c/examples/smoke.c` updated in lockstep (CI builds the smoke test as C and C++).

**Both:**
- Evaluation routes through the tree-walker when host functions are registered (the bytecode VM has no host registry), mirroring the existing bindings path; zero overhead when none are registered.
- Collision (`register`) and compilable-builtin-override (`register_override`) rules are validated at registration time, so misuse fails early rather than at evaluate.

**Docs:** a `register`/`register_override` section plus a "Why host functions are synchronous" note in `docs/api.md`, a runnable `examples/host_functions.py`, the C `README.md`/header updates, and CHANGELOG entries for both bindings.

## Testing

### Test Environment

- Rust: `cargo test --features capi` / `cargo clippy --features python`
- Python: extension built with `maturin develop`; `pytest`, `ruff`, `mypy`
- C: `gcc`/`g++ -Wall -Wextra -Werror` against the built shared library

### Test Checklist

- [x] All existing tests pass (`cargo test`, `pytest`) — no regression
- [x] New tests added — `tests/python/test_host_functions.py` (17 cases) and 7 C-ABI cases in `src/capi.rs`
- [x] C smoke test passes as both C and C++ (registration, `$now` override, collision rejection)
- [x] `cargo clippy` clean on new code; `ruff` clean; `mypy` adds no new errors

### Test Cases

```python
import jsonatapy
expr = jsonatapy.compile("$now()")
expr.register_override("now", lambda: "2020-01-01T00:00:00.000Z")
assert expr.evaluate(None) == "2020-01-01T00:00:00.000Z"
```

```c
JsonataExpr *e = jsonata_compile("$greet(name)");
jsonata_register_fn(e, "greet", greet_cb, NULL);   /* greet_cb: ["Ada"] -> "hello Ada" */
char *r = jsonata_evaluate(e, "{\"name\":\"Ada\"}"); /* "hello Ada" */
```

## Documentation

- [x] `docs/api.md` — register/override section + synchronous-design note
- [x] Runnable `examples/host_functions.py`
- [x] C `bindings/c/README.md`, `jsonata.h`, and `smoke.c`
- [x] CHANGELOG updated for both Python and C under `[Unreleased]`
- [x] Docstrings / rustdoc on all new public surface

## Compatibility

- [x] No breaking changes (additive only in both bindings)
- [x] Backward compatible: expressions without host functions are unaffected and pay no runtime cost
- [x] Behavior matches the Rust core (same precedence and shadowing rules)

## Breaking Changes

- [ ] This PR introduces breaking changes — no.

## Performance Impact

- [x] No regression for the common path: host-fn dispatch is behind an `is_empty()` guard; expressions with no host fns still take the bytecode fast path.

## Code Quality

- [x] `cargo fmt` / `ruff format` applied
- [x] `cargo clippy` clean on new code; `ruff` clean
- [x] Self-reviewed; no debug/print statements outside examples

## Additional Notes

**`async def` handling (Python):** the sync core cannot await, so a coroutine return is rejected. The one Python-visible quirk is a benign `RuntimeWarning: coroutine was never awaited`, unavoidable since detecting the coroutine means the function was already called; the `ValueError` is raised regardless.

**C string ownership:** host callbacks return a JSON string that jsonata copies and never frees — the host keeps ownership. This avoids cross-allocator frees across the FFI boundary.

**Deferred:** reentrancy (host-defined higher-order functions) remains a future phase, enabled by the reserved `HostCtx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)