### PR TITLE
fix: JSONata 2.2.2 conformance ($contains, $each, empty joins)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,12 +33,11 @@ updates:
       - "dependencies"
       - "github-actions"
 
-  # Git submodules (jsonata-js reference)
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels:
-      - "dependencies"
-      - "submodule"
+  # NOTE: the jsonata-js reference submodule (tests/jsonata-js) is deliberately
+  # NOT managed by Dependabot. A raw submodule bump is a JSONata-version change
+  # that can shift expected behavior and fail the conformance suite with no
+  # context (see PR #82). Reference-suite updates are handled by the purpose-built
+  # `.github/workflows/sync-jsonata.yml`, which detects new jsonata-js releases,
+  # runs the reference suite against the bump, and opens a tracking *issue* (plus a
+  # WIP PR) when cases fail — or a clean PR when they all pass. Do not re-add a
+  # `gitsubmodule` ecosystem entry here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Dependabot no longer auto-bumps the `tests/jsonata-js` reference submodule (removed the
+  `gitsubmodule` ecosystem entry). Reference-suite updates are handled by the
+  `sync-jsonata.yml` workflow, which runs the conformance suite against each new jsonata-js
+  release and opens a tracking issue (or a clean PR) — avoiding context-free failing bump
+  PRs like #82.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- JSONata 2.2.2 conformance (reference submodule bumped to `6c7e95f`):
+  - `$contains(str, token)` now returns `undefined` when either argument is undefined,
+    instead of raising a type error (jsonata-js #809).
+  - `$each(obj, fn)` now returns `undefined` when its first argument is undefined, instead
+    of raising `each() first argument must be an object`.
+  - An object constructor (group-by) applied to an empty or undefined sequence now yields
+    an empty object `{}` instead of `undefined` (jsonata-js #817, "correctly handle empty
+    joins"); `null` input still returns `null` and non-empty grouping is unchanged.
 
 ### Security
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2177,8 +2177,13 @@ fn call_pure_builtin(
                     "contains() requires exactly 2 arguments".to_string(),
                 ));
             }
