### PR TITLE
docs: add CI, docs and conformance badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,16 @@ Release versions will follow the reference jsonata-js project major and minor re
 
 This project currently chooses not to implement async at this time, because it has limited value for most of the most common use-cases and the overhead of the async functionality would slow down synchronous use cases.  We focused on sync performance instead.
 
+[![Test Suite](https://github.com/txjmb/jsonata-core/actions/workflows/test.yml/badge.svg)](https://github.com/txjmb/jsonata-core/actions/workflows/test.yml)
+[![Code Quality](https://github.com/txjmb/jsonata-core/actions/workflows/lint.yml/badge.svg)](https://github.com/txjmb/jsonata-core/actions/workflows/lint.yml)
+[![Security](https://github.com/txjmb/jsonata-core/actions/workflows/security.yml/badge.svg)](https://github.com/txjmb/jsonata-core/actions/workflows/security.yml)
+
 [![Crates.io](https://img.shields.io/crates/v/jsonata-core.svg)](https://crates.io/crates/jsonata-core)
 [![PyPI version](https://badge.fury.io/py/jsonatapy.svg)](https://pypi.org/project/jsonatapy/)
 [![Python versions](https://img.shields.io/pypi/pyversions/jsonatapy.svg)](https://pypi.org/project/jsonatapy/)
+[![docs.rs](https://img.shields.io/docsrs/jsonata-core.svg)](https://docs.rs/jsonata-core)
+[![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://txjmb.github.io/jsonata-core)
+[![JSONata conformance](https://img.shields.io/badge/JSONata%20conformance-1686%2F1686-brightgreen.svg)](https://github.com/jsonata-js/jsonata/tree/master/test/test-suite)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ---


### PR DESCRIPTION
Adds badges to README.md

## Added

```
Test Suite      test.yml workflow status
Code Quality    lint.yml workflow status
Security        security.yml workflow status

docs.rs         Rust crate API docs
Docs            the mkdocs site at txjmb.github.io/jsonata-core
JSONata conformance   1686/1686
```

Every URL was fetched before committing rather than assumed — all return 200, including the two shields endpoints and the gh-pages docs site.

## Deliberately not added

**Codecov.** The `Code Coverage` job runs `cargo tarpaulin` and posts a PR comment, but nothing uploads to codecov.io — so the badge would render `unknown`. Worth adding *after* wiring up the upload, if you want it; happy to do that as a follow-up.

## Two notes

**Style:** written in the repo's existing markdown badge form rather than the HTML `<a>`/`<img>` of the example, so the block stays consistent with the piptrends badges directly above it. Trivial to switch if you prefer the HTML.

**The conformance badge is static.** It needs updating when the pinned jsonata-js submodule changes the case count. The number itself is enforced by the reference suite, so it can't be silently *wrong* — only stale. If that bothers you, the alternative is dropping it or generating it from the fixture.

