### PR TITLE
docs: record why base64 stays UTF-8, from the reference's code and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,12 +53,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsing shares them and needs the error. ([#126](https://github.com/txjmb/jsonata-core/issues/126))
 
 ### Deliberately not changed
-- `$base64encode`/`$base64decode` keep treating their payload as UTF-8. jsonata-js reads it as
-  latin1 (`Buffer.from(str, 'binary')`), which truncates each UTF-16 code unit to one byte:
-  in jsonata-js 2.2.2 `$base64encode("🙂")` is `"PUI="` and decoding that gives `"=B"`. Matching
-  it would round-trip ASCII and corrupt everything else, and would silently change results for
-  anyone encoding non-ASCII today. The reference's own suite pins only an ASCII round-trip, so
-  nothing upstream settles it; a unit test now pins our choice so it cannot flip unnoticed.
+- `$base64encode`/`$base64decode` keep treating their payload as UTF-8, because jsonata's own
+  documentation asks for both latin1 *and* UTF-8 and its implementation matches only the first.
+  `$base64encode` is documented as latin1 — "all characters in the string are in the 0x00 to
+  0xFF range... Unicode characters outside of that range are not supported" — while
+  `$base64decode` is documented as "using a UTF-8 Unicode codepage", which its implementation
+  does not do. No reading of the reference is self-consistent, and UTF-8 on both sides is the
+  half that matches a documented contract exactly while also round-tripping. Above `0xFF`
+  nothing is defined at all: `window.btoa` throws `InvalidCharacterError` where Node truncates
+  each UTF-16 code unit to a byte, so browser and Node disagree. The cost is real but narrow —
+  for `0x80`–`0xFF`, encode has an environment-independent documented answer we do not give
+  (`$base64encode("héllo")` is `"aOlsbG8="` upstream, `"aMOpbGxv"` here); matching it would
+  require latin1 decode too, which would then contradict the decode docs. A unit test pins our
+  choice, with the full reasoning, so it cannot flip unnoticed.
   ([#126](https://github.com/txjmb/jsonata-core/issues/126))
 - An explicit null now behaves as a value in object construction and in the `[]` array-keep,
   rather than short-circuiting them: `nul{"a": $}` is `{"a": null}` (it was `null`, and

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2637,21 +2637,42 @@ mod tests {
         }
     }
 
-    /// $base64decode follows jsonata-js in what it *accepts*, not in how it
-    /// reads the bytes.
+    /// $base64 follows jsonata-js in what it *accepts*, not in how it reads
+    /// the bytes. Deliberate, and the reasoning is worth keeping because
+    /// jsonata's own documentation contradicts itself here.
     ///
-    /// jsonata-js decodes through Node's Buffer and calls `.toString('binary')`,
-    /// i.e. latin1, and encodes with `Buffer.from(str, 'binary')`, which
-    /// truncates each UTF-16 code unit to one byte. That round-trips ASCII and
-    /// destroys everything else -- in jsonata-js 2.2.2,
-    /// `$base64encode("\u{1f642}")` is "PUI=" and decoding it back gives "=B".
-    /// jsonata-core treats the payload as UTF-8 instead, so the round-trip
-    /// holds for any string.
+    /// `functions.js` delegates to the platform: `window.btoa`/`window.atob`
+    /// in a browser, and under Node `Buffer.from(str, 'binary')` /
+    /// `.toString('binary')` -- chosen, per its own comment, only to emulate
+    /// btoa/atob without pulling in the Buffer polyfill. So latin1 is the
+    /// intent, not an accident of Node.
     ///
-    /// This is a deliberate divergence, not an oversight (#126 group 3), and
-    /// the reference's own suite pins only an ASCII round-trip, so nothing
-    /// upstream settles it. If it is ever revisited, this test is the thing
-    /// that has to change first.
+    /// The docs then say two different things (docs/string-functions.md):
+    ///
+    ///   $base64encode -- "Each character in the string is treated as a byte
+    ///   of binary data. This requires that all characters in the string are
+    ///   in the 0x00 to 0xFF range... Unicode characters outside of that range
+    ///   are not supported."   -> latin1, out-of-range explicitly unsupported
+    ///
+    ///   $base64decode -- "Converts base 64 encoded bytes to a string, using a
+    ///   UTF-8 Unicode codepage."                                   -> UTF-8
+    ///
+    /// The decode implementation does not do what the decode docs say. So
+    /// there is no reading of the reference that is self-consistent, and
+    /// UTF-8 on both sides is the half that matches a documented contract
+    /// exactly while also round-tripping.
+    ///
+    /// Above 0xFF nothing is defined at all: `window.btoa("\u{1f642}")` throws
+    /// InvalidCharacterError, while Node truncates each UTF-16 code unit to a
+    /// byte and yields "PUI=", which decodes back to "=B". Browser and Node
+    /// disagree, so there is no conformance target to hit.
+    ///
+    /// What this does cost: for 0x80..=0xFF, encode has a documented,
+    /// environment-independent answer we do not give --
+    /// `$base64encode("h\u{e9}llo")` is "aOlsbG8=" in jsonata-js and
+    /// "aMOpbGxv" here. Matching it would require latin1 decode too (or the
+    /// round-trip breaks), which would then contradict the decode docs.
+    /// See #126 group 3. If this is ever revisited, start here.
     #[test]
     fn base64_round_trips_non_ascii_where_jsonata_js_does_not() {
         for original in [


### PR DESCRIPTION
Comment and changelog only — no behaviour change. You asked whether jsonata settles the charset question in code rather than in tests. It does, partly, and the answer is sharper than my earlier note.

## What the code says

`functions.js` delegates to the platform:

```js
var btoa = typeof window !== 'undefined' ? window.btoa :
    function (str) {
        // Simply doing `new Buffer` at this point causes Browserify to pull
        // in the entire Buffer browser library, which is large and unnecessary.
        return new global.Buffer.from(str, 'binary').toString('base64');
    };
```

The Buffer branch exists, by its own comment, **only to emulate `btoa`/`atob` without pulling in the polyfill.** So latin1 is the *intent*, not an accident of Node. My earlier note was wrong to imply otherwise.

## What the docs say — and they disagree with each other

From `docs/string-functions.md`:

> **`$base64encode`** — "Each character in the string is treated as a byte of binary data. This requires that all characters in the string are in the 0x00 to 0xFF range… Unicode characters outside of that range are not supported."

> **`$base64decode`** — "Converts base 64 encoded bytes to a string, **using a UTF-8 Unicode codepage**."

Encode is documented latin1. Decode is documented **UTF-8** — and its implementation does not do that. **There is no self-consistent reading of the reference**, so "match the reference" isn't a well-defined goal here.

## Above 0xFF there is no target at all

Verified with Node's own spec-compliant `btoa`, which is the same algorithm as `window.btoa`:

```
        btoa            Buffer.from(s,'binary')
"héllo"  aOlsbG8=        aOlsbG8=        ← agree
"日本"    THROWS          5Sw=            ← disagree
"🙂"     THROWS          PUI=            ← disagree
```

Browser throws `InvalidCharacterError`; Node silently truncates each UTF-16 code unit to a byte.

## Decision unchanged, cost now stated

UTF-8 on both sides is the half that matches a documented contract **exactly** and round-trips.

But the cost is real and I understated it before: for **0x80–0xFF**, encode has an environment-independent, documented answer we do not give — `$base64encode("héllo")` is `"aOlsbG8="` upstream and `"aMOpbGxv"` here. Matching it would force latin1 *decode* too (otherwise the round-trip breaks), which would then contradict the decode docs.

The unit test comment now carries all of this, so whoever revisits it starts from the evidence rather than re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)