+            // jsonata-js #809: $contains returns undefined when either argument
+            // (the string OR the pattern) is undefined.
+            if effective_args[0].is_undefined() || effective_args[1].is_undefined() {
+                return Ok(JValue::Undefined);
+            }
             match &effective_args[0] {
-                JValue::Null | JValue::Undefined => Ok(JValue::Null),
+                JValue::Null => Ok(JValue::Null),
                 JValue::String(s) => Ok(functions::string::contains(s, &effective_args[1])?),
                 _ => Err(EvaluatorError::TypeError(
                     "contains() requires a string as the first argument".to_string(),
@@ -3900,15 +3905,20 @@ impl Evaluator {
                 self.keep_tuple_stream = saved_keep;
                 let input_value = input_value?;
 
-                // If input is undefined, return undefined (not empty object)
-                if input_value.is_undefined() {
-                    return Ok(JValue::Undefined);
-                }
-
-                // Handle array input - process each item
+                // Handle array input - process each item.
+                //
+                // jsonata-js #817 ("correctly handle empty joins"): an object
+                // constructor (group-by) applied to an empty or undefined
+                // sequence must yield an empty object `{}`, not undefined.
+                // jsonata-js wraps the input via `createSequence`, so an
+                // undefined input becomes an *empty* sequence that flows through
+                // grouping and produces `{}`. We mirror that by mapping undefined
+                // to an empty item list here (rather than short-circuiting), and
+                // let the empty-input handling below generate the `{}`.
                 let items: Vec<JValue> = match input_value {
                     JValue::Array(ref arr) => (**arr).clone(),
                     JValue::Null => return Ok(JValue::Null),
+                    JValue::Undefined => Vec::new(),
                     other => vec![other],
                 };
 
@@ -7742,7 +7752,9 @@ impl Evaluator {
                 if evaluated_args[0].is_null() {
                     return Ok(JValue::Null);
                 }
-                if evaluated_args[0].is_undefined() {
+                // jsonata-js #809: $contains returns undefined when either argument
+                // (the string OR the pattern) is undefined.
+                if evaluated_args[0].is_undefined() || evaluated_args[1].is_undefined() {
                     return Ok(JValue::Undefined);
                 }
                 match &evaluated_args[0] {
@@ -9392,6 +9404,9 @@ impl Evaluator {
                         Ok(JValue::array(result))
                     }
                     JValue::Null => Ok(JValue::Null),
+                    // jsonata-js: $each returns undefined when its first argument
+                    // is undefined (e.g. a path that resolves to nothing).
+                    JValue::Undefined => Ok(JValue::Undefined),
                     _ => Err(EvaluatorError::TypeError(
                         "each() first argument must be an object".to_string(),
                     )),


### PR DESCRIPTION
## Description

Bumps the `tests/jsonata-js` reference submodule to **jsonata-js v2.2.2** (`06fc08c` → `6c7e95f`) and implements the three behavior changes its reference suite now expects. **Supersedes and closes #82** (the Dependabot bump, which was red because those three behaviors weren't yet implemented).

Closes #82.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — aligns three functions with jsonata-js 2.2.2

## Related Issues

Supersedes #82 (Dependabot submodule bump).

## Changes Made

Reference-suite deltas from jsonata-js 2.2.2, all fixed in `src/evaluator.rs`:

1. **`$contains(str, token)` returns `undefined` when *either* argument is undefined** (jsonata-js [#809](https://github.com/jsonata-js/jsonata/pull/809)), instead of raising `contains() requires string arguments`. Fixed in both the compiled fast path (`call_pure_builtin`) and the tree-walker (`evaluate_function_call`).
2. **`$each(obj, fn)` returns `undefined` when its first argument is undefined**, instead of raising `each() first argument must be an object`.
3. **An object constructor (group-by) over an empty/undefined sequence yields `{}`** (jsonata-js [#817](https://github.com/jsonata-js/jsonata/pull/817), "correctly handle empty joins") instead of `undefined`. Undefined input is routed into the pre-existing empty-array→`{}` path; `Null` input still returns `Null` and non-empty grouping is unchanged.

Also (`ci:` commit): **removed the `gitsubmodule` entry from `.github/dependabot.yml`.** A raw submodule bump is a JSONata-version change that can shift expected behavior and fail the conformance suite with no context (this PR's predecessor, #82). Reference-suite updates are already handled by `.github/workflows/sync-jsonata.yml`, which runs the suite against each new jsonata-js release and opens a tracking **issue** (plus a WIP PR) on failures, or a clean PR when all cases pass.

## Testing

### Test Environment
- Rust: `cargo test` (incl. the `joins` reference group)
- Python: `maturin develop` + full reference suite

### Test Checklist
- [x] Full reference suite: **1686 passed, 0 failed** (was 3 failed / 1683 passed)
- [x] `joins` reference group passes (`library-joins[12]` now `{}`)
- [x] No regressions: lib 175, integration 72, host_functions 12, all green
- [x] `cargo fmt` / `cargo clippy` clean on changed code

## Compatibility

- [x] Brings jsonata-core in line with jsonata-js 2.2.2 for these three cases
- Behavior changes are confined to previously-erroring or previously-`undefined` edge cases (undefined-argument propagation for `$contains`/`$each`; empty group-by → `{}`); they match the reference implementation and the full suite is green.

## Breaking Changes

- [ ] No. The changed outputs were previously *errors* or `undefined` on edge inputs; well-formed expressions are unaffected.

## Code Quality

- [x] `cargo fmt` applied; clippy clean on changed regions
- [x] Self-reviewed (including independent re-run of the full reference suite)

## Reviewer Guidelines

**Focus areas:**
- The empty-join change in the `ObjectTransform` arm of `evaluate_internal` — it routes `undefined` input into the existing `items.is_empty()` → `[Undefined]` → `{}` path rather than short-circuiting; `Null` still returns `Null`.
- The `$contains` fix touches two dispatch paths (compiled + tree-walker) to keep behavior consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018myqZqco6k9udkNVg4bqEY)_