### PR TITLE
chore(release): the four 2.2.8 commits that did not land in #143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.8] - 2026-08-25
 
-A conformance release. Almost everything here brings `jsonatapy` closer to the pinned
-jsonata-js (v2.2.2), and a fair amount of it **changes the answer** for expressions that
-already run today. If you are upgrading, the summary below is the part worth reading; the
-itemised entries follow.
+Primarily a conformance release, with documentation work on the Rust crate alongside it. Most
+of what follows brings `jsonatapy` closer to the pinned jsonata-js (v2.2.2), and a fair amount
+of it **changes the answer** for expressions that already run today. If you are upgrading, the
+summary below is the part worth reading; the itemised entries follow.
 
 ### What changed, and who it affects
 
@@ -82,6 +82,11 @@ generic errors now carry `T0410`, `D3061`, `D3110`, `D3137`, `D3138`, `D3139` or
 builtins that worked in direct calls but raised when passed to `$map`/`$filter` now behave
 identically either way.
 
+**Documentation.** The `jsonata-core` crate's examples now compile and are run as doctests
+rather than being marked `ignore`, docs.rs renders without the broken links five rustdoc
+warnings were producing, and the module list no longer advertises private modules. The Python
+package is classified Production/Stable rather than Beta.
+
 **Internals with no behavioural intent.** Builtin dispatch is now a single shared
 implementation rather than three partial copies, and the differential harness gained the
 ability to see distinctions it was previously blind to — `null` vs `undefined`, error codes,
@@ -96,8 +101,15 @@ first time. The one deliberate exception is base64's character set, documented b
 
 
 ### Added
+- The `jsonata-core` crate documentation now carries four compiling examples — quick start,
+  compile-once/evaluate-many, error handling, and host functions via `register_fn`. The
+  crate-level example was previously marked `rust,ignore`, so nothing verified it was correct;
+  `cargo test --doc` now runs 5 doctests.
 
 ### Changed
+- The published Python package is now classified `Development Status :: 5 - Production/Stable`.
+  It still read `4 - Beta` at full reference-suite parity, and that classifier is the only
+  signal the PyPI sidebar and downstream trend trackers read.
 - Every builtin that needs only its arguments is now implemented once, in `src/builtins.rs`,
   and shared by the compiled path and the tree-walker instead of being written out in each.
   Fifty-three builtins were spread across two dispatch sites: twenty-nine were implemented
@@ -118,6 +130,13 @@ first time. The one deliberate exception is base64's character set, documented b
 ### Removed
 
 ### Fixed
+- Five rustdoc warnings that rendered as broken links on docs.rs are gone. JSONata syntax in
+  doc comments — `[expr]`, `|location|update[,delete]|` — was being parsed as intra-doc links,
+  and `Rc<str>` as an unclosed HTML tag. `cargo doc` is now warning-free under both the default
+  features and `--all-features`.
+- The crate's documentation header said `jsonatapy` (the crate is `jsonata-core`), and its
+  module list advertised `datetime` and `signature` as public when both are private while
+  omitting the feature-gated `lazy` and `capi`.
 - A positional predicate that names the same index more than once now repeats the element, as
   jsonata-js does: `nums[[0,0]]` is `[10, 10]`, not `10`. The reference walks the selector array
   and pushes the item on every hit; we used an `any()`-style membership test, which can only ever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,17 @@ hiding real divergences, which is where most of this release came from.
 
 ### Compatibility
 
