### PR TITLE
fix: D3140 for malformed URLs, and stop leaking a codec error — part of #144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,16 @@ cannot grow unnoticed.
 ### Removed
 
 ### Fixed
+- `$decodeUrl` and `$decodeUrlComponent` report `D3140` on malformed input, naming the function
+  and quoting the value as jsonata-js does, instead of an uncoded "Invalid percent-encoded URL".
+- An expression containing an unpaired surrogate no longer leaks a raw `UnicodeEncodeError`. A
+  Python `str` can hold one and a Rust `String` cannot, so such an expression cannot cross the
+  boundary to be parsed at all; PyO3's codec error now becomes a `ValueError` naming the
+  surrogate and its position, so the library keeps a single error type. (`$encodeUrl` on a lone
+  surrogate is `D3140` upstream; there is no point at which we could raise it, since the
+  expression never parses.)
+- The reference suite compares the `code` of cases that specify an error *object*, not just
+  those with a bare `code` field. Nothing about those 15 was checked before.
 - `$.7a` now raises `S0201`, not `S0213`. jsonata-js raises `S0213` ("literal value cannot be
   used as a step") from a pass that runs *after* parsing, so an unexpected trailing token fails
   the parse first; we raised it inline, before the trailing token was reached. Our `S0213` was

--- a/python/jsonatapy/__init__.py
+++ b/python/jsonatapy/__init__.py
@@ -507,7 +507,20 @@ def compile(
         is more efficient than calling `evaluate()` repeatedly with
         the same expression string.
     """
-    return JsonataExpression(_compile(expression, timeout, max_stack_depth, max_sequence_length))
+    try:
+        return JsonataExpression(
+            _compile(expression, timeout, max_stack_depth, max_sequence_length)
+        )
+    except UnicodeEncodeError as exc:
+        # A Python str may hold an unpaired surrogate; a Rust String may not,
+        # so such an expression cannot cross the boundary at all and PyO3
+        # raises a bare UnicodeEncodeError. Re-raise as ValueError so the
+        # library keeps one error type, and say why rather than leaking a
+        # codec message.
+        raise ValueError(
+            "Expression contains an unpaired surrogate and cannot be compiled: "
+            f"{exc.object[exc.start : exc.end]!r} at position {exc.start}"
+        ) from exc
 
 
 def evaluate(

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2028,9 +2028,12 @@ pub mod encoding {
     pub fn decode_url_component(s: &str) -> Result<JValue, FunctionError> {
         match percent_encoding::percent_decode_str(s).decode_utf8() {
             Ok(decoded) => Ok(JValue::string(decoded.to_string())),
-            Err(_) => Err(FunctionError::RuntimeError(
-                "Invalid percent-encoded string".to_string(),
-            )),
+            // jsonata-js reports every malformed-URL failure as D3140, naming
+            // the function and quoting the offending value.
+            Err(_) => Err(FunctionError::RuntimeError(format!(
+                "D3140: Malformed URL passed to ${}(): \"{}\"",
+                "decodeUrlComponent", s
+            ))),
         }
     }
 
@@ -2047,9 +2050,12 @@ pub mod encoding {
     pub fn decode_url(s: &str) -> Result<JValue, FunctionError> {
         match percent_encoding::percent_decode_str(s).decode_utf8() {
             Ok(decoded) => Ok(JValue::string(decoded.to_string())),
-            Err(_) => Err(FunctionError::RuntimeError(
-                "Invalid percent-encoded URL".to_string(),
-            )),
+            // jsonata-js reports every malformed-URL failure as D3140, naming
+            // the function and quoting the offending value.
+            Err(_) => Err(FunctionError::RuntimeError(format!(
+                "D3140: Malformed URL passed to ${}(): \"{}\"",
+                "decodeUrl", s
+            ))),
         }
     }
 }

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -97,6 +97,13 @@ def extract_error_code(error_msg: str) -> str | None:
 # Reference cases that are known to diverge, each with the reason. Marked
 # xfail(strict), so one that starts passing fails the suite and has to be
 # removed from here. Empty is the goal, and currently the state.
+# Reference cases that are known to diverge, each with the reason. Marked
+# xfail(strict), so one that starts passing fails the suite and has to be
+# removed from here. Empty is the goal, and currently the state.
+#
+# Note what does NOT belong here: a case we satisfy only because our error
+# carries no code for the suite to compare. That is not a known divergence, it
+# is an unverified case -- counted by UNVERIFIED_ERROR_CEILING above.
 KNOWN_DIVERGENCES: dict[str, str] = {}
 
 
@@ -131,7 +138,7 @@ print(f"{'=' * 70}\n")
 # A ceiling, not a target. It only ever goes down -- see #144. The point of
 # asserting it is that "1686 passing" says less than it sounds for these cases,
 # and a new uncoded error would otherwise slip in unnoticed.
-UNVERIFIED_ERROR_CEILING = 58
+UNVERIFIED_ERROR_CEILING = 45
 
 
 @pytest.mark.reference
@@ -162,7 +169,12 @@ def test_unverified_error_cases_do_not_grow():
             else:
                 compiled.evaluate(data, bindings) if bindings else compiled.evaluate(data)
         except Exception as exc:  # any raise is what these cases expect
-            if "code" not in spec or extract_error_code(str(exc)) is None:
+            # Unverified means *we* gave the suite nothing to compare: our
+            # error carries no JSONata code. Cases specifying an error object
+            # count the same way -- only its `code` is compared, so an uncoded
+            # error satisfies them too.
+            wants_code = spec.get("code") or spec.get("error", {}).get("code")
+            if wants_code and extract_error_code(str(exc)) is None:
                 unverified.append(test_id)
 
     assert len(unverified) <= UNVERIFIED_ERROR_CEILING, (
@@ -322,10 +334,18 @@ def test_reference_suite(test_id: str, group_name: str, spec: dict[str, Any], en
                 )
 
         elif has_error_obj:
-            # Expected an error with specific error object
-            # TODO: Validate full error object structure
-            # For now, just accept that an error occurred
-            pass
+            # The case gives an error *object*. Only its `code` is compared;
+            # the other fields (functionName, value, token) are not modelled
+            # here. Previously nothing was compared at all.
+            expected_code = spec["error"].get("code")
+            actual_code = extract_error_code(error_msg)
+            if expected_code and actual_code and actual_code != expected_code:
+                pytest.fail(
+                    f"Error code mismatch for expression: {expr}\n"
+                    f"Expected code: {expected_code}\n"
+                    f"Actual code:   {actual_code}\n"
+                    f"Error message: {error_msg}"
+                )
 
         elif has_result or has_undefined:
             # Unexpected error when expecting successful result


### PR DESCRIPTION
One commit, landing after #146 merged. (Same timing as before: the merge snapshots the branch, so anything pushed afterwards needs its own PR.)

Four reference cases specify `D3140` and none of them got it, because the suite never inspected an `error` object at all.

## Fixed

**`$decodeUrl` / `$decodeUrlComponent`** now carry `D3140` with the reference's own message shape — naming the function and quoting the value — instead of an uncoded `"Invalid percent-encoded URL"`.

## Not fixed, because it cannot be

The two **encode** cases are a different problem. Their expression contains an unpaired surrogate (`U+D800`): a Python `str` can hold one, a Rust `String` cannot. The expression never crosses the boundary to be parsed, so there is no point at which `$encodeUrl` could raise `D3140`.

What *was* wrong is that PyO3's raw `UnicodeEncodeError` escaped to the caller — **not even a `ValueError`**, so anyone catching the library's documented error type missed it entirely:

```
before:  UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 12
after:   ValueError: Expression contains an unpaired surrogate and cannot be
                     compiled: '\ud800' at position 12
```

## Harness

The error-object branch compares the code now. **11 of the 15 already matched**, which is why enabling it was nearly free; the 4 that didn't are the URL cases above.

That also corrected the ratchet's definition — it counted an error-object case as unverified because the spec has no top-level `code` key, when the real question is whether *we* emit a code for the suite to compare.

```
unverified cases:  58 → 45
```

## One thing deliberately not done

I did **not** pin the two surrogate cases as known divergences. They pass — because our error carries no code and the loose branch accepts that — so marking them `xfail(strict)` made them fail as XPASS. They are *unverified*, not *divergent*, and the ratchet is where they belong. Worth stating because the distinction is easy to blur: "we satisfy this case" and "this case checks us" are not the same claim.

## Gate

```
tests/python        25016 passed, 4 skipped, 0 xfailed
cargo test --release --features cli   all green
clippy -D warnings, fmt --check       clean
ruff check / format                   clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)