### PR TITLE
fix: code the last reachable uncoded errors — completes #144's coding work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- The last uncoded errors carry their code: calling a non-function is `T1006`, partially
+  applying one (a call carrying a `?` placeholder) is `T1008`, assigning to something that is
+  not a variable is `S0212`, and a type parameter applied to something other than a function or
+  array is `S0401`. Every reference case that names an error code now has that code compared
+  against ours, except two that cannot be reached at all — `$encodeUrl` on an unpaired
+  surrogate, where the expression never crosses into Rust to be parsed.
+  ([#144](https://github.com/txjmb/jsonata-core/issues/144))
 - Parse errors carry their JSONata code. Unterminated strings are `S0101`, unsupported escapes
   `S0103`, a malformed `\u` escape `S0104`, an unterminated backquoted name `S0105`, a wrong
   token `S0202`, running out of input while expecting one `S0203`, an unknown operator `S0204`,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -6720,7 +6720,8 @@ impl Evaluator {
                 AstNode::Variable(name) => name.clone(),
                 _ => {
                     return Err(EvaluatorError::TypeError(
-                        "Left side of := must be a variable".to_string(),
+                        "S0212: The left side of := must be a variable name (start with $)"
+                            .to_string(),
                     ))
                 }
             };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,6 +39,17 @@ fn invalid_escape_message(seq: &str) -> String {
     }
 }
 
+/// Calling something that is not a function. jsonata-js distinguishes an
+/// ordinary invocation (T1006) from a *partial* application -- a call carrying
+/// a `?` placeholder -- which is T1008.
+fn invalid_call_message(args: &[AstNode]) -> String {
+    if args.iter().any(|a| matches!(a, AstNode::Placeholder)) {
+        "T1008: Attempted to partially apply a non-function".to_string()
+    } else {
+        "T1006: Attempted to invoke a non-function".to_string()
+    }
+}
+
 /// Running out of input while expecting something is S0203; finding the wrong
 /// thing is S0202. A missing *parameter name* is its own code, S0208.
 fn expected_message(expected: &str, found: &str) -> String {
@@ -1656,7 +1667,7 @@ impl Parser {
                                         };
                                     } else {
                                         return Err(ParserError::InvalidSyntax(
-                                            "Invalid function call".to_string(),
+                                            invalid_call_message(&args),
                                         ));
                                     }
                                 }