-All 1686 reference-suite cases pass, and the differential corpus (over 20,000 comparisons
-against jsonata-js across two engines and two input paths) has **no known divergences** for the
-first time. The one deliberate exception is base64's character set, documented below.
+The differential corpus — over 20,000 comparisons against jsonata-js across two engines and two
+input paths — has **no known divergences** for the first time. The one deliberate exception is
+base64's character set, documented below.
+
+The reference suite runs 1685 of its 1686 cases green, with one pinned as a known divergence
+(`$.7a` is `S0201` upstream and `S0213` here — both syntax errors, differing in *when* the step
+is validated). Worth stating plainly rather than quoting the pass count: 44 of its
+error-expecting cases still assert only that *something* was raised, because the errors we
+produce for them carry no JSONata code to compare, and 15 more specify an error object that is
+not inspected. That is [#144](https://github.com/txjmb/jsonata-core/issues/144), and it is
+mostly parser errors. It is a gap in what the suite verifies, not a set of known failures.
 
 
 ### Added
@@ -130,6 +138,13 @@ first time. The one deliberate exception is base64's character set, documented b
 ### Removed
 
 ### Fixed
+- The reference-suite harness compares error codes it previously ignored. `extract_error_code`
+  was anchored to the start of the message, so any coded error carrying a prefix — `"Runtime
+  error: D3030: ..."`, `"Parse error: Invalid syntax: S0209: ..."` — read as *uncoded*, and an
+  uncoded error is accepted for any expected code. 36 cases that emit exactly the right code
+  were passing without it ever being compared, and one emitting the wrong code passed the same
+  way. Now 228 of the 273 code-expecting cases are genuinely compared, up from 191.
+  ([#144](https://github.com/txjmb/jsonata-core/issues/144))
 - Five rustdoc warnings that rendered as broken links on docs.rs are gone. JSONata syntax in
   doc comments — `[expr]`, `|location|update[,delete]|` — was being parsed as intra-doc links,
   and `Rc<str>` as an unclosed HTML tag. `cargo doc` is now warning-free under both the default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,13 +99,16 @@ The differential corpus — over 20,000 comparisons against jsonata-js across tw
 input paths — has **no known divergences** for the first time. The one deliberate exception is
 base64's character set, documented below.
 
-The reference suite runs 1685 of its 1686 cases green, with one pinned as a known divergence
-(`$.7a` is `S0201` upstream and `S0213` here — both syntax errors, differing in *when* the step
-is validated). Worth stating plainly rather than quoting the pass count: 44 of its
-error-expecting cases still assert only that *something* was raised, because the errors we
-produce for them carry no JSONata code to compare, and 15 more specify an error object that is
-not inspected. That is [#144](https://github.com/txjmb/jsonata-core/issues/144), and it is
-mostly parser errors. It is a gap in what the suite verifies, not a set of known failures.
+All 1686 reference-suite cases pass, and each now runs through **both** evaluation engines —
+the suite previously ran only whichever the default resolved to, so the tree-walker was
+exercised by the differential corpus and nowhere else.
+
+Worth stating plainly rather than quoting the pass count: 43 of its error-expecting cases still
+assert only that *something* was raised, because the errors we produce for them carry no JSONata
+code to compare, and 15 more specify an error object that is not inspected. That is
+[#144](https://github.com/txjmb/jsonata-core/issues/144), and it is mostly parser errors. It is
+a gap in what the suite verifies, not a set of known failures — a test now pins the count so it
+cannot grow unnoticed.
 
 
 ### Added
@@ -138,6 +141,17 @@ mostly parser errors. It is a gap in what the suite verifies, not a set of known
 ### Removed
 
 ### Fixed
+- `$.7a` now raises `S0201`, not `S0213`. jsonata-js raises `S0213` ("literal value cannot be
+  used as a step") from a pass that runs *after* parsing, so an unexpected trailing token fails
+  the parse first; we raised it inline, before the trailing token was reached. Our `S0213` was
+  already right for `$.7` and `a.7` — only the ordering was wrong. A leftover token now also
+  carries `S0201`, the code the reference uses for it, instead of an uncoded "Expected end of
+  expression".
+- Every reference-suite case now runs through both evaluation engines, and the suite pins how
+  many of its error cases it cannot actually verify. At 2.2.7 four cases had the two engines
+  raising different errors, each accepted because both were errors and the check was loose.
+- The test reporter no longer crashes the run with an `INTERNALERROR` when a non-parametrized
+  test fails; it read `item.callspec` unguarded on the failure path.
 - The reference-suite harness compares error codes it previously ignored. `extract_error_code`
   was anchored to the start of the message, so any coded error carrying a prefix — `"Runtime
   error: D3030: ..."`, `"Parse error: Invalid syntax: S0209: ..."` — read as *uncoded*, and an

--- a/README.md
+++ b/README.md
@@ -12,9 +12,33 @@ JSONata implementation in Python, so the goal was to port JSONata to Rust (with 
 for Python) and see how fast it could go. The answer: faster than V8 for most expression
 workloads, and faster than the next pure-Rust implementation.  The rust versions are published on crates.io, and the python wheels on pypi.  There is also a command-line binary and Python command-line available (works great with uvx) for use in scripting.  The Python library is also usable in a command-line fashion, and a C-compatible library is available for those who want to easily use jsonata in C/C++.
 
-Many, many thanks to the incredible work of all the maintainers of the [JSONata](https://github.com/jsonata-js/jsonata) reference library.  JSONata is a very powerful, well-designed, and useful language that has made an impact on many projects.  This project leverages their outstanding work to extend that capability to Python and Rust and would not be possible without that project.  The implementation in Rust was strongly influenced by their implementation.  The 1600+ (1682/1682 passing for last build of this project) tests they created provided the scaffolding and validation for all of this project.  This project will continue to follow and be a derivative of the reference project as the JSONata reference library evolves.
+Many, many thanks to the incredible work of all the maintainers of the [JSONata](https://github.com/jsonata-js/jsonata) reference library.  JSONata is a very powerful, well-designed, and useful language that has made an impact on many projects.  This project leverages their outstanding work to extend that capability to Python and Rust and would not be possible without that project.  The implementation in Rust was strongly influenced by their implementation.  The 1600+ (1686/1686 passing for last build of this project) tests they created provided the scaffolding and validation for all of this project.  This project will continue to follow and be a derivative of the reference project as the JSONata reference library evolves.
 
 Release versions will follow the reference jsonata-js project major and minor release numbers, but not necessarily patches.  This will make it easier for adopters of this library to understand each release's JSONata API compatibility.  As an example, 2.2.8 should be compliant with 2.2.x jsonata-js tests, but may have fixes specific to this library.  If a patch release for jsonata-js is relevant for this project, it will be included in a patch release that may or may not follow the patch numbers of the upstream project.
+
+> ### ⚠️ Upgrading to 2.2.8 — please test before you deploy
+>
+> 2.2.8 is primarily a **conformance** release: it corrects a number of places where this
+> library disagreed with the jsonata-js reference. Most of those corrections **change the
+> result** of expressions that already run today, so an upgrade is not guaranteed to be
+> drop-in.
+>
+> The areas most likely to affect you:
+>
+> - **Boolean coercion of containers.** A one-element array holding a falsy value — `[0]`,
+>   `[""]`, `[false]`, `[null]` — is now falsy, as the reference has it. This affects `? :`,
+>   `and`, `or`, `$not`, filter predicates and `$filter`.
+> - **`$formatNumber` rounds half-to-even.** `$formatNumber(12.345, "#,##0.00")` was `"12.35"`
+>   and is now `"12.34"`.
+> - **Sequence and null handling in paths**, including `*`, `#$i`, `[]` versus `[true]`, and
+>   how an explicit `null` behaves in object construction.
+> - **Stricter argument validation** on six builtins that previously validated nothing, and
+>   **more accurate error codes** across roughly 112 error shapes.
+>
+> Every one of these moves *toward* the reference implementation — but if your expressions were
+> written against the old behaviour, they may need review. **Read the
+> [release notes](CHANGELOG.md) before upgrading**; the 2.2.8 section opens with a summary of
+> what changed and who is affected by each item, ahead of the detailed entries.
 
 This project currently chooses not to implement async at this time, because it has limited value for most of the most common use-cases and the overhead of the async functionality would slow down synchronous use cases.  We focused on sync performance instead.
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -743,6 +743,15 @@ pub struct Parser {
     /// to a deeper node every iteration without a new recursive call).
     /// Both must be bounded by this one counter; see `MAX_PARSE_DEPTH`.
     depth: usize,
+    /// An S0213 ("literal value cannot be used as a step") noticed while
+    /// parsing, held until the whole expression has parsed.
+    ///
+    /// jsonata-js raises S0213 from `processAST`, a pass that runs after
+    /// parsing, so a *parse* error beats it: `$.7a` is S0201 for the
+    /// unexpected trailing `a`, even though the `7` step is also invalid.
+    /// Raising it inline made us answer S0213 there. Deferring restores the
+    /// ordering without moving the check itself into a post-parse pass.
+    pending_literal_step: Option<String>,
 }
 
 impl Parser {
@@ -753,6 +762,7 @@ impl Parser {
             lexer,
             current_token,
             depth: 0,
+            pending_literal_step: None,
         })
     }
 
@@ -1313,23 +1323,22 @@ impl Parser {
 
                         // S0213: The literal value cannot be used as a step within a path expression
                         // Numbers, booleans (true/false), and null cannot be path steps
-                        match &rhs {
-                            AstNode::Number(n) => {
-                                return Err(ParserError::InvalidSyntax(
-                                    format!("S0213: The literal value {} cannot be used as a step within a path expression", n),
+                        let literal_step = match &rhs {
+                            AstNode::Number(n) => Some(n.to_string()),
+                            AstNode::Boolean(b) => Some(b.to_string()),
+                            AstNode::Null => Some("null".to_string()),
+                            _ => None,
+                        };
+                        if let Some(literal) = literal_step {
+                            // Recorded, not raised: see `pending_literal_step`.
+                            // The first one wins, matching a post-parse pass
+                            // walking the tree in order.
+                            if self.pending_literal_step.is_none() {
+                                self.pending_literal_step = Some(format!(
+                                    "S0213: The literal value {} cannot be used as a step within a path expression",
+                                    literal
                                 ));
                             }
-                            AstNode::Boolean(b) => {
-                                return Err(ParserError::InvalidSyntax(
-                                    format!("S0213: The literal value {} cannot be used as a step within a path expression", b),
-                                ));
-                            }
-                            AstNode::Null => {
-                                return Err(ParserError::InvalidSyntax(
-                                    "S0213: The literal value null cannot be used as a step within a path expression".to_string(),
-                                ));
-                            }
-                            _ => {}
                         }
 
                         match rhs {
@@ -1793,11 +1802,18 @@ impl Parser {
     pub fn parse(&mut self) -> Result<AstNode, ParserError> {
         let ast = self.parse_expression(0)?;
 
+        // A token left over is S0201 in jsonata-js -- its general "syntax
+        // error at this token" -- and it beats a deferred S0213, which the
+        // reference only reaches in its post-parse pass.
         if self.current_token != Token::Eof {
-            return Err(ParserError::Expected {
-                expected: "end of expression".to_string(),
-                found: format!("{:?}", self.current_token),
-            });
+            return Err(ParserError::InvalidSyntax(format!(
+                "S0201: Syntax error: {:?}",
+                self.current_token
+            )));
+        }
+
+        if let Some(message) = self.pending_literal_step.take() {
+            return Err(ParserError::InvalidSyntax(message));
         }
 
         Ok(ast)

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -102,9 +102,13 @@ class ReferenceSuiteReporter:
                     self.by_group.setdefault(group, {"passed": 0, "failed": 0, "skipped": 0})
                     self.by_group[group]["failed"] += 1
 
-                # Track failed test details
-                test_id = item.callspec.params.get("test_id", "unknown")
-                expr = item.callspec.params.get("spec", {}).get("expr", "unknown")
+                # Track failed test details. Guarded: the branch above is, and
+                # this one was not, so any *non-parametrized* failing test in
+                # this module crashed the reporter with an INTERNALERROR
+                # instead of reporting the failure.
+                params = item.callspec.params if hasattr(item, "callspec") else {}
+                test_id = params.get("test_id", item.nodeid)
+                expr = params.get("spec", {}).get("expr", "unknown")
                 self.failed_tests.append(
                     {
                         "test_id": test_id,

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -83,17 +83,42 @@ def extract_error_code(error_msg: str) -> str | None:
     Returns:
         The error code if found, None otherwise
     """
-    # Error format: "T2001: Unknown function: foo"
-    match = re.match(r"^([TDUS]\d{4}):", str(error_msg))
+    # Not anchored. Our messages are not uniformly "CODE: text" -- many carry a
+    # prefix ("Runtime error: D3030: ...", "Parse error: Invalid syntax:
+    # S0209: ..."). An anchored match read all of those as *uncoded*, and the
+    # caller accepts an uncoded error for any expected code, so 36 cases that
+    # emit exactly the right code were passing without it ever being compared
+    # -- and one case emitting the WRONG code passed the same way.
+    match = re.search(r"\b([TDUS]\d{4})\b", str(error_msg))
     return match.group(1) if match else None
+
+
+# Reference cases that are known to diverge, each with the reason. Marked
+# xfail(strict), so one that starts passing fails the suite and has to be
+# removed from here. Empty is the goal.
+KNOWN_DIVERGENCES = {
+    "token-conversion/case002": (
+        "`$.7a` is S0201 upstream and S0213 here. Both are syntax errors and our "
+        "S0213 is correct for `$.7` and `a.7`; the difference is *ordering*. "
+        "jsonata-js raises S0213 from processAST, a post-parse pass, so the "
+        "unexpected trailing token `a` fails the parse first. We validate the step "
+        "during DOT parsing, before the trailing token is ever reached. Matching it "
+        "means deferring the check to a post-parse pass -- see the parser error-code "
+        "issue."
+    ),
+}
 
 
 def _build_pytest_params(
     cases: list[tuple[str, str, dict[str, Any]]],
 ) -> list["pytest.mark.structures.ParameterSet"]:
-    return [
-        pytest.param(test_id, group_name, spec, id=test_id) for test_id, group_name, spec in cases
-    ]
+    params = []
+    for test_id, group_name, spec in cases:
+        marks = []
+        if test_id in KNOWN_DIVERGENCES:
+            marks.append(pytest.mark.xfail(strict=True, reason=KNOWN_DIVERGENCES[test_id]))
+        params.append(pytest.param(test_id, group_name, spec, id=test_id, marks=marks))
+    return params
 
 
 # Load all test cases

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+import jsonatapy
 import pytest
 
 # Load all datasets once at module level
@@ -95,18 +96,8 @@ def extract_error_code(error_msg: str) -> str | None:
 
 # Reference cases that are known to diverge, each with the reason. Marked
 # xfail(strict), so one that starts passing fails the suite and has to be
-# removed from here. Empty is the goal.
-KNOWN_DIVERGENCES = {
-    "token-conversion/case002": (
-        "`$.7a` is S0201 upstream and S0213 here. Both are syntax errors and our "
-        "S0213 is correct for `$.7` and `a.7`; the difference is *ordering*. "
-        "jsonata-js raises S0213 from processAST, a post-parse pass, so the "
-        "unexpected trailing token `a` fails the parse first. We validate the step "
-        "during DOT parsing, before the trailing token is ever reached. Matching it "
-        "means deferring the check to a post-parse pass -- see the parser error-code "
-        "issue."
-    ),
-}
+# removed from here. Empty is the goal, and currently the state.
+KNOWN_DIVERGENCES: dict[str, str] = {}
 
 
 def _build_pytest_params(
@@ -133,9 +124,81 @@ print(f"Loaded {len(test_cases)} test cases")
 print(f"{'=' * 70}\n")
 
 
+# How many reference cases the suite currently cannot actually verify: we raise
+# an error carrying no JSONata code (and an uncoded error is accepted for any
+# expected code), or the case specifies an error object nothing inspects.
+#
+# A ceiling, not a target. It only ever goes down -- see #144. The point of
+# asserting it is that "1686 passing" says less than it sounds for these cases,
+# and a new uncoded error would otherwise slip in unnoticed.
+UNVERIFIED_ERROR_CEILING = 58
+
+
+@pytest.mark.reference
+def test_unverified_error_cases_do_not_grow():
+    """Pin how much of the suite asserts only that *something* was raised."""
+    unverified = []
+    for test_id, _group, spec in test_cases:
+        if "code" not in spec and "error" not in spec:
+            continue
+        expr = spec.get("expr")
+        if expr is None:
+            continue
+        if "data" in spec:
+            data = spec["data"]
+        elif "dataset" in spec:
+            data = None if spec["dataset"] is None else DATASETS.get(spec["dataset"])
+        else:
+            data = None
+        bindings = spec.get("bindings", {})
+        try:
+            compiled = jsonatapy.compile(expr)
+            if data is None:
+                (
+                    compiled.evaluate_json_or_none(None, bindings)
+                    if bindings
+                    else compiled.evaluate_json_or_none(None)
+                )
+            else:
+                compiled.evaluate(data, bindings) if bindings else compiled.evaluate(data)
+        except Exception as exc:  # any raise is what these cases expect
+            if "code" not in spec or extract_error_code(str(exc)) is None:
+                unverified.append(test_id)
+
+    assert len(unverified) <= UNVERIFIED_ERROR_CEILING, (
+        f"{len(unverified)} reference cases assert only that something was raised, "
+        f"up from {UNVERIFIED_ERROR_CEILING}. A new error was added without a JSONata "
+        f"code, or an existing one lost its code. See #144.\n"
+        + "\n".join(f"  {t}" for t in unverified[:20])
+    )
+    if len(unverified) < UNVERIFIED_ERROR_CEILING:
+        pytest.fail(
+            f"Only {len(unverified)} cases are now unverified, down from "
+            f"{UNVERIFIED_ERROR_CEILING}. Lower UNVERIFIED_ERROR_CEILING to "
+            f"{len(unverified)} to lock the improvement in."
+        )
+
+
+@pytest.fixture(params=[False, True], ids=["vm_preferred", "forced_tree_walker"])
+def engine(request):
+    """Run every reference case through both evaluation paths.
+
+    The suite ran only whatever the default resolved to, so the tree-walker was
+    exercised by the differential corpus and nowhere else. Nothing here would
+    have caught the two engines answering a reference case differently -- and
+    at 2.2.7 four of them did, each accepted because both answers were errors
+    and the error check was loose. Auditing found no engine-only failure, but
+    "true when someone last checked by hand" is not a guarantee; this makes it
+    one.
+    """
+    jsonatapy._set_force_tree_walker(request.param)
+    yield request.param
+    jsonatapy._set_force_tree_walker(False)
+
+
 @pytest.mark.reference
 @pytest.mark.parametrize("test_id,group_name,spec", test_params)
-def test_reference_suite(test_id: str, group_name: str, spec: dict[str, Any]):
+def test_reference_suite(test_id: str, group_name: str, spec: dict[str, Any], engine: bool):
     """
     Run a single test case from the reference JSONata suite.
 


### PR DESCRIPTION
**#143 merged with only its first commit.** `main` carries the version bump and the initial release notes, but four later commits on the same branch are not on `main`:

| commit | what |
|---|---|
| `6f59abf` | changelog entries for the Rust documentation work (`ab68c7b`) |
| `c94ae29` | reference-suite error-code comparison + the ratchet |
| `857f978` | **the `S0213`/`S0201` parser fix** |
| `7b1c81d` | the README upgrade note |

`main` is currently versioned **2.2.8** but is missing the parser fix and both harness improvements. Verified against `origin/main`:

```
version on main            2.2.8
changelog 2.2.8 section    present
parser fix (S0213 defer)   ABSENT
engine fixture (both paths) ABSENT
README upgrade note        ABSENT
```

Cutting a release from `main` as it stands would ship a 2.2.8 that does not match its own release notes.

## What these four add

**`857f978` — the parser fix.** `$.7a` raises `S0201`, not `S0213`. jsonata-js raises `S0213` from a pass that runs *after* parsing, so an unexpected trailing token fails the parse first; we raised it inline. A leftover token also now carries `S0201` rather than an uncoded "Expected end of expression". This was the last known reference-suite divergence — `KNOWN_DIVERGENCES` is empty with it.

**`c94ae29` — the harness.** `extract_error_code` was anchored to the start of the message, so any coded error carrying a prefix read as *uncoded* — and an uncoded error is accepted for any expected code. 36 cases emitting exactly the right code were never having it compared, and one emitting the wrong code passed the same way. Also parametrises every reference case over **both engines** (1686 → 3372) and adds a ratchet on how many error cases the suite cannot verify. Includes a fix for an unguarded `item.callspec` in `conftest.py` that crashed the whole run with `INTERNALERROR` whenever a non-parametrized test failed.

**`6f59abf`** records the Rust doc work already in this range — doctests, docs.rs warnings, the PyPI classifier — which the release section had omitted.

**`7b1c81d`** adds the README note asking people to test before deploying, since several changes alter results for expressions that already run.

## Gate

```
tests/python        25016 passed, 4 skipped, 0 xfailed
  reference suite   3372 (1686 × 2 engines)
cargo test --release --features cli   all green
clippy -D warnings, fmt --check       clean
ruff check / format                   clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)