### PR TITLE
fix: carry JSONata error codes through the evaluator and parser — #144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Nine more evaluator errors carry their JSONata code: `$sqrt` of a negative number is `D3060`,
+  `$power` overflowing is `D3061`, the single-argument `$sort` on mixed types is `D3070`,
+  `$single` matching more than one value is `D3138`, a non-string object key is `T1003`, a
+  non-function right side of `~>` is `T2006`, and `$split` given a matcher function that does
+  not produce the expected structure is `T1010`. Calling a function without its `$` splits the
+  way jsonata-js splits it: a name that *is* a builtin gets `T1005` with the "did you mean
+  `$name`?" suggestion, anything else gets `T1006`.
+  ([#144](https://github.com/txjmb/jsonata-core/issues/144))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Parse errors carry their JSONata code. Unterminated strings are `S0101`, unsupported escapes
+  `S0103`, a malformed `\u` escape `S0104`, an unterminated backquoted name `S0105`, a wrong
+  token `S0202`, running out of input while expecting one `S0203`, an unknown operator `S0204`,
+  an unexpected end of expression `S0207`, and a symbol used where an operand belongs `S0211`.
+  Previously all of these were uncoded prose, so callers branching on error codes could not
+  distinguish a syntax error from any other failure.
+  ([#144](https://github.com/txjmb/jsonata-core/issues/144))
 - Nine more evaluator errors carry their JSONata code: `$sqrt` of a negative number is `D3060`,
   `$power` overflowing is `D3061`, the single-argument `$sort` on mixed types is `D3070`,
   `$single` matching more than one value is `D3138`, a non-string object key is `T1003`, a

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3654,7 +3654,7 @@ impl Evaluator {
                                     continue;
                                 }
                                 return Err(EvaluatorError::TypeError(format!(
-                                    "Object key must be a string, got: {:?}",
+                                    "T1003: Key in object structure must evaluate to a string; got: {:?}",
                                     other
                                 )));
                             }
@@ -6706,7 +6706,7 @@ impl Evaluator {
                 }
                 _ => {
                     return Err(EvaluatorError::TypeError(
-                        "Right side of ~> must be a function call or function reference"
+                        "T2006: The right side of the function application operator ~> must be a function"
                             .to_string(),
                     ));
                 }
@@ -7180,10 +7180,20 @@ impl Evaluator {
         // If the function was called without $ prefix and it's not a stored lambda,
         // it's an error (unknown function without $ prefix)
         if !is_builtin && name != "__lambda__" {
-            return Err(EvaluatorError::ReferenceError(format!(
-                "Unknown function: {}",
-                name
-            )));
+            // Reached only for a call written WITHOUT the `$`. jsonata-js
+            // separates the two cases: a name that is a builtin was almost
+            // certainly missing its sigil, and gets T1005 with the suggestion;
+            // anything else is T1006.
+            return Err(if self.is_builtin_function(name) {
+                EvaluatorError::ReferenceError(format!(
+                    "T1005: Attempted to invoke a non-function. Did you mean ${}?",
+                    name
+                ))
+            } else {
+                EvaluatorError::ReferenceError(
+                    "T1006: Attempted to invoke a non-function".to_string(),
+                )
+            });
         }
 
         // Special handling for $exists function
@@ -8283,7 +8293,8 @@ impl Evaluator {
                         )),
                         1 => Ok(matches.into_iter().next().unwrap()),
                         count => Err(EvaluatorError::EvaluationError(format!(
-                            "single() predicate matches {} values (expected exactly 1)",
+                            "D3138: The $single() function expected exactly 1 matching result.  \
+                             Instead it matched more. ({} values)",
                             count
                         ))),
                     }
@@ -8359,8 +8370,10 @@ impl Evaluator {
             }
             "eval" => self.eval_from_values(&evaluated_args, data),
 
+            // `$notreal(1)` -- written with the sigil, so no "did you mean"
+            // suggestion applies; jsonata-js calls this T1006.
             _ => Err(EvaluatorError::ReferenceError(format!(
-                "Unknown function: {}",
+                "T1006: Attempted to invoke a non-function: ${}",
                 name
             ))),
         }
@@ -9683,7 +9696,15 @@ impl Evaluator {
             Err(e) => {
                 // D3121 is the error code for evaluation errors in $eval
                 let err_msg = e.to_string();
-                if err_msg.starts_with("D3121") || err_msg.contains("Unknown function") {
+                // An unknown function inside $eval is D3121, not the T100x the
+                // inner evaluation produced. Matched on the codes rather than
+                // on the prose it used to say ("Unknown function: x"), which
+                // is exactly the coupling that broke when those messages
+                // gained their JSONata codes.
+                if err_msg.starts_with("D3121")
+                    || err_msg.contains("T1005")
+                    || err_msg.contains("T1006")
+                {
                     Err(EvaluatorError::EvaluationError(format!(
                         "D3121: {}",
                         err_msg

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -471,12 +471,17 @@ pub mod string {
             return Ok(JValue::array(result));
         }
 
-        // Handle string separator
+        // Handle string separator. The signature `<s-(sf)n?:a<s>>` admits a
+        // string or a function, and the regex/function branch is handled
+        // above, so anything left here is a plain function used as a matcher
+        // that did not produce the expected structure -- T1010 in jsonata-js.
         let sep = match separator {
             JValue::String(s) => &**s,
             _ => {
                 return Err(FunctionError::TypeError(
-                    "split() requires string arguments".to_string(),
+                    "T1010: The matcher function argument passed to function $split does not \
+                     return the correct object structure"
+                        .to_string(),
                 ))
             }
         };
@@ -1008,9 +1013,10 @@ pub mod numeric {
     /// $sqrt(number) - Square root
     pub fn sqrt(n: f64) -> Result<JValue, FunctionError> {
         if n < 0.0 {
-            return Err(FunctionError::ArgumentError(
-                "Cannot take square root of negative number".to_string(),
-            ));
+            return Err(FunctionError::ArgumentError(format!(
+                "D3060: The sqrt function cannot be applied to a negative number: {}",
+                n
+            )));
         }
         Ok(JValue::Number(n.sqrt()))
     }
@@ -1019,9 +1025,11 @@ pub mod numeric {
     pub fn power(base: f64, exponent: f64) -> Result<JValue, FunctionError> {
         let result = base.powf(exponent);
         if result.is_nan() || result.is_infinite() {
-            return Err(FunctionError::RuntimeError(
-                "Power operation resulted in invalid number".to_string(),
-            ));
+            return Err(FunctionError::RuntimeError(format!(
+                "D3061: The power function has resulted in a value that cannot be \
+                 represented as a JSON number: base={}, exponent={}",
+                base, exponent
+            )));
         }
         Ok(JValue::Number(result))
     }
@@ -1757,7 +1765,10 @@ pub mod array {
             // scalar into a singleton before we get here.
         } else {
             return Err(FunctionError::TypeError(
-                "sort() requires all elements to be of the same comparable type".to_string(),
+                "D3070: The single argument form of the sort function can only be applied to an \
+                 array of strings or an array of numbers.  Use the second argument to specify a \
+                 comparison function"
+                    .to_string(),
             ));
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,12 +7,58 @@ use crate::ast::{AstNode, BinaryOp, PathStep, Stage, UnaryOp};
 use thiserror::Error;
 
 /// Parser errors
+/// The JSONata code for a token that turned up where an operand was expected.
+///
+/// jsonata-js splits this two ways: a *recognised* symbol used in prefix
+/// position is S0211 ("cannot be used as a unary operator"), while something
+/// that is not an operator at all is S0204 ("Unknown operator"). End of input
+/// is neither -- it is S0207.
+fn unexpected_token_message(token: &str) -> String {
+    if token == "Eof" {
+        return "S0207: Unexpected end of expression".to_string();
+    }
+    // A named token variant (`RightParen`, `GreaterThan`, `At`, `Colon`, ...)
+    // is a symbol the lexer knows; a bare punctuation character is not.
+    if token.chars().next().is_some_and(char::is_alphabetic) {
+        format!("S0211: The symbol {token} cannot be used as a unary operator")
+    } else {
+        format!("S0204: Unknown operator: {token}")
+    }
+}
+
+/// `\u` needs four hex digits (S0104); any other escape is simply unsupported
+/// (S0103).
+fn invalid_escape_message(seq: &str) -> String {
+    if seq.starts_with('u') || seq.starts_with("\\u") {
+        "S0104: The escape sequence \\u must be followed by 4 hex digits".to_string()
+    } else {
+        format!(
+            "S0103: Unsupported escape sequence: \\{}",
+            seq.trim_start_matches('\\')
+        )
+    }
+}
+
+/// Running out of input while expecting something is S0203; finding the wrong
+/// thing is S0202. A missing *parameter name* is its own code, S0208.
+fn expected_message(expected: &str, found: &str) -> String {
+    if expected == "parameter name" {
+        return "S0208: Parameter of function definition must be a variable name (start with $)"
+            .to_string();
+    }
+    if found == "Eof" {
+        format!("S0203: Expected {expected} before end of expression")
+    } else {
+        format!("S0202: Expected {expected}, got {found}")
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ParserError {
-    #[error("Unexpected token: {0}")]
+    #[error("{}", unexpected_token_message(.0))]
     UnexpectedToken(String),
 
-    #[error("Unexpected end of expression")]
+    #[error("S0207: Unexpected end of expression")]
     UnexpectedEnd,
 
     #[error("Invalid syntax: {0}")]
@@ -21,19 +67,19 @@ pub enum ParserError {
     #[error("Invalid number: {0}")]
     InvalidNumber(String),
 
-    #[error("Unclosed string literal")]
+    #[error("S0101: String literal must be terminated by a matching quote")]
     UnclosedString,
 
-    #[error("Invalid escape sequence: {0}")]
+    #[error("{}", invalid_escape_message(.0))]
     InvalidEscape(String),
 
     #[error("Unclosed comment")]
     UnclosedComment,
 
-    #[error("Unclosed backtick name")]
+    #[error("S0105: Quoted property name must be terminated with a backquote (`)")]
     UnclosedBacktick,
 
-    #[error("Expected {expected}, found {found}")]
+    #[error("{}", expected_message(expected, found))]
     Expected { expected: String, found: String },
 
     /// A JSONata-spec-coded parse error (S0214-S0217 for the %/@ operators).
@@ -78,8 +124,52 @@ mod parser_error_display_message_tests {
 
     #[test]
     fn uncoded_error_gets_parse_error_prefix() {
-        let e = ParserError::UnexpectedToken("foo".to_string());
-        assert_eq!(e.display_message(), "Parse error: Unexpected token: foo");
+        // `InvalidNumber` is one of the variants that still carries no JSONata
+        // code. It used to be `UnexpectedToken`, which now always produces one
+        // (S0204/S0207/S0211) and so no longer exercises the uncoded path.
+        let e = ParserError::InvalidNumber("1e999".to_string());
+        assert_eq!(e.display_message(), "Parse error: Invalid number: 1e999");
+    }
+
+    /// The variants that gained codes render them *inside* the message, so the
+    /// `Parse error:` prefix still applies -- `display_message` only strips the
+    /// prefix for `Coded`, which carries its code structurally.
+    #[test]
+    fn variant_derived_codes_appear_in_the_message() {
+        for (error, expected) in [
+            (
+                ParserError::UnexpectedToken("Eof".to_string()),
+                "Parse error: S0207: Unexpected end of expression",
+            ),
+            (
+                ParserError::UnexpectedToken("At".to_string()),
+                "Parse error: S0211: The symbol At cannot be used as a unary operator",
+            ),
+            (
+                ParserError::UnexpectedToken("!".to_string()),
+                "Parse error: S0204: Unknown operator: !",
+            ),
+            (
+                ParserError::UnclosedString,
+                "Parse error: S0101: String literal must be terminated by a matching quote",
+            ),
+            (
+                ParserError::Expected {
+                    expected: "RightParen".to_string(),
+                    found: "Eof".to_string(),
+                },
+                "Parse error: S0203: Expected RightParen before end of expression",
+            ),
+            (
+                ParserError::Expected {
+                    expected: "RightBracket".to_string(),
+                    found: "Colon".to_string(),
+                },
+                "Parse error: S0202: Expected RightBracket, got Colon",
+            ),
+        ] {
+            assert_eq!(error.display_message(), expected);
+        }
     }
 }
 

--- a/tests/python/test_mcp_server.py
+++ b/tests/python/test_mcp_server.py
@@ -96,7 +96,13 @@ async def test_evaluate_batch_compile_error_is_not_double_prefixed() -> None:
             "evaluate_batch",
             {"expressions": ["a["], "data": "{}"},
         )
-        assert result.data[0] == "Parse error: Unexpected token: Eof"
+        message = result.data[0]
+        # The point of this test is the prefix, not the wording: assert the
+        # property rather than the exact text, which changed when parse errors
+        # gained their JSONata codes.
+        assert message.startswith("Parse error: ")
+        assert message.count("Parse error:") == 1, f"double-prefixed: {message}"
+        assert "S0207" in message
 
 
 async def test_explain_with_no_topic_returns_function_index() -> None:

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -104,7 +104,20 @@ def extract_error_code(error_msg: str) -> str | None:
 # Note what does NOT belong here: a case we satisfy only because our error
 # carries no code for the suite to compare. That is not a known divergence, it
 # is an unverified case -- counted by UNVERIFIED_ERROR_CEILING above.
-KNOWN_DIVERGENCES: dict[str, str] = {}
+KNOWN_DIVERGENCES: dict[str, str] = {
+    "errors/case005": (
+        "`unknown(function)` is T1006 upstream. `function` is a keyword here, so the parser "
+        "commits to a lambda and fails on its shape (S0202) before anything decides the call "
+        "target is not a function. Getting T1006 means recognising the call context first, "
+        "which is a parser restructure rather than an error-code mapping."
+    ),
+    "function-signatures/case034": (
+        "`<(sa<n>)>` -- a choice group containing a parameterized type -- is S0402 upstream. "
+        "Our signature parser rejects the shape while still reading tokens, so it surfaces as "
+        "S0202. Needs the signature grammar to recognise the construct in order to reject it "
+        "specifically."
+    ),
+}
 
 
 def _build_pytest_params(
@@ -138,7 +151,7 @@ print(f"{'=' * 70}\n")
 # A ceiling, not a target. It only ever goes down -- see #144. The point of
 # asserting it is that "1686 passing" says less than it sounds for these cases,
 # and a new uncoded error would otherwise slip in unnoticed.
-UNVERIFIED_ERROR_CEILING = 32
+UNVERIFIED_ERROR_CEILING = 12
 
 
 @pytest.mark.reference

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -138,7 +138,7 @@ print(f"{'=' * 70}\n")
 # A ceiling, not a target. It only ever goes down -- see #144. The point of
 # asserting it is that "1686 passing" says less than it sounds for these cases,
 # and a new uncoded error would otherwise slip in unnoticed.
-UNVERIFIED_ERROR_CEILING = 45
+UNVERIFIED_ERROR_CEILING = 32
 
 
 @pytest.mark.reference


### PR DESCRIPTION
The substantive half of #144. **Unverified reference cases: 45 → 12.**

## Evaluator (first commit)

Nine errors produced the right message with no code, so the suite accepted them for whatever code the case expected:

```
D3060  $sqrt of a negative number        T1003  non-string object key
D3061  $power overflowing                T2006  non-function right side of ~>
D3070  single-arg $sort, mixed types     T1010  $split given a bad matcher
D3138  $single matching more than one
```

**`T1005` vs `T1006` is a distinction, not a prefix.** jsonata-js separates a call written without its `$` where the name *is* a builtin — almost certainly a missing sigil, so `T1005` with "did you mean `$sum`?" — from every other non-function invocation (`T1006`). Verified: `sum(1)` is T1005; `foo(1)`, `2(blah)` and `$notreal(1)` are all T1006.

That exposed a coupling worth naming: **`$eval` decided whether to re-wrap an inner failure as `D3121` by matching the prose `"Unknown function"`** — which these messages no longer say. It matches on the codes now. Caught by `function-eval/case006`, not by inspection.

## Parser (second commit)

```
S0101 unterminated string     S0203 ran out of input while expecting a token
S0103 unsupported escape      S0204 unknown operator
S0104 malformed \u escape     S0207 unexpected end of expression
S0105 unterminated backquote  S0211 symbol used where an operand belongs
S0202 wrong token             S0208 missing parameter name
```

Mapped on the **error variant**, not at each construction site, so codes can't drift from messages.

Three are a split rather than a rename, and the split is what the reference does: `UnexpectedToken` → `S0207` at end of input, `S0211` for a recognised symbol in prefix position, `S0204` for something that isn't an operator at all (`@ bar` and `55=>5` are S0211; `[1!2]` is S0204). `Expected` → `S0203` when input ran out, `S0202` otherwise.

## Two cases now get a wrong code, and are pinned rather than hidden

| case | upstream | ours | why |
|---|---|---|---|
| `errors/case005` | `T1006` | `S0202` | `function` is a keyword, so the parser commits to a lambda and fails on its shape before anything decides the call target isn't a function |
| `function-signatures/case034` | `S0402` | `S0202` | our signature parser rejects a choice group with a parameterized type while still reading tokens |

Both need parser restructuring, not a mapping. **Pinned `xfail(strict)` with the reasoning** — previously they were silently accepted, so this is strictly more honest even though the code is wrong.

## Two tests were coupled to the old wording

The MCP test asserted an exact string when its actual subject is *"the prefix is not doubled"* — it asserts that property now. The parser display test used `UnexpectedToken` as its example of an **uncoded** error, which it no longer is; it uses `InvalidNumber`, and a new test pins the derived codes so a future edit to the format strings fails there rather than in the reference suite.

## Gate

```
tests/python        25012 passed, 4 skipped, 4 xfailed
cargo test --release --features cli   187 tests, all green
clippy -D warnings, fmt --check       clean
ruff check / format                   clean
```

## What remains in #144

12 unverified cases: 2 unpaired-surrogate ones that cannot cross the Rust boundary at all, and 10 more parse shapes needing the same treatment. The ratchet holds the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)