### PR TITLE
Conformance fixes (number stringification, field extraction, array groups, error codes) + C API guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   engine itself.
 
 ### Fixed
+- Errors carry their JSONata spec code at the front of the message again: the
+  `FunctionError` wrapping used to bury codes behind prose prefixes ("Runtime
+  error: D3030: Cannot convert 'x' to number"), so the C ABI, the Rust CLI, and
+  the Python CLI each grew a different classifier and disagreed on whether the
+  same error was coded. The inner message now passes through unwrapped
+  ("D3030: ..."), `EvaluatorError::code()` / `evaluator::error_code_prefix` is
+  the one definition of "coded error" (prefix-anchored), and the C ABI and both
+  CLIs classify with it — the same failure now presents identically in every
+  binary. The C ABI's mid-string code scan is retired (it existed only to see
+  through the now-removed prose prefixes).
 - Number stringification now matches jsonata-js exactly (verified against the pinned
   reference with a 307-case randomized differential over scalars, containers,
   prettified output, and `&` concatenation). Three divergences fixed: non-integers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `jsonata_set_limits` on the C ABI: wall-clock timeout (D1012), max AST recursion
+  depth (D1011), and max sequence length (D2015) — the same three guardrails the
+  Python bindings expose. C embedders previously had no way to bound a runaway
+  expression at all (the cleanup review's finding); 0 = unlimited, resettable per
+  handle. Covered by the C/C++ smoke tests and a Rust-side capi test.
 - `jsonata_core::Expression` — a compile-once API for Rust callers that runs
   compilable expressions on the bytecode VM, exactly like the Python and C
   bindings always have. Until now the VM was unreachable from the pure-Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   engine itself.
 
 ### Fixed
+- Number stringification now matches jsonata-js exactly (verified against the pinned
+  reference with a 307-case randomized differential over scalars, containers,
+  prettified output, and `&` concatenation). Three divergences fixed: non-integers
+  were truncated to 14 significant digits instead of rounded to 15 (`$string(1/3)`
+  was `0.33333333333333`, now `0.333333333333333` — the old formatter counted the
+  `0` of a leading `0.` as significant); integer-valued floats above 2^53 printed
+  their exact i64 digits instead of the float's shortest round-trip decimal; and
+  numbers nested in containers went through serde with different rules again.
+  `$string` now stringifies through its own writer implementing the reference's
+  replacer (functions → `""`, non-integers → `toPrecision(15)`), and one
+  `value::js_number_to_string` defines JS number printing (plain digits in
+  [1e-6, 1e21), exponential with `+` outside, `-0` as `0`) for `$string`, concat,
+  `Display`, and `$join`. Pinned by `tests/python/test_number_stringification.py`.
 - `$var.field` over an array containing nested-array elements now recurses into
   them like jsonata-js's `lookup`: `($v := [[{"p":1}],{"p":2}]; $v.p)` is `[1,2]`
   (previously `2` — the tree-walker's two-step fast path hand-rolled its mapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   engine itself.
 
 ### Fixed
+- Two families of tree-walker drift found by unifying the remaining field-extraction
+  loops onto `compiled_field_step` (each pinned on BOTH engines in
+  `tests/python/test_field_step_and_arraygroup.py` with jsonata-js reference outputs):
+  the single-step-Name fast path skipped null-valued fields and returned Null on empty
+  (`p` over `[{"p":null},{"p":2}]` was `2` on the tree-walker, `[null,2]` on the VM and
+  in the reference — the engines disagreed); and the `.[...]` array-group constructor
+  kept undefined elements as null (`foo.blah.[baz]` gave `[[..],[null],[null]]` instead
+  of `[[..],[],[]]`, masked downstream by that null-skip), while its empty results
+  conflated "constructed empty array over a single value" (kept: `{"a":1}.[b]` is `[]`)
+  with "mapped over an empty array" (undefined: `emptyarr.[b]`). Both tree-walker
+  Name-step loops (the fast path and the general step loop's inner loop) now delegate
+  to `compiled_field_step`, deleting ~100 lines of drifted copies; the reference
+  suite's `array-constructor/case013`/`case014` now pass by the correct route.
 - Errors carry their JSONata spec code at the front of the message again: the
   `FunctionError` wrapping used to bury codes behind prose prefixes ("Runtime
   error: D3030: Cannot convert 'x' to number"), so the C ABI, the Rust CLI, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with "mapped over an empty array" (undefined: `emptyarr.[b]`). Both tree-walker
   Name-step loops (the fast path and the general step loop's inner loop) now delegate
   to `compiled_field_step`, deleting ~100 lines of drifted copies; the reference
-  suite's `array-constructor/case013`/`case014` now pass by the correct route.
+  suite's `array-constructor/case013`/`case014` now pass by the correct route. The
+  fast path's tuple branch (a third copy, with the same null-skip drift) is deleted
+  outright — tuple streams fall through to the general step loop's single tuple
+  implementation, and `$#$i.p` over `[{"p":null},{"p":2}]` is now `[null,2]` on both
+  engines, matching the reference.
 - Errors carry their JSONata spec code at the front of the message again: the
   `FunctionError` wrapping used to bury codes behind prose prefixes ("Runtime
   error: D3030: Cannot convert 'x' to number"), so the C ABI, the Rust CLI, and

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -141,7 +141,13 @@ Rust library rebuilds with your project.)
    deliberately (e.g. a frozen `$now`, or a disabled `$eval`). `user_data`
    must outlive the handle. Registering a host function routes evaluation
    through the tree-walker, like variable bindings.
-8. **Panics:** internal engine panics are caught at the boundary and
+8. **Guardrails:** `jsonata_set_limits(expr, timeout_ms, max_stack_depth,
+   max_sequence_length)` bounds wall-clock time (D1012), AST recursion
+   depth (D1011), and query-result sequence length (D2015) for all
+   subsequent evaluations on that handle — the same three limits the
+   Python bindings expose. 0 means "unlimited" (the default); call again
+   to change or reset.
+9. **Panics:** internal engine panics are caught at the boundary and
    surface as errors prefixed `internal error:` — they will not abort
    your process.
 

--- a/bindings/c/examples/smoke.c
+++ b/bindings/c/examples/smoke.c
@@ -112,6 +112,27 @@ int main(void) {
         jsonata_free_expr(e);
     }
 
+    /* evaluation guardrails */
+    {
+        JsonataExpr *e = jsonata_compile("$map([1..100000], function($x) { $x })");
+        CHECK(jsonata_set_limits(NULL, 0, 0, 0) == -1, "set_limits NULL handle -> -1");
+        CHECK(jsonata_set_limits(e, 0, 0, 10) == 0, "set_limits succeeds");
+        char *r = jsonata_evaluate(e, "{}");
+        char *err = take_error();
+        char *code = jsonata_last_error_code();
+        CHECK(r == NULL && err != NULL, "sequence limit -> NULL + message");
+        CHECK(code != NULL && strcmp(code, "D2015") == 0,
+              "sequence limit -> spec code D2015");
+        jsonata_free_string(err);
+        jsonata_free_string(code);
+        /* lifting the limit makes the same handle work again */
+        CHECK(jsonata_set_limits(e, 0, 0, 0) == 0, "set_limits reset succeeds");
+        char *r2 = jsonata_evaluate(e, "{}");
+        CHECK(r2 != NULL, "evaluate succeeds after limit reset");
+        jsonata_free_string(r2);
+        jsonata_free_expr(e);
+    }
+
     /* variable binding */
     {
         JsonataExpr *e = jsonata_compile("$sum($xs) + n");

--- a/bindings/c/jsonata.h
+++ b/bindings/c/jsonata.h
@@ -110,6 +110,19 @@ int jsonata_register_fn(JsonataExpr *expr, const char *name,
 int jsonata_register_fn_override(JsonataExpr *expr, const char *name,
                                  jsonata_host_fn fn, void *user_data);
 
+/*
+ * Set evaluation guardrails, applied to every subsequent jsonata_evaluate()
+ * on this handle. Each limit uses 0 for "unlimited" (the default):
+ *   - timeout_ms          bounds wall-clock evaluation time (D1012 on breach)
+ *   - max_stack_depth     bounds AST recursion depth (D1011)
+ *   - max_sequence_length bounds query-result sequences (D2015)
+ * These are the same three guardrails the Python bindings expose.
+ * Returns 0 on success, -1 on a NULL handle (error slot set).
+ */
+int jsonata_set_limits(JsonataExpr *expr, unsigned long long timeout_ms,
+                       unsigned long long max_stack_depth,
+                       unsigned long long max_sequence_length);
+
 /* Free a handle returned by jsonata_compile(). NULL is a no-op. */
 void jsonata_free_expr(JsonataExpr *expr);
 

--- a/src/bin/jsonata/error_format.rs
+++ b/src/bin/jsonata/error_format.rs
@@ -9,19 +9,11 @@ use jsonata_core::evaluator::EvaluatorError;
 /// callers use it directly.
 pub fn format_evaluator_error(e: &EvaluatorError) -> String {
     let msg = e.message();
-    if is_coded_error(msg) {
+    if e.code().is_some() {
         msg.to_string()
     } else {
         format!("error: {}", msg)
     }
-}
-
-fn is_coded_error(message: &str) -> bool {
-    let bytes = message.as_bytes();
-    bytes.len() >= 6
-        && matches!(bytes[0], b'T' | b'D' | b'U' | b'S')
-        && bytes[1..5].iter().all(u8::is_ascii_digit)
-        && bytes[5] == b':'
 }
 
 #[cfg(test)]

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -43,6 +43,9 @@ pub struct JsonataExpr {
     /// subsequent `jsonata_evaluate`. Like bindings, a non-empty list forces
     /// the tree-walker (the VM has no host registry).
     host_fns: Vec<CHostFnReg>,
+    /// Evaluation guardrails set via `jsonata_set_limits`, applied on every
+    /// subsequent `jsonata_evaluate`. Defaults to unlimited.
+    options: EvaluatorOptions,
 }
 
 /// A host function callback.
@@ -155,6 +158,7 @@ pub unsafe extern "C" fn jsonata_compile(expr_utf8: *const c_char) -> *mut Jsona
                 bytecode: OnceCell::new(),
                 bindings: Vec::new(),
                 host_fns: Vec::new(),
+                options: EvaluatorOptions::default(),
             }))
         }
         Err(e) => {
@@ -348,18 +352,13 @@ pub unsafe extern "C" fn jsonata_evaluate(
         // bytecode AND no user bindings or host functions exist, tree-walker
         // otherwise (the VM takes no host registry).
         let result = if expr.bindings.is_empty() && expr.host_fns.is_empty() {
-            crate::expression::run_compiled(
-                &expr.ast,
-                &expr.bytecode,
-                &data,
-                EvaluatorOptions::default(),
-            )
+            crate::expression::run_compiled(&expr.ast, &expr.bytecode, &data, expr.options.clone())
         } else {
             let mut context = evaluator::Context::new();
             for (name, value) in &expr.bindings {
                 context.bind(name.clone(), value.clone());
             }
-            let mut ev = evaluator::Evaluator::with_options(context, EvaluatorOptions::default());
+            let mut ev = evaluator::Evaluator::with_options(context, expr.options.clone());
             for reg in &expr.host_fns {
                 let hf = CHostFn {
                     func: reg.func,
@@ -476,6 +475,37 @@ fn extract_error_code(msg: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Set evaluation guardrails on the expression, applied to every subsequent
+/// `jsonata_evaluate` on this handle. Each limit uses 0 for "unlimited" (the
+/// default): `timeout_ms` bounds wall-clock evaluation time (D1012 on
+/// breach), `max_stack_depth` bounds AST recursion depth (D1011), and
+/// `max_sequence_length` bounds query-result sequences (D2015) — the same
+/// three guardrails the Python bindings expose. Returns 0 on success, -1 on
+/// a NULL handle (error slot set).
+///
+/// # Safety
+/// `expr` must be a live pointer from `jsonata_compile` or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn jsonata_set_limits(
+    expr: *mut JsonataExpr,
+    timeout_ms: u64,
+    max_stack_depth: u64,
+    max_sequence_length: u64,
+) -> c_int {
+    if expr.is_null() {
+        set_error("jsonata_set_limits: NULL expression handle".to_string());
+        return -1;
+    }
+    let expr = &mut *expr;
+    expr.options = EvaluatorOptions {
+        timeout_ms: (timeout_ms > 0).then_some(timeout_ms),
+        max_stack_depth: (max_stack_depth > 0).then_some(max_stack_depth as usize),
+        max_sequence_length: (max_sequence_length > 0).then_some(max_sequence_length as usize),
+    };
+    clear_error();
+    0
 }
 
 #[no_mangle]
@@ -883,6 +913,27 @@ mod tests {
                 -1
             );
             assert!(last_error().unwrap().contains("NULL"));
+            jsonata_free_expr(h);
+        }
+    }
+    #[test]
+    fn set_limits_enforced_and_resettable() {
+        unsafe {
+            let ce = CString::new("$map([1..100000], function($x) { $x })").unwrap();
+            let cd = CString::new("{}").unwrap();
+            let h = jsonata_compile(ce.as_ptr());
+            assert!(!h.is_null());
+            assert_eq!(jsonata_set_limits(std::ptr::null_mut(), 0, 0, 0), -1);
+            assert_eq!(jsonata_set_limits(h, 0, 0, 10), 0);
+            let r = jsonata_evaluate(h, cd.as_ptr());
+            assert!(r.is_null(), "sequence limit must fail the evaluation");
+            let err = last_error().expect("error slot set");
+            assert!(err.contains("D2015"), "unexpected error: {err}");
+            // Lifting the limit makes the same handle succeed again.
+            assert_eq!(jsonata_set_limits(h, 0, 0, 0), 0);
+            let r2 = jsonata_evaluate(h, cd.as_ptr());
+            assert!(!r2.is_null());
+            jsonata_free_string(r2);
             jsonata_free_expr(h);
         }
     }

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -456,25 +456,13 @@ pub extern "C" fn jsonata_last_error_code() -> *mut c_char {
     })
 }
 
-/// A JSONata spec code is one uppercase ASCII letter followed by exactly
-/// four digits, terminated by ':' (e.g. "T2002: ..."). The engine sometimes
-/// stores it at the start of the message and sometimes behind a prose
-/// prefix ("Runtime error: D3030: ..."), so scan for the first
-/// token-boundary occurrence. Uncoded prose ("Parse error: something",
-/// "invalid input JSON: ...") yields None.
+/// The JSONata spec code of `msg`, using the crate-wide rule
+/// (`evaluator::error_code_prefix`): a leading `X####:` prefix. Coded
+/// engine errors always carry the code at the front — the old mid-string
+/// scan existed only because `FunctionError` wrapping used to bury codes
+/// behind prose prefixes ("Runtime error: D3030: ...").
 fn extract_error_code(msg: &str) -> Option<String> {
-    let bytes = msg.as_bytes();
-    for i in 0..bytes.len().saturating_sub(5) {
-        let at_boundary = i == 0 || bytes[i - 1] == b' ';
-        if at_boundary
-            && bytes[i].is_ascii_uppercase()
-            && bytes[i + 1..i + 5].iter().all(|b| b.is_ascii_digit())
-            && bytes[i + 5] == b':'
-        {
-            return Some(msg[i..i + 5].to_string());
-        }
-    }
-    None
+    evaluator::error_code_prefix(msg).map(str::to_string)
 }
 
 /// Set evaluation guardrails on the expression, applied to every subsequent
@@ -734,8 +722,16 @@ mod tests {
             Some("T2002")
         );
         assert_eq!(extract_error_code("S0214: bad %").as_deref(), Some("S0214"));
+        // Codes are no longer buried behind prose prefixes (the
+        // FunctionError wrapping that produced "Runtime error: D3030: ..."
+        // is gone), so the classifier is prefix-anchored: a mid-string code
+        // does not count.
         assert_eq!(
-            extract_error_code("Runtime error: D3030: Cannot convert").as_deref(),
+            extract_error_code("Runtime error: D3030: Cannot convert"),
+            None
+        );
+        assert_eq!(
+            extract_error_code("D3030: Cannot convert 'x' to number").as_deref(),
             Some("D3030")
         );
         assert_eq!(extract_error_code("Parse error: something"), None);

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4070,10 +4070,14 @@ impl Evaluator {
 
             // Array grouping: same as Array but prevents flattening in path contexts
             AstNode::ArrayGroup(elements) => {
+                // Undefined elements are dropped like in every array constructor;
+                // explicit null is a value and stays.
                 let mut result = Vec::new();
                 for element in elements {
                     let value = self.evaluate_internal(element, data)?;
-                    result.push(value);
+                    if !value.is_undefined() {
+                        result.push(value);
+                    }
                 }
                 Ok(JValue::array(result))
             }
@@ -4492,55 +4496,19 @@ impl Evaluator {
                         });
 
                         if !has_tuples {
-                            // Fast path: no tuples, just direct field lookups
-                            let mut result = Vec::with_capacity(arr.len());
-                            for item in arr.iter() {
-                                if let JValue::Object(obj) = item {
-                                    if let Some(val) = obj.get(field_name) {
-                                        if !val.is_null() {
-                                            match val {
-                                                JValue::Array(arr_val) => {
-                                                    result.extend(arr_val.iter().cloned());
-                                                }
-                                                other => result.push(other.clone()),
-                                            }
-                                        }
-                                    }
-                                } else if let JValue::Array(inner_arr) = item {
-                                    let nested_result = self.evaluate_path(
-                                        &[PathStep::new(AstNode::Name(field_name.clone()))],
-                                        &JValue::Array(inner_arr.clone()),
-                                    )?;
-                                    match nested_result {
-                                        JValue::Array(nested) => {
-                                            result.extend(nested.iter().cloned());
-                                        }
-                                        JValue::Null => {}
-                                        other => result.push(other),
-                                    }
-                                } else {
-                                    #[cfg(feature = "python")]
-                                    if let JValue::LazyPyDict(lazy) = item {
-                                        let val = lazy.get_field(field_name)?;
-                                        if !val.is_null() && !val.is_undefined() {
-                                            match val {
-                                                JValue::Array(arr_val) => {
-                                                    result.extend(arr_val.iter().cloned());
-                                                }
-                                                other => result.push(other),
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            if result.is_empty() {
-                                Ok(JValue::Null)
-                            } else if result.len() == 1 {
-                                Ok(result.into_iter().next().unwrap())
-                            } else {
-                                check_sequence_length(result.len(), &self.options)?;
-                                Ok(JValue::array(result))
+                            // No tuples: delegate to the shared field step
+                            // (skip undefined, KEEP nulls, flatten one level,
+                            // empty -> undefined) plus the end-of-path
+                            // singleton unwrap — the same policy as the VM's
+                            // get_field_cached and jsonata-js. The hand-rolled
+                            // loop this replaces skipped nulls and returned
+                            // Null when empty, so `p` over [{"p":null},{"p":2}]
+                            // was 2 on the tree-walker but [null,2] on the VM
+                            // and in the reference.
+                            let extracted = compiled_field_step(field_name, data, &self.options)?;
+                            match extracted {
+                                JValue::Array(arr) if arr.len() == 1 => Ok(arr[0].clone()),
+                                other => Ok(other),
                             }
                         } else {
                             // Tuple path: per-element tuple handling
@@ -5263,51 +5231,16 @@ impl Evaluator {
                             });
 
                             if !has_tuples && stages.is_empty() {
-                                let mut result = Vec::with_capacity(arr.len());
-                                for item in arr.iter() {
-                                    match item {
-                                        JValue::Object(obj) => {
-                                            // `None` is an absent field (undefined -> drops out);
-                                            // `Some(Null)` is a present null, which is a value and
-                                            // stays in the sequence. Mirrors compiled_field_step.
-                                            if let Some(val) = obj.get(field_name) {
-                                                match val {
-                                                    JValue::Undefined => {}
-                                                    JValue::Array(arr_val) => {
-                                                        result.extend(arr_val.iter().cloned())
-                                                    }
-                                                    other => result.push(other.clone()),
-                                                }
-                                            }
-                                        }
-                                        JValue::Array(_) => {
-                                            let nested_result =
-                                                self.evaluate_path(&[step.clone()], item)?;
-                                            match nested_result {
-                                                JValue::Array(nested) => {
-                                                    result.extend(nested.iter().cloned())
-                                                }
-                                                JValue::Null => {}
-                                                other => result.push(other),
-                                            }
-                                        }
-                                        #[cfg(feature = "python")]
-                                        JValue::LazyPyDict(lazy) => {
-                                            let val = lazy.get_field(field_name)?;
-                                            // A present null is a value; only an absent field (Undefined) drops out.
-                                            if !val.is_undefined() {
-                                                match val {
-                                                    JValue::Array(arr_val) => {
-                                                        result.extend(arr_val.iter().cloned())
-                                                    }
-                                                    other => result.push(other),
-                                                }
-                                            }
-                                        }
-                                        _ => {}
-                                    }
+                                // Delegate to the shared field step (skip undefined,
+                                // keep nulls, flatten one level, recurse into nested
+                                // arrays). Mid-path wants the raw sequence: no
+                                // singleton unwrap, and an empty result stays an
+                                // empty array so the remaining steps map over
+                                // nothing exactly as before.
+                                match compiled_field_step(field_name, &current, &self.options)? {
+                                    JValue::Undefined => JValue::array(Vec::new()),
+                                    other => other,
                                 }
-                                JValue::array(result)
                             } else {
                                 // Full path with tuple support and stages
                                 let mut result = Vec::new();
@@ -5557,11 +5490,16 @@ impl Evaluator {
                                         // Keep the array as a single element to preserve nesting
                                         group_values.push(value);
                                     } else {
-                                        // Flatten the value into group_values
+                                        // Flatten the value into group_values. Undefined is
+                                        // dropped like in every array constructor (jsonata-js:
+                                        // `foo.blah.[baz]` over an element without `baz` is
+                                        // `[]`, not `[null]`); explicit null is a value and
+                                        // stays.
                                         match value {
                                             JValue::Array(arr) => {
                                                 group_values.extend(arr.iter().cloned())
                                             }
+                                            JValue::Undefined => {}
                                             other => group_values.push(other),
                                         }
                                     }
@@ -5575,18 +5513,29 @@ impl Evaluator {
                             // (not wrapped in an outer singleton array) — e.g.
                             // `$.[value,epochSeconds]` over a 1-element array yields
                             // `[3, 1578381600]`, not `[[3, 1578381600]]`.
-                            if is_last_step && result.len() == 1 {
+                            if result.is_empty() {
+                                // Mapping over an EMPTY array produced nothing at
+                                // all — undefined, like any step mapped over an
+                                // empty sequence (`emptyarr.[b]`), NOT a kept empty
+                                // array (that is the single-value construction
+                                // case, handled in finalize_path_result).
+                                JValue::Undefined
+                            } else if is_last_step && result.len() == 1 {
                                 result.into_iter().next().unwrap()
                             } else {
                                 JValue::array(result)
                             }
                         }
                         _ => {
-                            // For non-arrays, just evaluate the array constructor normally
+                            // For non-arrays, just evaluate the array constructor
+                            // normally; undefined elements are dropped like in every
+                            // array constructor (`{"a":1}.[b]` is `[]`).
                             let mut result = Vec::new();
                             for element in elements {
                                 let value = self.evaluate_internal(element, &current)?;
-                                result.push(value);
+                                if !value.is_undefined() {
+                                    result.push(value);
+                                }
                             }
                             JValue::array(result)
                         }
@@ -5824,8 +5773,18 @@ impl Evaluator {
             // path that found nothing never even reaches the predicate,
             // because the step loop returns undefined first, which is why
             // `nope[]` needs no special case here.
+            // ...and a trailing `.[...]` group over a SINGLE value is a
+            // constructed array, not a result sequence: `{"a":1}.[b]` is `[]`
+            // in jsonata-js, while `emptyarr.[b]` (mapped over nothing) is
+            // undefined — `did_array_mapping` is again what tells them apart.
             JValue::Array(arr)
-                if arr.is_empty() && (did_array_mapping || !has_explicit_array_keep) =>
+                if arr.is_empty()
+                    && (did_array_mapping || !has_explicit_array_keep)
+                    && (did_array_mapping
+                        || !matches!(
+                            steps.last().map(|s| &s.node),
+                            Some(AstNode::ArrayGroup(_))
+                        )) =>
             {
                 JValue::Undefined
             }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -4469,153 +4469,49 @@ impl Evaluator {
         // creation handled below.
         if steps.len() == 1 && !Self::step_creates_tuple(&steps[0]) {
             if let AstNode::Name(field_name) = &steps[0].node {
-                return match data {
-                    JValue::Object(obj) => {
-                        // Check if this is a tuple - extract '@' value
-                        if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
-                            match obj.get("@") {
-                                Some(JValue::Object(inner)) => {
-                                    Ok(inner.get(field_name).cloned().unwrap_or(JValue::Undefined))
+                // A tuple stream falls through to the general step loop below —
+                // its tuple arm is the single implementation of tuple-aware
+                // field extraction (the fast path used to carry a drifted copy
+                // that skipped nulls and returned Null on empty).
+                let is_tuple_stream = matches!(data, JValue::Array(arr) if arr.first().is_some_and(
+                    |item| matches!(item, JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)))
+                ));
+                if !is_tuple_stream {
+                    return match data {
+                        JValue::Object(obj) => {
+                            // Check if this is a tuple - extract '@' value
+                            if obj.get("__tuple__") == Some(&JValue::Bool(true)) {
+                                match obj.get("@") {
+                                    Some(JValue::Object(inner)) => Ok(inner
+                                        .get(field_name)
+                                        .cloned()
+                                        .unwrap_or(JValue::Undefined)),
+                                    #[cfg(feature = "python")]
+                                    Some(JValue::LazyPyDict(lazy)) => {
+                                        Ok(lazy.get_field(field_name)?)
+                                    }
+                                    _ => Ok(JValue::Undefined),
                                 }
-                                #[cfg(feature = "python")]
-                                Some(JValue::LazyPyDict(lazy)) => Ok(lazy.get_field(field_name)?),
-                                _ => Ok(JValue::Undefined),
+                            } else {
+                                Ok(obj.get(field_name).cloned().unwrap_or(JValue::Undefined))
                             }
-                        } else {
-                            Ok(obj.get(field_name).cloned().unwrap_or(JValue::Undefined))
                         }
-                    }
-                    #[cfg(feature = "python")]
-                    JValue::LazyPyDict(lazy) => Ok(lazy.get_field(field_name)?),
-                    JValue::Array(arr) => {
-                        // Array mapping: extract field from each element
-                        // Optimized: use references to access fields without cloning entire objects
-                        // Check first element for tuple-ness (tuples are all-or-nothing)
-                        let has_tuples = arr.first().is_some_and(|item| {
-                            matches!(item, JValue::Object(obj) if obj.get("__tuple__") == Some(&JValue::Bool(true)))
-                        });
-
-                        if !has_tuples {
-                            // No tuples: delegate to the shared field step
-                            // (skip undefined, KEEP nulls, flatten one level,
-                            // empty -> undefined) plus the end-of-path
-                            // singleton unwrap — the same policy as the VM's
-                            // get_field_cached and jsonata-js. The hand-rolled
-                            // loop this replaces skipped nulls and returned
-                            // Null when empty, so `p` over [{"p":null},{"p":2}]
-                            // was 2 on the tree-walker but [null,2] on the VM
-                            // and in the reference.
+                        #[cfg(feature = "python")]
+                        JValue::LazyPyDict(lazy) => Ok(lazy.get_field(field_name)?),
+                        JValue::Array(_) => {
+                            // Delegate to the shared field step (skip undefined,
+                            // KEEP nulls, flatten one level, empty -> undefined)
+                            // plus the end-of-path singleton unwrap — the same
+                            // policy as the VM's get_field_cached and jsonata-js.
                             let extracted = compiled_field_step(field_name, data, &self.options)?;
                             match extracted {
                                 JValue::Array(arr) if arr.len() == 1 => Ok(arr[0].clone()),
                                 other => Ok(other),
                             }
-                        } else {
-                            // Tuple path: per-element tuple handling
-                            let mut result = Vec::new();
-                            for item in arr.iter() {
-                                match item {
-                                    JValue::Object(obj) => {
-                                        let is_tuple =
-                                            obj.get("__tuple__") == Some(&JValue::Bool(true));
-
-                                        if is_tuple {
-                                            let field_val: Option<JValue> = match obj.get("@") {
-                                                Some(JValue::Object(inner)) => {
-                                                    inner.get(field_name).cloned()
-                                                }
-                                                #[cfg(feature = "python")]
-                                                Some(JValue::LazyPyDict(lazy)) => {
-                                                    let v = lazy.get_field(field_name)?;
-                                                    if v.is_undefined() {
-                                                        None
-                                                    } else {
-                                                        Some(v)
-                                                    }
-                                                }
-                                                _ => continue,
-                                            };
-
-                                            if let Some(val) = field_val.as_ref() {
-                                                if !val.is_null() {
-                                                    // Build tuple wrapper - only clone bindings when needed
-                                                    let wrap = |v: JValue| -> JValue {
-                                                        let mut wrapper = IndexMap::new();
-                                                        wrapper.insert("@".to_string(), v);
-                                                        wrapper.insert(
-                                                            "__tuple__".to_string(),
-                                                            JValue::Bool(true),
-                                                        );
-                                                        for (k, v) in obj.iter() {
-                                                            if k.starts_with('$') {
-                                                                wrapper
-                                                                    .insert(k.clone(), v.clone());
-                                                            }
-                                                        }
-                                                        JValue::object(wrapper)
-                                                    };
-
-                                                    match val {
-                                                        JValue::Array(arr_val) => {
-                                                            for item in arr_val.iter() {
-                                                                result.push(wrap(item.clone()));
-                                                            }
-                                                        }
-                                                        other => result.push(wrap(other.clone())),
-                                                    }
-                                                }
-                                            }
-                                        } else {
-                                            // Non-tuple: access field directly by reference, only clone the field value
-                                            if let Some(val) = obj.get(field_name) {
-                                                if !val.is_null() {
-                                                    match val {
-                                                        JValue::Array(arr_val) => {
-                                                            for item in arr_val.iter() {
-                                                                result.push(item.clone());
-                                                            }
-                                                        }
-                                                        other => result.push(other.clone()),
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                    JValue::Array(inner_arr) => {
-                                        // Recursively map over nested array
-                                        let nested_result = self.evaluate_path(
-                                            &[PathStep::new(AstNode::Name(field_name.clone()))],
-                                            &JValue::Array(inner_arr.clone()),
-                                        )?;
-                                        // Add nested result to our results
-                                        match nested_result {
-                                            JValue::Array(nested) => {
-                                                // Flatten nested arrays from recursive mapping
-                                                result.extend(nested.iter().cloned());
-                                            }
-                                            JValue::Null => {}
-                                            other => result.push(other),
-                                        }
-                                    }
-                                    _ => {} // Skip non-object items
-                                }
-                            }
-
-                            // Return array result
-                            // JSONata singleton unwrapping: if we have exactly one result,
-                            // unwrap it (even if it's an array)
-                            if result.is_empty() {
-                                Ok(JValue::Null)
-                            } else if result.len() == 1 {
-                                Ok(result.into_iter().next().unwrap())
-                            } else {
-                                check_sequence_length(result.len(), &self.options)?;
-                                Ok(JValue::array(result))
-                            }
-                        } // end else (tuple path)
-                    }
-                    _ => Ok(JValue::Undefined),
-                };
+                        }
+                        _ => Ok(JValue::Undefined),
+                    };
+                }
             }
         }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2298,7 +2298,20 @@ impl From<crate::functions::FunctionError> for EvaluatorError {
         if let crate::functions::FunctionError::PyConversionError(m) = &e {
             return EvaluatorError::PyConversionError(m.clone());
         }
-        EvaluatorError::EvaluationError(e.to_string())
+        // Pass the inner message through rather than thiserror's Display,
+        // which prepends "Runtime error: "/"Argument error: "/"Type error: "
+        // — burying the JSONata spec code ("Runtime error: D3030: ...") so
+        // no prefix-anchored classifier (the CLIs, `EvaluatorError::code`)
+        // could see it, and double-stacking with EvaluatorError's own
+        // Display prefix ("Evaluation error: Runtime error: ...").
+        use crate::functions::FunctionError as FE;
+        let msg = match e {
+            FE::ArgumentError(m) | FE::TypeError(m) | FE::RuntimeError(m) => m,
+            // Handled by the early return above; kept for exhaustiveness.
+            #[cfg(feature = "python")]
+            FE::PyConversionError(m) => m,
+        };
+        EvaluatorError::EvaluationError(msg)
     }
 }
 
@@ -2324,6 +2337,30 @@ impl EvaluatorError {
             #[cfg(feature = "python")]
             EvaluatorError::PyConversionError(m) => m,
         }
+    }
+
+    /// The JSONata spec code ("T2010", "D3030", ...) this error carries, if
+    /// any: the message's leading `X####:` prefix. This is THE definition of
+    /// "is this a coded error" — the C ABI's `jsonata_last_error_code` and
+    /// the CLI's error formatting both classify with it (the Python CLI
+    /// mirrors it with an equivalent anchored regex), so the same failure
+    /// presents the same way in every binary.
+    pub fn code(&self) -> Option<&str> {
+        error_code_prefix(self.message())
+    }
+}
+
+/// The leading JSONata spec code of `msg` (`X####:` at offset 0), if any.
+pub fn error_code_prefix(msg: &str) -> Option<&str> {
+    let b = msg.as_bytes();
+    if b.len() >= 6
+        && b[0].is_ascii_uppercase()
+        && b[1..5].iter().all(u8::is_ascii_digit)
+        && b[5] == b':'
+    {
+        Some(&msg[..5])
+    } else {
+        None
     }
 }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -127,14 +127,11 @@ pub mod string {
                     )));
                 }
 
-                // Format numbers like JavaScript does
-                if f.fract() == 0.0 && f.abs() < (i64::MAX as f64) {
-                    (f as i64).to_string()
-                } else {
-                    // Non-integer - use precision formatting
-                    // JavaScript uses toPrecision(15) for non-integers in JSON.stringify
-                    format_number_with_precision(f)
-                }
+                // Format numbers like JavaScript does: integers print as
+                // the shortest round-trip decimal; non-integers are rounded
+                // to 15 significant digits first (jsonata-js's replacer:
+                // `Number.isInteger(val) ? val : Number(val.toPrecision(15))`)
+                format_stringified_number(f)
             }
             JValue::Bool(b) => b.to_string(),
             JValue::Null => {
@@ -166,64 +163,25 @@ pub mod string {
         Ok(JValue::string(result))
     }
 
-    /// Helper to format a number with precision like JavaScript's toPrecision(15)
-    ///
-    /// JavaScript uses `toPrecision(15)` which formats with 15 significant figures.
-    /// This matches that behavior by:
-    /// 1. Formatting with 15 significant figures
-    /// 2. Removing trailing zeros
-    /// 3. Converting back to number to normalize format
-    fn format_number_with_precision(f: f64) -> String {
-        // Format with 15 significant figures like JavaScript's toPrecision(15)
-        // The format uses scientific notation to ensure precision
-        let formatted = format!("{:.14e}", f);
+    /// Round to 15 significant digits, the way jsonata-js's `$string`
+    /// replacer treats every non-integer number
+    /// (`Number(val.toPrecision(15))`). `{:.14e}` (1 leading digit + 14
+    /// decimals) is exactly `toPrecision(15)`; the round-trip parse yields
+    /// the normalized rounded value.
+    fn round_to_precision_15(f: f64) -> f64 {
+        format!("{:.14e}", f).parse().unwrap_or(f)
+    }
 
-        // Parse back to f64 and format normally to get the canonical representation
-        // This mimics JavaScript's behavior of normalizing the result
-        if let Ok(parsed) = formatted.parse::<f64>() {
-            // Convert to string without exponential notation unless necessary
-            if parsed.abs() >= 1e-6 && parsed.abs() < 1e21 {
-                // Regular notation
-                let s = format!("{}", parsed);
-                // Ensure we don't have excessive precision
-                if s.contains('.') {
-                    let parts: Vec<&str> = s.split('.').collect();
-                    if parts.len() == 2 {
-                        let int_part = parts[0];
-                        let frac_part = parts[1];
-                        let total_digits = int_part.trim_start_matches('-').len() + frac_part.len();
-
-                        if total_digits > 15 {
-                            // Truncate to 15 significant figures
-                            let sig_figs = 15 - int_part.trim_start_matches('-').len();
-                            if sig_figs > 0 && sig_figs <= frac_part.len() {
-                                let truncated_frac = &frac_part[..sig_figs];
-                                // Remove trailing zeros
-                                let trimmed = truncated_frac.trim_end_matches('0');
-                                if trimmed.is_empty() {
-                                    return int_part.to_string();
-                                } else {
-                                    return format!("{}.{}", int_part, trimmed);
-                                }
-                            }
-                        }
-                    }
-                }
-                s
-            } else {
-                // Use exponential notation for very small or large numbers
-                // Format matches JavaScript: always include sign in exponent
-                let exp_str = format!("{:e}", parsed);
-                // Ensure exponent has + sign: "1e100" -> "1e+100"
-                if exp_str.contains('e') && !exp_str.contains("e-") && !exp_str.contains("e+") {
-                    exp_str.replace('e', "e+")
-                } else {
-                    exp_str
-                }
-            }
+    /// Print one finite number for `$string`/stringification: integers keep
+    /// full (shortest round-trip) precision, non-integers are rounded to 15
+    /// significant digits first, and both print via the shared JS number
+    /// printer (exponential outside [1e-6, 1e21), `+` on positive exponents,
+    /// `-0` as `0`).
+    fn format_stringified_number(f: f64) -> String {
+        if f.fract() == 0.0 {
+            crate::value::js_number_to_string(f)
         } else {
-            // Fallback
-            format!("{}", f)
+            crate::value::js_number_to_string(round_to_precision_15(f))
         }
     }
 
@@ -245,95 +203,110 @@ pub mod string {
         }
     }
 
-    /// Helper to stringify a value as JSON with custom replacer logic
-    ///
-    /// Mimics JavaScript's JSON.stringify with a replacer function that:
-    /// - Converts non-integer numbers to 15 significant figures
-    /// - Keeps integers without decimal point
-    /// - Converts functions to empty string
+    /// Stringify a value the way jsonata-js's `$string` does
+    /// (`JSON.stringify` with the function-to-"" / non-integer-toPrecision(15)
+    /// replacer). Hand-rolled rather than routed through serde so numbers
+    /// print with JavaScript's exact rules — integers above 2^53 print as the
+    /// float's shortest round-trip decimal, not the exact i64 digits serde
+    /// would emit.
     fn stringify_value_custom(
         value: &JValue,
         indent: Option<usize>,
     ) -> Result<String, FunctionError> {
         reject_non_finite(value)?;
-        // Transform the value recursively before stringifying
-        let transformed = transform_for_stringify(value);
-
-        let result = if indent.is_some() {
-            serde_json::to_string_pretty(&transformed)
-                .map_err(|e| FunctionError::RuntimeError(format!("JSON stringify error: {}", e)))?
-        } else {
-            serde_json::to_string(&transformed)
-                .map_err(|e| FunctionError::RuntimeError(format!("JSON stringify error: {}", e)))?
-        };
-        Ok(result)
+        let mut out = String::new();
+        write_stringified(value, indent, 0, &mut out);
+        Ok(out)
     }
 
-    /// Transform a value for JSON.stringify, applying the replacer logic
-    fn transform_for_stringify(value: &JValue) -> JValue {
+    /// Recursive writer for `stringify_value_custom`. `indent` = Some(width)
+    /// pretty-prints exactly like `JSON.stringify(v, replacer, width)` (and
+    /// serde_json's pretty printer): items one per line, `": "` after keys,
+    /// empty containers stay `{}`/`[]`.
+    fn write_stringified(value: &JValue, indent: Option<usize>, depth: usize, out: &mut String) {
+        let (open_sep, close_sep, item_sep, key_sep): (String, String, &str, &str) = match indent {
+            Some(w) => (
+                format!("\n{}", " ".repeat(w * (depth + 1))),
+                format!("\n{}", " ".repeat(w * depth)),
+                ",",
+                ": ",
+            ),
+            None => (String::new(), String::new(), ",", ":"),
+        };
         match value {
-            JValue::Number(n) => {
-                let f = *n;
-                // Check if it's an integer first
-                if f.fract() == 0.0 && f.is_finite() && f.abs() < (1i64 << 53) as f64 {
-                    // Keep as integer
-                    value.clone()
-                } else {
-                    // Non-integer: apply toPrecision(15) and keep as f64
-                    let formatted = format_number_with_precision(f);
-                    if let Ok(parsed) = formatted.parse::<f64>() {
-                        JValue::Number(parsed)
-                    } else {
-                        value.clone()
-                    }
-                }
+            // JSON.stringify turns undefined into null in array position; an
+            // undefined-valued object key never gets here (construction drops
+            // it), so mapping the whole variant to null preserves both.
+            JValue::Null | JValue::Undefined => out.push_str("null"),
+            JValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+            JValue::Number(n) => out.push_str(&format_stringified_number(*n)),
+            JValue::String(s) => write_json_escaped(s, out),
+            // The replacer maps functions to "" wherever they appear.
+            JValue::Lambda { .. } | JValue::Builtin { .. } => out.push_str("\"\""),
+            JValue::Regex { pattern, flags } => {
+                // Mirrors the serde Serialize impl: a regex value renders as
+                // {"pattern": ..., "flags": ...}.
+                out.push('{');
+                out.push_str(&open_sep);
+                write_json_escaped("pattern", out);
+                out.push_str(key_sep);
+                write_json_escaped(pattern, out);
+                out.push_str(item_sep);
+                out.push_str(&open_sep);
+                write_json_escaped("flags", out);
+                out.push_str(key_sep);
+                write_json_escaped(flags, out);
+                out.push_str(&close_sep);
+                out.push('}');
             }
             JValue::Array(arr) => {
-                let transformed: Vec<JValue> = arr
-                    .iter()
-                    .map(|v| {
-                        if v.is_function() {
-                            return JValue::string("");
-                        }
-                        transform_for_stringify(v)
-                    })
-                    .collect();
-                JValue::array(transformed)
+                if arr.is_empty() {
+                    out.push_str("[]");
+                    return;
+                }
+                out.push('[');
+                for (i, v) in arr.iter().enumerate() {
+                    if i > 0 {
+                        out.push_str(item_sep);
+                    }
+                    out.push_str(&open_sep);
+                    write_stringified(v, indent, depth + 1, out);
+                }
+                out.push_str(&close_sep);
+                out.push(']');
             }
             JValue::Object(obj) => {
-                if value.is_function() {
-                    return JValue::string("");
+                if obj.is_empty() {
+                    out.push_str("{}");
+                    return;
                 }
-
-                let transformed: IndexMap<String, JValue> = obj
-                    .iter()
-                    .map(|(k, v)| {
-                        if v.is_function() {
-                            return (k.clone(), JValue::string(""));
-                        }
-                        (k.clone(), transform_for_stringify(v))
-                    })
-                    .collect();
-                JValue::object(transformed)
+                out.push('{');
+                for (i, (k, v)) in obj.iter().enumerate() {
+                    if i > 0 {
+                        out.push_str(item_sep);
+                    }
+                    out.push_str(&open_sep);
+                    write_json_escaped(k, out);
+                    out.push_str(key_sep);
+                    write_stringified(v, indent, depth + 1, out);
+                }
+                out.push_str(&close_sep);
+                out.push('}');
             }
             #[cfg(feature = "python")]
             JValue::LazyPyDict(lazy) => match lazy.to_object_ref() {
                 Some(obj) => {
-                    let transformed: IndexMap<String, JValue> = obj
-                        .iter()
-                        .map(|(k, v)| {
-                            if v.is_function() {
-                                return (k.clone(), JValue::string(""));
-                            }
-                            (k.clone(), transform_for_stringify(v))
-                        })
-                        .collect();
-                    JValue::object(transformed)
+                    write_stringified(&JValue::object(obj.clone()), indent, depth, out);
                 }
-                None => JValue::Null,
+                None => out.push_str("null"),
             },
-            _ => value.clone(),
         }
+    }
+
+    /// Append the JSON string literal (quotes and escapes included) for `s`.
+    fn write_json_escaped(s: &str, out: &mut String) {
+        // serde_json's string escaping is JSON.stringify's.
+        out.push_str(&serde_json::to_string(s).expect("string serialization is infallible"));
     }
 
     /// $length() - Get string length with proper Unicode support
@@ -532,13 +505,11 @@ pub mod string {
         Ok(JValue::string(parts.join(sep)))
     }
 
-    /// Helper to format a number for $join (matching serde_json Number's Display)
+    /// Format a number for $join. Unreachable through validated dispatch —
+    /// the reference raises T0412 for non-string elements — but kept for
+    /// unvalidated callers, printing the JS way like everything else.
     fn format_join_number(n: f64) -> String {
-        if n.fract() == 0.0 && n.abs() < (i64::MAX as f64) {
-            (n as i64).to_string()
-        } else {
-            n.to_string()
-        }
+        crate::value::js_number_to_string(n)
     }
 
     /// Helper to perform capture group substitution in replacement string

--- a/src/value.rs
+++ b/src/value.rs
@@ -482,15 +482,41 @@ fn escape_json_string(s: &str) -> String {
     result
 }
 
+/// Print a finite f64 the way JavaScript's `String(number)` /
+/// `JSON.stringify(number)` does: shortest round-trip decimal, plain digits
+/// for magnitudes in [1e-6, 1e21), exponential (with an explicit `+` on
+/// positive exponents) outside that range, and `-0` printed as `0` (matching
+/// `JSON.stringify(-0)`).
+///
+/// This is the one definition of JS number printing; `$string` layers its
+/// non-integer `toPrecision(15)` rounding on top of it (see
+/// `functions::string`). Callers must handle non-finite values first.
+pub(crate) fn js_number_to_string(f: f64) -> String {
+    debug_assert!(f.is_finite());
+    if f == 0.0 {
+        return "0".to_string();
+    }
+    let abs = f.abs();
+    if (1e-6..1e21).contains(&abs) {
+        // Rust's Display is shortest-round-trip and never exponential,
+        // which matches JS exactly in this range.
+        format!("{}", f)
+    } else {
+        let exp_str = format!("{:e}", f);
+        if exp_str.contains('e') && !exp_str.contains("e-") && !exp_str.contains("e+") {
+            exp_str.replace('e', "e+")
+        } else {
+            exp_str
+        }
+    }
+}
+
 fn format_number(n: f64, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if !n.is_finite() {
         // NaN and +/-Infinity serialize as null (matching JSON spec)
         write!(f, "null")
-    } else if n.fract() == 0.0 && n.abs() < 1e20 {
-        write!(f, "{}", n as i64)
     } else {
-        // Use serde_json's number formatting for consistency
-        write!(f, "{}", n)
+        write!(f, "{}", js_number_to_string(n))
     }
 }
 

--- a/tests/python/test_field_step_and_arraygroup.py
+++ b/tests/python/test_field_step_and_arraygroup.py
@@ -76,3 +76,13 @@ def test_array_group_singleton_mapping_keeps_group(engine):
     assert ev("$.[value, eps]", [{"value": 3, "eps": 9}]) == [3, 9]
     assert ev("blah.[baz]", {"blah": [{"baz": 1}]}) == [1]
     assert ev("blah.[baz]", {"blah": [{"baz": 1}, {"baz": 2}]}) == [[1], [2]]
+
+
+def test_tuple_stream_field_extraction_keeps_nulls(engine):
+    # The fast path's tuple branch used to skip nulls and return Null on
+    # empty; tuple streams now go through the general loop's single tuple
+    # implementation. Reference outputs from jsonata-js.
+    assert ev("$#$i.p", [{"p": None}, {"p": 2}]) == [None, 2]
+    assert ev("$#$i.p", [{"q": 1}]) is None
+    assert ev("arr#$i.p", {"arr": [{"p": 1}, {"p": [2, 3]}]}) == [1, 2, 3]
+    assert ev("($#$i.p)[$i=0]", [{"p": None}, {"p": 2}]) is None

--- a/tests/python/test_field_step_and_arraygroup.py
+++ b/tests/python/test_field_step_and_arraygroup.py
@@ -1,0 +1,78 @@
+"""Field-step and array-group conformance, pinned against jsonata-js.
+
+Two families of tree-walker drift fixed while unifying the field-extraction
+loops onto `compiled_field_step` (all expected values below were produced by
+the pinned jsonata-js submodule, and every case is asserted on BOTH engines):
+
+1. The single-step-Name fast path skipped null-valued fields and returned
+   Null for an empty result, so `p` over [{"p":null},{"p":2}] was 2 on the
+   tree-walker but [null,2] on the VM and in the reference.
+2. The `.[...]` array-group constructor kept undefined elements as null
+   (`foo.blah.[baz]` gave [[..],[null],[null]] instead of [[..],[],[]]),
+   masked downstream by the null-skip in (1); and its empty results confused
+   "constructed empty array over a single value" (kept: `{"a":1}.[b]` is [])
+   with "mapped over an empty array" (undefined: `emptyarr.[b]`).
+"""
+
+import jsonatapy
+import jsonatapy._jsonatapy as _impl
+import pytest
+
+
+@pytest.fixture(params=[False, True], ids=["vm", "tree"])
+def engine(request):
+    _impl._set_force_tree_walker(request.param)
+    yield
+    _impl._set_force_tree_walker(False)
+
+
+def ev(src, data):
+    return jsonatapy.compile(src).evaluate(data)
+
+
+def test_name_step_keeps_nulls(engine):
+    assert ev("p", [{"p": None}, {"p": 2}]) == [None, 2]
+    assert ev("p", [{"p": None}, {"p": None}]) == [None, None]
+    assert ev("p", [{"p": None}]) is None  # reference: null (unwrapped singleton)
+
+
+def test_name_step_empty_is_undefined(engine):
+    assert ev("p", [{"q": 1}]) is None  # reference: undefined
+
+
+def test_name_step_flattens_and_recurses(engine):
+    assert ev("p", [{"p": [1, 2]}, {"p": 3}]) == [1, 2, 3]
+
+
+def test_array_group_drops_undefined_elements(engine):
+    data = {
+        "foo": {
+            "blah": [
+                {"baz": {"fud": "hello"}},
+                {"buz": {"fud": "world"}},
+                {"bazz": "gotcha"},
+            ]
+        }
+    }
+    assert ev("foo.blah.[baz]", data) == [[{"fud": "hello"}], [], []]
+    assert ev("foo.blah.[baz].fud", data) == "hello"
+    assert ev("foo.blah.[baz, buz].fud", data) == ["hello", "world"]
+
+
+def test_array_group_over_single_value_keeps_empty_array(engine):
+    assert ev('{"a":1}.[b]', {}) == []
+    assert ev("foo.[b]", {"foo": {"bar": 1}}) == []
+
+
+def test_array_group_mapped_over_empty_array_is_undefined(engine):
+    assert ev("emptyarr.[b]", {"emptyarr": []}) is None
+    assert ev("nothing.[b]", {}) is None
+
+
+def test_array_group_singleton_mapping_keeps_group(engine):
+    # jsonata-js: the lone constructed group IS the result — and it is NOT
+    # singleton-unwrapped further ([3] stays [3]).
+    assert ev("$.[value]", [{"value": 3}]) == [3]
+    assert ev("$.[value, eps]", [{"value": 3, "eps": 9}]) == [3, 9]
+    assert ev("blah.[baz]", {"blah": [{"baz": 1}]}) == [1]
+    assert ev("blah.[baz]", {"blah": [{"baz": 1}, {"baz": 2}]}) == [[1], [2]]

--- a/tests/python/test_number_stringification.py
+++ b/tests/python/test_number_stringification.py
@@ -1,0 +1,70 @@
+"""JS-parity number stringification for $string, concat, and JSON output.
+
+jsonata-js's `$string` is `JSON.stringify` with a replacer that rounds every
+NON-integer number to 15 significant digits (`Number(val.toPrecision(15))`)
+and leaves integer-valued numbers at full (shortest round-trip) precision.
+JavaScript's number printer then uses plain digits in [1e-6, 1e21) and
+exponential notation (with `+` on positive exponents) outside it.
+
+We diverged three ways: non-integers were truncated to 14 significant digits
+(the old formatter counted the `0` of a leading `0.` as significant),
+integer-valued floats above 2^53 printed their exact i64 digits instead of
+the float's shortest round-trip decimal, and nested numbers in
+containers went through serde with different rules again. All expected
+values below were produced by the pinned jsonata-js submodule, and a
+307-case randomized differential (scalars, containers, prettify, concat)
+matches it exactly.
+"""
+
+import jsonatapy
+
+
+def ev(src, data=None):
+    return jsonatapy.compile(src).evaluate(data if data is not None else {})
+
+
+def test_non_integer_rounds_to_15_significant_digits():
+    assert ev("$string(1/3)") == "0.333333333333333"
+    assert ev("$string(-1/3)") == "-0.333333333333333"
+    assert ev("$string(0.1234567890123456789)") == "0.123456789012346"
+
+
+def test_leading_zero_is_not_a_significant_digit():
+    # The old formatter emitted 0.00000123456789012345 here (14 digits).
+    assert ev("$string(0.00000123456789012345678)") == "0.00000123456789012346"
+
+
+def test_integers_keep_shortest_roundtrip_precision():
+    # Above 2^53: JS prints the float's shortest round-trip decimal, not the
+    # exact i64 value (…744) the old formatter emitted.
+    assert ev("$string(x)", {"x": 7.693663077734049e17}) == "769366307773404900"
+    assert ev("$string(9007199254740993)") == "9007199254740992"
+    assert ev("$string(1e19)") == "10000000000000000000"
+
+
+def test_exponential_thresholds_match_js():
+    assert ev("$string(1e21)") == "1e+21"
+    assert ev("$string(1.23456789e-9)") == "1.23456789e-9"
+    assert ev("$string(0.000001)") == "0.000001"
+    assert ev("$string(1e-7)") == "1e-7"
+
+
+def test_negative_zero_prints_as_zero():
+    assert ev("$string(x)", {"x": -0.0}) == "0"
+
+
+def test_nested_numbers_use_the_same_rules():
+    assert ev('$string({"a": 1/3})') == '{"a":0.333333333333333}'
+    assert ev("$string([1/3, 2])") == "[0.333333333333333,2]"
+    assert ev("$string(x)", {"x": {"a": 7.693663077734049e17}}) == '{"a":769366307773404900}'
+
+
+def test_prettify_matches_js_stringify():
+    assert (
+        ev('$string({"a": [1, "s"], "b": {}}, true)')
+        == '{\n  "a": [\n    1,\n    "s"\n  ],\n  "b": {}\n}'
+    )
+
+
+def test_concat_uses_string_rules():
+    assert ev('"v=" & 1/3') == "v=0.333333333333333"


### PR DESCRIPTION
## Description

Round 2 of the cleanup/conformance work (follows #156; branch restarted from the merged main). Five commits: three conformance fixes verified against the pinned jsonata-js submodule, the C API guardrails the cleanup review flagged as a functional gap, and completion of the field-extraction unification — which surfaced and fixed two engine-disagreement bugs the VM's default dispatch had been masking. The letrec closure project identified during this work is filed separately as #157.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring (no functional changes)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issues

Relates to #156 (previous round). #157 filed for the follow-on letrec closure redesign.

## Changes Made

**`8b1c920` — number stringification matches jsonata-js exactly.** Three divergences fixed: non-integers were truncated to 14 significant digits instead of rounded to 15 (the old formatter counted the `0` of a leading `0.` as significant — `$string(1/3)` printed 14 threes); integer-valued floats above 2^53 printed exact i64 digits where JS prints the shortest round-trip decimal; and numbers nested in containers went through serde with a third set of rules. `$string` now stringifies through its own writer implementing the reference's replacer, and one `value::js_number_to_string` defines JS number printing for `$string`, `&` concat, `Display`, and `$join`. **Verified with a 307-case randomized differential against the pinned submodule: 0 mismatches across 1,228 comparisons** (scalars, containers, prettify, concat).

**`64151bd` — `jsonata_set_limits` on the C ABI.** C embedders previously had no way to bound a runaway expression (timeout/stack/sequence guardrails were hardcoded to unlimited). Now settable per handle (0 = unlimited, resettable), applied on both VM and tree-walker arms; header + README documented, exercised by the C and C++ smoke tests and a Rust-side capi test.

**`7cf4376` — one definition of coded errors.** `FunctionError` wrapping buried spec codes behind prose ("Runtime error: D3030: …"), which is why the C API, Rust CLI, and Python CLI each grew a different classifier and disagreed on whether the same error was coded. Inner messages now pass through unwrapped; `EvaluatorError::code()` / `error_code_prefix` is the single classification rule used by all three binaries; the C API's mid-string scanner is retired.

**`1f5be51` + `6087342` — field-extraction unification completed.** Forcing the tree-walker exposed that **the two engines disagreed**: `p` over `[{"p":null},{"p":2}]` was `2` on the tree-walker, `[null,2]` on the VM and in the reference. Unifying onto `compiled_field_step` then unmasked the compensating bug: the `.[…]` array-group constructor kept undefined elements as null (`foo.blah.[baz]` gave `[[..],[null],[null]]` instead of `[[..],[],[]]`) — reference cases `array-constructor/case013`/`014` only passed because the two bugs cancelled. Both tree-walker Name-step loops and the fast path's tuple branch (a third copy with the same drift) now delegate to the shared implementations, deleting ~250 lines of drifted copies; empty-group semantics fixed (`{"a":1}.[b]` is `[]`, `emptyarr.[b]` is undefined, `$.[value]` stays `[3]`).

## Testing

### Test Environment

- Python version: 3.11
- Operating System: Linux x86_64 (dev container)
- jsonatapy version: 2.2.8 (this branch)

### Test Checklist

- [x] All existing tests pass (`cargo test --all-features`: 416; `pytest`: 25,074)
- [x] New tests added for bug fixes/features
- [x] Reference test suite still passes — on BOTH engines (default and `JSONATAPY_FORCE_TREE_WALKER=1`), plus the differential corpus
- [x] Tested manually with provided examples
- [x] Edge cases considered and tested
- [x] Performance impact assessed (forced-tree `products.price` and the `lazy_check.py` rows unchanged at the machine baseline)

### Test Cases

```python
import jsonatapy

# 15 significant digits, not 14 (matches pinned jsonata-js)
assert jsonatapy.compile("$string(1/3)").evaluate({}) == "0.333333333333333"

# engines agreed with each other and the reference only after the fix
assert jsonatapy.compile("p").evaluate([{"p": None}, {"p": 2}]) == [None, 2]

# array groups drop undefined like every other array constructor
assert jsonatapy.compile("foo.blah.[baz]").evaluate(
    {"foo": {"blah": [{"baz": {"fud": "hello"}}, {"buz": 1}]}}
) == [[{"fud": "hello"}], []]
```

New test files: `test_number_stringification.py`, `test_field_step_and_arraygroup.py` (every case parametrized over both engines, expected values from the pinned reference).

## Documentation

- [x] Added/updated docstrings for public APIs (`jsonata_set_limits`, `EvaluatorError::code`, `js_number_to_string`)
- [x] Added/updated inline comments for complex logic
- [x] Updated CHANGELOG.md
- [x] Rustdoc comments added for Rust code
- [x] `bindings/c/jsonata.h` and `bindings/c/README.md` document the new guardrails

## Compatibility

- [x] Behavior matches JavaScript JSONata reference implementation (every fix verified directly against the pinned submodule; expected values pinned in tests)
- [x] No breaking changes to public Python API

### JavaScript Reference Verification

**JavaScript (pinned jsonata-js submodule):**
```javascript
await jsonata('$string(1/3)').evaluate({})                       // "0.333333333333333"
await jsonata('p').evaluate([{p:null},{p:2}])                    // [null,2]
await jsonata('foo.blah.[baz]').evaluate(dataset10)              // [[{"fud":"hello"}],[],[]]
await jsonata('{"a":1}.[b]').evaluate({})                        // []
```

**jsonatapy (this branch, both engines):** identical results.

## Breaking Changes

- [ ] This PR introduces breaking changes

None. Error *texts* change where prose prefixes were stripped ("Runtime error: D3030: …" → "D3030: …") and where number printing now matches the reference — same codes, corrected values. One known pre-existing divergence is documented and left alone: `blah.[baz][0]` (numeric predicate after a group) returns `[1]` vs the reference's `[1,2]` — separate predicate-stage semantics.

## Performance Impact

- [x] Performance benchmarks run
- [x] No significant performance regression

**Benchmark results:**
```
lazy_check.py rows and forced-tree products.price: unchanged within the
machine's current baseline band before/after every commit.
```

## Code Quality

- [x] Code follows project style guidelines
- [x] `cargo fmt` applied
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] No new compiler warnings
- [x] Removed debug/print statements

## Additional Notes

Commits are self-contained and individually validated; commit-by-commit review recommended. The field-extraction commits are the interesting ones: two of the "seven divergent field-extraction loops" from the cleanup review turned out to be masking each other's bugs, which is exactly the failure mode that motivated the unification.

## Reviewer Guidelines

**Focus areas for review:**
- `1f5be51`'s array-group empty-result semantics (`finalize_path_result` guard): the constructed-vs-mapped distinction is pinned by tests but is the subtlest judgement call in the set
- The `$string` writer (`8b1c920`): hand-rolled JSON stringification replacing the serde route — string escaping still goes through serde_json per element
- Whether the stripped error-message prefixes affect any downstream consumers you know of that parsed the old texts

**Questions for reviewers:**
- Should `blah.[baz][0]` (documented pre-existing divergence) get its own issue like #157?

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVbmpLm9srfGrNKuY7pe66)_