@@ -1670,9 +1681,9 @@ impl Parser {
                                     };
                                 }
                                 _ => {
-                                    return Err(ParserError::InvalidSyntax(
-                                        "Invalid function call".to_string(),
-                                    ))
+                                    return Err(ParserError::InvalidSyntax(invalid_call_message(
+                                        &args,
+                                    )))
                                 }
                             };
                         }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -427,7 +427,8 @@ impl Signature {
                 _ => {
                     // '<' not valid after other types
                     return Err(SignatureError::InvalidSignature(format!(
-                        "Type parameter '<' not valid after type {:?}",
+                        "S0401: Type parameters can only be applied to functions and arrays \
+                         (got {:?})",
                         param_type
                     )));
                 }

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -104,18 +104,22 @@ def extract_error_code(error_msg: str) -> str | None:
 # Note what does NOT belong here: a case we satisfy only because our error
 # carries no code for the suite to compare. That is not a known divergence, it
 # is an unverified case -- counted by UNVERIFIED_ERROR_CEILING above.
+# Tracked in #150 -- both need the parser to recognise a construct, not an
+# error-variant mapping.
 KNOWN_DIVERGENCES: dict[str, str] = {
     "errors/case005": (
         "`unknown(function)` is T1006 upstream. `function` is a keyword here, so the parser "
         "commits to a lambda and fails on its shape (S0202) before anything decides the call "
         "target is not a function. Getting T1006 means recognising the call context first, "
-        "which is a parser restructure rather than an error-code mapping."
+        "which is a parser restructure rather than an error-code mapping. The trigger is the "
+        "keyword `function` in argument position, not the call target: `foo(function)` fails "
+        "the same way and `unknown(fn)` is already correct. See #150."
     ),
     "function-signatures/case034": (
         "`<(sa<n>)>` -- a choice group containing a parameterized type -- is S0402 upstream. "
         "Our signature parser rejects the shape while still reading tokens, so it surfaces as "
-        "S0202. Needs the signature grammar to recognise the construct in order to reject it "
-        "specifically."
+        "S0202. Needs the signature grammar to parse a choice group's contents far enough to "
+        "detect a parameterized type inside one; `<(sa)>` without the parameter works. See #150."
     ),
 }
 

--- a/tests/python/test_reference_suite.py
+++ b/tests/python/test_reference_suite.py
@@ -144,14 +144,21 @@ print(f"Loaded {len(test_cases)} test cases")
 print(f"{'=' * 70}\n")
 
 
-# How many reference cases the suite currently cannot actually verify: we raise
-# an error carrying no JSONata code (and an uncoded error is accepted for any
-# expected code), or the case specifies an error object nothing inspects.
+# How many reference cases the suite cannot actually verify: we raise an error
+# carrying no JSONata code, and an uncoded error is accepted for any expected
+# code.
 #
-# A ceiling, not a target. It only ever goes down -- see #144. The point of
-# asserting it is that "1686 passing" says less than it sounds for these cases,
-# and a new uncoded error would otherwise slip in unnoticed.
-UNVERIFIED_ERROR_CEILING = 12
+# Down from 107 at 2.2.7 to 2, and 2 is the floor rather than a to-do. Both are
+# `$encodeUrl`/`$encodeUrlComponent` on an unpaired surrogate: a Python str can
+# hold one and a Rust String cannot, so the expression never crosses the
+# boundary to be parsed and there is no point at which D3140 could be raised.
+# We fail with a ValueError naming the surrogate instead of leaking PyO3's
+# codec error.
+#
+# The assertion cuts both ways -- it fails if the number grows, and fails
+# telling you to lower it if it shrinks -- so a new uncoded error cannot slip
+# in unnoticed and an improvement cannot go unrecorded. See #144.
+UNVERIFIED_ERROR_CEILING = 2
 
 
 @pytest.mark.reference


### PR DESCRIPTION
**Unverified reference cases: 12 → 2**, and 2 is the floor.

Since 2.2.7 this measure has gone **107 → 2**.

## Coded

```
T1006  calling a non-function
T1008  partially applying one -- a call carrying a `?` placeholder
S0212  assigning to something that is not a variable
S0401  a type parameter applied to something other than a function or array
```

`T1006` and `T1008` come from the same two parser sites and are told apart by whether the argument list holds a `Placeholder` — the same distinction jsonata-js makes. Verified against it: `2(blah)` and `2()` are `T1006`, `3(?)` is `T1008`.

## The floor, and why it is one

The two remaining cases are `$encodeUrl` / `$encodeUrlComponent` on an unpaired surrogate. A Python `str` can hold one; a Rust `String` cannot. The expression never crosses into Rust to be parsed, so there is no point at which `D3140` could be raised — we fail with a `ValueError` naming the surrogate rather than leaking PyO3's codec error.

The ceiling comment now says this explicitly, so the next reader doesn't treat 2 as remaining work.

## What the ratchet is worth

It cuts both ways — fails if the number grows, and fails *telling you to lower it* if it shrinks. Every step of #144 was driven by it rather than by me remembering to re-measure:

```
59 → 45 → 32 → 12 → 2
```

## Gate

```
tests/python        25012 passed, 4 skipped, 4 xfailed
cargo test --release --features cli   all green
clippy -D warnings, fmt --check       clean
ruff check                            clean
```

## What is left of #144

Only the two pinned wrong-code cases from #148 — `unknown(function)` wanting `T1006` and the choice-group signature wanting `S0402`. Both need parser restructuring rather than an error-code mapping, and both are `xfail(strict)` with the reasoning attached, so they are visible rather than silently accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)