### PR TITLE
chore(release): 2.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.2.8] - 2026-08-25
+
+A conformance release. Almost everything here brings `jsonatapy` closer to the pinned
+jsonata-js (v2.2.2), and a fair amount of it **changes the answer** for expressions that
+already run today. If you are upgrading, the summary below is the part worth reading; the
+itemised entries follow.
+
+### What changed, and who it affects
+
+**Boolean coercion of containers — the broadest change.** JSONata has one truthiness rule and
+applies it recursively: a container is truthy only if some element is truthy, all the way down.
+`jsonatapy` had three rules, and the one every implicit consumer used asked only "is it
+non-empty?". A single-element array holding a falsy value — `[0]`, `[""]`, `[false]`, `[null]` —
+was therefore truthy where the reference says false. That affects `? :`, `and`, `or`, `$not`,
+filter predicates, `$filter`, and any lambda whose result is coerced.
+
+*You are exposed if* your data holds one-element arrays of falsy values (`{"flags": [false]}`,
+`{"counts": [0]}`) or you build them (`[expr]`, `expr[]`, `$map`, `$filter`). Ordinary path
+expressions are unaffected — a path matching one value unwraps to the scalar, so
+`items[v=0].v` was already `0`, not `[0]`.
+
+**`$formatNumber` produces different numbers.** Rounding was half-away-from-zero; the reference
+rounds half-to-even. `$formatNumber(12.345, "#,##0.00")` was `"12.35"` and is now `"12.34"`.
+Three further defects around empty fractional parts, optional digits and exponents are fixed in
+the same pass.
+
+*You are exposed if* you format numbers for display or comparison and depend on the previous
+rounding.
+
+**Sequence and null handling in paths.** `*` on a value with no children is `undefined` rather
+than `null`; `*` and `#$i` now unwrap a lone result like every other sequence-producing step;
+an explicit null is treated as a value by object construction and `[]` rather than
+short-circuiting them; and `[]` and `[true]` are finally distinct operators.
+
+*You are exposed if* you rely on the shape (wrapped vs unwrapped) of single-result expressions,
+or on `null` where the reference produces `undefined` — the two differ in object construction,
+which drops undefined-valued keys but keeps null-valued ones.
+
+**Stricter argument validation.** Six builtins (`$base64encode`, `$base64decode`, `$toMillis`,
+`$fromMillis`, `$formatInteger`, `$parseInteger`) had no signature at all and so validated
+nothing. They now reject an explicit null with `T0410` where they previously returned `null`,
+and they accept the context forms (`str.$base64encode()`) that never worked.
+
+*You are exposed if* you pass a possibly-null value to any of those six and relied on getting
+`null` back rather than an error.
+
+**More permissive parsing in two places.** `$base64decode` now accepts what the reference
+accepts — partial quanta, characters outside the alphabet, the URL-safe alphabet — instead of
+raising. `$parseInteger` returns `NaN` for a value that does not match its picture rather than
+raising `D3136`.
+
+*You are exposed if* you depended on those raising to detect bad input.
+
+**Error codes.** Roughly 112 error shapes reported the wrong code, or none at all. If you branch
+on JSONata error codes, more of them are now correct — and a few that previously surfaced as
+generic errors now carry `T0410`, `D3061`, `D3110`, `D3137`, `D3138`, `D3139` or `D3141`.
+
+**Things that used to fail and now work.** Passing a builtin by reference through a variable
+(`$f := $uppercase; $map(arr, $f)`) returned empty strings and now works, for every builtin.
+`$eval` works as a callback. `$single` is recognised when passed by reference. Twenty-four
+builtins that worked in direct calls but raised when passed to `$map`/`$filter` now behave
+identically either way.
+
+**Internals with no behavioural intent.** Builtin dispatch is now a single shared
+implementation rather than three partial copies, and the differential harness gained the
+ability to see distinctions it was previously blind to — `null` vs `undefined`, error codes,
+and by-reference dispatch of evaluator-dependent builtins. Each of those blind spots was
+hiding real divergences, which is where most of this release came from.
+
+### Compatibility
+
+All 1686 reference-suite cases pass, and the differential corpus (over 20,000 comparisons
+against jsonata-js across two engines and two input paths) has **no known divergences** for the
+first time. The one deliberate exception is base64's character set, documented below.
+
+
+### Added
+
+### Changed
 - Every builtin that needs only its arguments is now implemented once, in `src/builtins.rs`,
   and shared by the compiled path and the tree-walker instead of being written out in each.
   Fifty-three builtins were spread across two dispatch sites: twenty-nine were implemented
