### PR TITLE
docs: state jsonata-js 2.2.2 test-suite compliance in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- JSONata 2.2.2 conformance (reference submodule bumped to `6c7e95f`):
+- Ensures compliance with the **jsonata-js 2.2.2** reference test suite (reference submodule
+  bumped to `6c7e95f`); the full reference suite — 1686 cases — passes. Three behavior
+  changes were required to match jsonata-js 2.2.2:
   - `$contains(str, token)` now returns `undefined` when either argument is undefined,
     instead of raising a type error (jsonata-js #809).
   - `$each(obj, fn)` now returns `undefined` when its first argument is undefined, instead


### PR DESCRIPTION
## Description

Follow-up to #84. Clarifies the `[Unreleased]` CHANGELOG entry so the **next release's notes explicitly state that the release ensures compliance with the jsonata-js 2.2.2 reference test suite** (all 1686 cases pass), rather than just "JSONata 2.2.2 conformance". Docs-only — no code changes.

## Type of Change

- [x] Documentation update

## Changes Made

- Reworded the `[Unreleased] → Fixed` lead line in `CHANGELOG.md` to: "Ensures compliance with the **jsonata-js 2.2.2** reference test suite … the full reference suite — 1686 cases — passes." The three specific behavior changes remain listed underneath.

## Testing

- N/A (CHANGELOG text only).

## Compatibility

- [x] No code or behavior change.

## Breaking Changes

- [ ] No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018myqZqco6k9udkNVg4bqEY)_