### PR TITLE
docs(rust): make crate examples compile, and mark the package stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["jsonata", "json", "query", "transform"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// during the extraction process, not as separate steps.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Stage {
-    /// Filter/predicate stage [expr]
+    /// Filter/predicate stage `[expr]`
     Filter(Box<AstNode>),
     /// Positional index stage `#$var` that lands on a step already carrying an
     /// index/stages (jsonata-js's `{type: 'index', value}` stage). Binds the
@@ -169,11 +169,11 @@ pub enum AstNode {
     /// fills every occurrence with a real label or raises S0217.
     Parent(String),
 
-    /// Array filter/predicate [condition]
+    /// Array filter/predicate `[condition]`
     /// Can be an index (number) or a predicate (boolean expression)
     Predicate(Box<AstNode>),
 
-    /// Array grouping in path expression .[expr]
+    /// Array grouping in path expression `.[expr]`
     /// Like Array but doesn't flatten when used in paths
     ArrayGroup(Vec<AstNode>),
 
@@ -191,7 +191,7 @@ pub enum AstNode {
         terms: Vec<(AstNode, bool)>,
     },
 
-    /// Transform operator |location|update[,delete]|
+    /// Transform operator `|location|update[,delete]|`
     /// Creates a function that transforms objects by:
     /// 1. Evaluating location to find objects to modify
     /// 2. Applying update (object constructor) to each matched object

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,32 +2,128 @@
 // Copyright (c) 2025 jsonatapy contributors
 // Licensed under the MIT License
 
-//! # jsonatapy
+//! # jsonata-core
 //!
-//! A high-performance Rust implementation of JSONata - the JSON query and
-//! transformation language - with optional Python bindings via PyO3.
+//! A high-performance Rust implementation of [JSONata](https://jsonata.org) — the
+//! JSON query and transformation language — with optional Python bindings via PyO3.
 //!
-//! ## Rust API
+//! ## Quick start
 //!
-//! ```rust,ignore
-//! use jsonata_core::parser;
-//! use jsonata_core::evaluator::Evaluator;
-//! use jsonata_core::value::JValue;
+//! Parsing produces an [`AstNode`](ast::AstNode); evaluating it against a
+//! [`value::JValue`] produces another `JValue`.
 //!
-//! let ast = parser::parse("user.name").unwrap();
-//! let data = JValue::from_json_str(r#"{"user":{"name":"Alice"}}"#).unwrap();
-//! let result = Evaluator::new().evaluate(&ast, &data).unwrap();
+//! ```
+//! use jsonata_core::{evaluator::Evaluator, parser, value::JValue};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let ast = parser::parse("Account.Order.Product.(Price * Quantity)")?;
+//! let data = JValue::from_json_str(
+//!     r#"{"Account": {"Order": [{"Product": [
+//!            {"Price": 34.45, "Quantity": 2},
+//!            {"Price": 21.67, "Quantity": 1}
+//!        ]}]}}"#,
+//! )?;
+//!
+//! let line_totals = Evaluator::new().evaluate(&ast, &data)?;
+//! assert_eq!(line_totals.to_json_string()?, "[68.9,21.67]");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Compile once, evaluate many times
+//!
+//! Parsing is the expensive step, and an `AstNode` is immutable once built — so
+//! hoist it out of your hot loop and reuse it across payloads.
+//!
+//! ```
+//! use jsonata_core::{evaluator::Evaluator, parser, value::JValue};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let ast = parser::parse("orders[price > 100].product")?;
+//! let mut ev = Evaluator::new();
+//!
+//! let payloads = [
+//!     r#"{"orders": [{"product": "widget", "price": 150}]}"#,
+//!     r#"{"orders": [{"product": "gizmo", "price": 50}]}"#,
+//! ];
+//!
+//! let mut matched = Vec::new();
+//! for payload in payloads {
+//!     let data = JValue::from_json_str(payload)?;
+//!     if let Some(product) = ev.evaluate(&ast, &data)?.as_str() {
+//!         matched.push(product.to_string());
+//!     }
+//! }
+//!
+//! assert_eq!(matched, ["widget"]);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Handling errors
+//!
+//! The two phases fail with two distinct error types, so you can tell a bad
+//! expression apart from a bad evaluation. Both implement [`std::error::Error`],
+//! so `?` into a boxed error works when you do not need to distinguish them.
+//!
+//! ```
+//! use jsonata_core::{evaluator::Evaluator, parser, value::JValue};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // A malformed expression fails at parse time.
+//! let err = parser::parse("orders[price > ").unwrap_err();
+//! println!("could not parse: {err}");
+//!
+//! // A well-formed expression can still fail against the data it is given.
+//! let ast = parser::parse("orders.price * 2")?;
+//! let data = JValue::from_json_str(r#"{"orders": [{"price": "free"}]}"#)?;
+//!
+//! let outcome = Evaluator::new().evaluate(&ast, &data);
+//! match &outcome {
+//!     Ok(total) => println!("total: {}", total.to_json_string()?),
+//!     Err(e) => println!("could not evaluate: {e}"),
+//! }
+//! // The left side of `*` is a string in this payload, so evaluation fails.
+//! assert!(outcome.is_err());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Extending expressions with host functions
+//!
+//! [`Evaluator::register_fn`](evaluator::Evaluator::register_fn) exposes your own
+//! Rust closures to an expression as `$name(...)`. See its documentation for
+//! resolution order and for overriding built-ins.
+//!
+//! ```
+//! use jsonata_core::{evaluator::Evaluator, parser, value::JValue};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut ev = Evaluator::new();
+//! ev.register_fn("initials", |args: &[JValue]| {
+//!     let name = args.first().and_then(|v| v.as_str()).unwrap_or("");
+//!     let initials: String = name.split_whitespace().filter_map(|w| w.chars().next()).collect();
+//!     Ok(JValue::from(initials))
+//! })?;
+//!
+//! let ast = parser::parse("$initials(user.name)")?;
+//! let data = JValue::from_json_str(r#"{"user": {"name": "Ada Lovelace"}}"#)?;
+//! assert_eq!(ev.evaluate(&ast, &data)?, JValue::from("AL"));
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Architecture
 //!
-//! - `parser` - Expression parser (converts JSONata strings to AST)
-//! - `evaluator` - Expression evaluator (executes AST against data)
-//! - `functions` - Built-in function implementations
-//! - `datetime` - Date/time handling functions
-//! - `signature` - Function signature validation
-//! - `ast` - Abstract Syntax Tree definitions
-//! - `value` - JValue type (the runtime value representation)
+//! - [`parser`] — expression parser (JSONata source to AST)
+//! - [`evaluator`] — expression evaluator (executes an AST against data)
+//! - [`value`] — the runtime value representation, [`value::JValue`]
+//! - [`functions`] — built-in function implementations
+//! - [`ast`] — Abstract Syntax Tree definitions
+//! - [`ast_transform`] — AST rewriting used by the compilation layer
+//!
+//! Two further modules are feature-gated: `lazy` (zero-copy views over Python
+//! objects, with `python`) and `capi` (the C ABI surface, with `capi`).
 
 pub mod ast;
 pub mod ast_transform;

--- a/src/value.rs
+++ b/src/value.rs
@@ -201,7 +201,7 @@ impl JValue {
         }
     }
 
-    /// Get a reference to the Rc<str> for the string variant.
+    /// Get a reference to the `Rc<str>` for the string variant.
     #[inline]
     pub fn as_rc_str(&self) -> Option<&Rc<str>> {
         match self {

--- a/uv.lock
+++ b/uv.lock
@@ -1173,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "jsonatapy"
-version = "2.2.5"
+version = "2.2.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

The crate-level example on docs.rs was marked `rust,ignore`, so it was never compiled and nothing verified it was correct. It was also the *only* Rust example in the crate.

Replaces it with four real, asserting doctests — quick start, compile-once/evaluate-many, error handling, and host functions via `register_fn` — using `?` inside a hidden `main` rather than `unwrap()` chains.

The `ignore` was gratuitous, not a workaround: `default = ["simd"]`, so pyo3 never enters the doctest link. Confirmed by removing it.

Also in scope:

- Fixed the header. It read `# jsonatapy`; the crate is `jsonata-core`.
- Fixed the module list, which advertised `datetime` and `signature` as public when both are private, and omitted the feature-gated `lazy` and `capi` (neither renders on docs.rs, which builds default features only — verified against the live 2.2.7 page).
- Cleared five pre-existing rustdoc warnings that render as broken links on docs.rs: JSONata syntax such as `[expr]` and `|location|update[,delete]|` was parsed as intra-doc links, and `Rc<str>` as an unclosed HTML tag.
- Set `Development Status :: 5 - Production/Stable`. The classifier is the only thing PyPI and piptrends read for that badge, and it still said `4 - Beta` at 1686/1686 reference-suite parity.
- Refreshed the stale `uv.lock` pin (2.2.5 → 2.2.7).

Left `register_fn`'s existing doctest alone — its `.expect("...")` documents an invariant, which is the right idiom there.

## Verification

```
doctests   5 passed (was 2, one of them ignored)
cargo doc  0 warnings, under both default features and --all-features
cargo test 272 passed
```

## Note

Neither change is visible until a release: the classifier needs a PyPI upload, and docs.rs keeps serving the 2.2.7 rustdoc until a new version reaches crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)