@@ -127,21 +215,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `D3130`, and the letters/roman/words parsers are untouched because date-time component
   parsing shares them and needs the error. ([#126](https://github.com/txjmb/jsonata-core/issues/126))
 
-### Deliberately not changed
-- `$base64encode`/`$base64decode` keep treating their payload as UTF-8, because jsonata's own
-  documentation asks for both latin1 *and* UTF-8 and its implementation matches only the first.
-  `$base64encode` is documented as latin1 — "all characters in the string are in the 0x00 to
-  0xFF range... Unicode characters outside of that range are not supported" — while
-  `$base64decode` is documented as "using a UTF-8 Unicode codepage", which its implementation
-  does not do. No reading of the reference is self-consistent, and UTF-8 on both sides is the
-  half that matches a documented contract exactly while also round-tripping. Above `0xFF`
-  nothing is defined at all: `window.btoa` throws `InvalidCharacterError` where Node truncates
-  each UTF-16 code unit to a byte, so browser and Node disagree. The cost is real but narrow —
-  for `0x80`–`0xFF`, encode has an environment-independent documented answer we do not give
-  (`$base64encode("héllo")` is `"aOlsbG8="` upstream, `"aMOpbGxv"` here); matching it would
-  require latin1 decode too, which would then contradict the decode docs. A unit test pins our
-  choice, with the full reasoning, so it cannot flip unnoticed.
-  ([#126](https://github.com/txjmb/jsonata-core/issues/126))
 - An explicit null now behaves as a value in object construction and in the `[]` array-keep,
   rather than short-circuiting them: `nul{"a": $}` is `{"a": null}` (it was `null`, and
   disagreed with the dotted `nul.{"a": $}`, which was already right), `nul[]` is `[null]`,
@@ -226,6 +299,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was wrong on both routes; the tree-walker arm had no `Undefined` case at all, and the new
   shared dispatcher's corpus is what exposed it.
   ([#107](https://github.com/txjmb/jsonata-core/issues/107))
+
+### Deliberately not changed
+- `$base64encode`/`$base64decode` keep treating their payload as UTF-8, because jsonata's own
+  documentation asks for both latin1 *and* UTF-8 and its implementation matches only the first.
+  `$base64encode` is documented as latin1 — "all characters in the string are in the 0x00 to
+  0xFF range... Unicode characters outside of that range are not supported" — while
+  `$base64decode` is documented as "using a UTF-8 Unicode codepage", which its implementation
+  does not do. No reading of the reference is self-consistent, and UTF-8 on both sides is the
+  half that matches a documented contract exactly while also round-tripping. Above `0xFF`
+  nothing is defined at all: `window.btoa` throws `InvalidCharacterError` where Node truncates
+  each UTF-16 code unit to a byte, so browser and Node disagree. The cost is real but narrow —
+  for `0x80`–`0xFF`, encode has an environment-independent documented answer we do not give
+  (`$base64encode("héllo")` is `"aOlsbG8="` upstream, `"aMOpbGxv"` here); matching it would
+  require latin1 decode too, which would then contradict the decode docs. A unit test pins our
+  choice, with the full reasoning, so it cannot flip unnoticed.
+  ([#126](https://github.com/txjmb/jsonata-core/issues/126))
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "jsonata-core"
-version = "2.2.7"
+version = "2.2.8"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonata-core"
-version = "2.2.7"
+version = "2.2.8"
 edition = "2021"
 authors = ["txjmb <txjmb@users.noreply.github.com>"]
 description = "High-performance Rust implementation of JSONata query and transformation language"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ workloads, and faster than the next pure-Rust implementation.  The rust versions
 
 Many, many thanks to the incredible work of all the maintainers of the [JSONata](https://github.com/jsonata-js/jsonata) reference library.  JSONata is a very powerful, well-designed, and useful language that has made an impact on many projects.  This project leverages their outstanding work to extend that capability to Python and Rust and would not be possible without that project.  The implementation in Rust was strongly influenced by their implementation.  The 1600+ (1682/1682 passing for last build of this project) tests they created provided the scaffolding and validation for all of this project.  This project will continue to follow and be a derivative of the reference project as the JSONata reference library evolves.
 
-Release versions will follow the reference jsonata-js project major and minor release numbers, but not necessarily patches.  This will make it easier for adopters of this library to understand each release's JSONata API compatibility.  As an example, 2.2.7 should be compliant with 2.2.x jsonata-js tests, but may have fixes specific to this library.  If a patch release for jsonata-js is relevant for this project, it will be included in a patch release that may or may not follow the patch numbers of the upstream project.
+Release versions will follow the reference jsonata-js project major and minor release numbers, but not necessarily patches.  This will make it easier for adopters of this library to understand each release's JSONata API compatibility.  As an example, 2.2.8 should be compliant with 2.2.x jsonata-js tests, but may have fixes specific to this library.  If a patch release for jsonata-js is relevant for this project, it will be included in a patch release that may or may not follow the patch numbers of the upstream project.
 
 This project currently chooses not to implement async at this time, because it has limited value for most of the most common use-cases and the overhead of the async functionality would slow down synchronous use cases.  We focused on sync performance instead.
 
@@ -57,10 +57,10 @@ let result = Evaluator::new().evaluate(&ast, &data)?;
 ```toml
 # Cargo.toml
 [dependencies]
-jsonata-core = "2.2.7"          # pure Rust, no Python dependency
+jsonata-core = "2.2.8"          # pure Rust, no Python dependency
 
 # Optional: disable SIMD for constrained targets
-jsonata-core = { version = "2.2.7", default-features = false }
+jsonata-core = { version = "2.2.8", default-features = false }
 ```
 
 ---

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,8 +8,8 @@ jsonatapy is a high-performance Rust implementation of JSONata with Python bindi
 
 | Implementation | Language | Version | Description |
 |----------------|----------|---------|-------------|
-| **jsonatapy** | Rust + Python | 2.2.7 | This project (compiled Rust extension via PyO3) |
-| **jsonatapy** (rust-only) | Rust + Python | 2.2.7 | Same library, JSON string I/O path (bypasses Python object conversion) |
+| **jsonatapy** | Rust + Python | 2.2.8 | This project (compiled Rust extension via PyO3) |
+| **jsonatapy** (rust-only) | Rust + Python | 2.2.8 | Same library, JSON string I/O path (bypasses Python object conversion) |
 | **jsonata-js** | JavaScript | 2.1.0 | Reference implementation (Node.js v20.20.2) |
 | **jsonata-python** | Python | unknown | Pure Python implementation |
 | **jsonata-rs** | Rust | 0.3 | Pure Rust implementation (CLI benchmark, no Python overhead) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "jsonatapy"
-version = "2.2.7"
+version = "2.2.8"
 description = "High-performance Python/Rust implementation of JSONata query and transformation language"
 authors = [
     {name = "txjmb", email = "txjmb@users.noreply.github.com"}


### PR DESCRIPTION
Version bump, release notes, and one changelog repair.

## On the four-component version

You remembered a blocker, and it's real but narrower than "Rust or Python". I tested both:

```
Cargo.toml  version = "2.2.2.1"
  error: unexpected character '.' after patch version number

PEP 440     2.2.2.1  →  valid, sorts correctly
```

**Cargo alone is the blocker** — it enforces strict SemVer, which is exactly three numeric components. Python would accept a fourth happily. So aligning all four digits with jsonata-js would mean `jsonata-core 2.2.8` and `jsonatapy 2.2.2.8` — two version strings for one artifact, from one `maturin` build.

The workarounds don't hold up either: a pre-release suffix (`2.2.2-8`) sorts *before* `2.2.2`, and build metadata (`2.2.2+8`) is ignored by crates.io for ordering, so two releases differing only in it collide.

Staying three-component, which is what the README already documents:

> Release versions will follow the reference jsonata-js project major and minor release numbers, but not necessarily patches.

The reference patch level is pinned and CI-enforced anyway — the submodule pin, plus the signature and arity fixtures generated from it, fail the build if it drifts. A fourth digit would restate what those already guarantee.

## Release notes

The section opens with prose aimed at someone deciding whether to upgrade, organised by **class of change** with an explicit "you are exposed if" for each, rather than a feature list:

- boolean coercion of containers (broadest)
- `$formatNumber` producing different numbers
- sequence/null handling in paths
- stricter argument validation
- more permissive parsing in two places
- error codes
- things that used to fail and now work
- internals with no behavioural intent

The itemised entries follow underneath, unchanged.

## Changelog repair

The `### Deliberately not changed` heading I added with the base64 charset note landed **mid-`Fixed`**, which silently refiled every later entry under it — the null-as-value, `[]`/`[true]`, `#$i`, wildcard and signature fixes among them. It now sits after `Fixed` and holds only the entry it was written for.

## Gate

```
tests/python        23329 passed, 4 skipped, 0 xfailed
  reference suite   1686 passed
cargo test --release --features cli   all green
clippy -D warnings, fmt --check       clean
built wheel reports 2.2.8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)