### PR TITLE
Letrec closure redesign: carry the closure in JValue::Lambda; delete the scope side table and escape-analysis GC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to release (semver format, e.g., 2.1.0 for JSONata 2.1.0)'
         required: true
         type: string
+      release_name:
+        description: 'Optional release name (e.g. Conform-ata); appears in the release title and the changelog heading'
+        required: false
+        type: string
+        default: ''
       dry_run:
         description: 'Dry run (skip publishing)'
         required: false
@@ -157,7 +162,7 @@ jobs:
           if grep -q "^## \[$VERSION\]" CHANGELOG.md; then
             echo "CHANGELOG.md already has a [$VERSION] entry - skipping (re-run case)"
           else
-            ./scripts/bump-changelog.sh "$VERSION"
+            RELEASE_NAME="${{ github.event.inputs.release_name }}" ./scripts/bump-changelog.sh "$VERSION"
           fi
 
           echo "Updated CHANGELOG.md:"
@@ -667,7 +672,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.validate-version.outputs.version }}
-          name: Release v${{ needs.validate-version.outputs.version }}
+          name: ${{ github.event.inputs.release_name != '' && format('Release v{0} - "{1}"', needs.validate-version.outputs.version, github.event.inputs.release_name) || format('Release v{0}', needs.validate-version.outputs.version) }}
           body_path: changelog.md
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dangles. Function equality is now closure identity rather than id-string
   equality. Remaining known divergences from jsonata-js's live-frame capture
   are documented in the same suite's `divergent_from_reference` module.
+- Partial application is a typed representation instead of a stringly-typed
+  protocol: `StoredLambda` carries an optional `PartialApplication { target,
+  bound_args, placeholder_positions, total_args }`, replacing the
+  `"__partial_call:name:bool:n"` marker-string body that was parsed at every
+  invocation and the `__bound_arg_N` / `__placeholder_positions` /
+  `__total_args` / `__partial_target` values smuggled through `captured_env`.
+  A user-defined target is a captured closure (`PartialTarget::Lambda`);
+  builtins/host functions stay name-resolved at call time
+  (`PartialTarget::Named`), preserving call-time shadowing. Partials no longer
+  snapshot the entire environment at creation (the old
+  `capture_current_environment()` call was only ever a smuggling container),
+  and one behavior corner now matches jsonata-js: rebinding a user function
+  after partially applying it no longer changes what the partial calls
+  (pinned in `tests/lambda_closure_suite.rs` with eight other partial pins).
 
 ### Added
 - `jsonata_set_limits` on the C ABI: wall-clock timeout (D1012), max AST recursion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Lambda values now carry their closure directly — `JValue::Lambda(Rc<StoredLambda>)`
+  instead of a `lambda_id` name tag resolved through a per-scope side table (#157).
+  The `Rc` provides the closure's lifetime, so the side table (`Scope.lambdas`),
+  the escape-analysis GC (`extract_lambda_ids`/`collect_lambda_ids` walking every
+  block/lambda result, `pop_scope_preserving_lambdas`) and the dual-map handling in
+  `unbind`/`clear_current_scope` are gone, along with the O(result size) walk on
+  every scope pop. Recursion is late-bound letrec: a closure defined as
+  `$f := function ...` records its own name and binds it to itself at each
+  invocation, so no `Rc` cycles exist and closures cannot leak (guarded by a
+  live-count test). Free-variable capture remains a by-value snapshot at
+  definition time, now applied uniformly to lambda-valued variables too.
+  Behavioral fixes (all matching jsonata-js, pinned in
+  `tests/lambda_closure_suite.rs`): a transform bound to a variable is callable
+  and pipeable (`$t := |...|...|; $t(x)`, `x ~> $t`); a partial application
+  escaping the scope that defined its target function works; an alias
+  (`$g := $f`) survives `$f` being rebound; calling a name rebound to a
+  non-function raises T1006 instead of silently invoking the stale lambda; a
+  closure captured inside another escaping closure's environment no longer
+  dangles. Function equality is now closure identity rather than id-string
+  equality. Remaining known divergences from jsonata-js's live-frame capture
+  are documented in the same suite's `divergent_from_reference` module.
+
 ### Added
 - `jsonata_set_limits` on the C ABI: wall-clock timeout (D1012), max AST recursion
   depth (D1011), and max sequence length (D2015) — the same three guardrails the

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -131,12 +131,7 @@ pub enum JValue {
     Array(Rc<Vec<JValue>>),       // Rc-wrapped for O(1) clone
     Object(Rc<IndexMap<String, JValue>>),  // Rc-wrapped
     Undefined,                    // JSONata undefined value
-    Lambda {                      // First-class lambda function
-        lambda_id: usize,
-        params: Vec<String>,
-        name: Option<String>,
-        signature: Option<String>,
-    },
+    Lambda(Rc<StoredLambda>),     // First-class function carrying its closure
     Builtin {                     // First-class built-in function
         name: String,
     },
@@ -169,7 +164,7 @@ Instead of wrapping in JSON objects:
 
 ```rust
 // First-class variant (fast)
-JValue::Lambda { lambda_id: 1, params: vec![], name: None, signature: None }
+JValue::Lambda(Rc::new(stored_lambda))
 
 // Tagged JSON object (slow)
 JValue::Object(map! {
@@ -178,7 +173,9 @@ JValue::Object(map! {
 })
 ```
 
-**Impact:** Enum discriminant check vs hash map lookup.
+**Impact:** Enum discriminant check vs hash map lookup — and the lambda value
+IS the closure (body, params, signature, captured environment), so invoking a
+function value never needs a lookup at all.
 
 **3. Undefined as Distinct Type**
 
@@ -271,9 +268,8 @@ fn evaluate_path(ctx: &mut Context, path: &PathNode) -> Result<JValue> {
 
 ```rust
 pub struct Context {
-    scopes: Vec<Scope>,          // Stack of scopes
-    lambdas: HashMap<usize, StoredLambda>,  // Lambda storage
-    next_lambda_id: usize,
+    scope_stack: Vec<Scope>,     // Stack of scopes
+    parent_data: Option<JValue>,
 }
 
 pub struct Scope {
@@ -282,8 +278,13 @@ pub struct Scope {
 
 pub struct StoredLambda {
     params: Vec<String>,
-    body: Rc<AstNode>,
-    captured_env: HashMap<String, JValue>,  // Captured variables
+    body: AstNode,
+    signature: Option<String>,
+    captured_env: HashMap<String, JValue>,  // Free variables, snapshot at definition
+    captured_data: Option<JValue>,          // Data context at definition
+    thunk: bool,                            // Body has optimizable tail calls
+    self_name: Option<String>,              // Set for `$f := function ...` (letrec)
+    // ...
 }
 ```
 
@@ -304,33 +305,40 @@ let result = evaluate_expression(ctx, expr)?;
 
 ### Lambda Storage
 
-Lambdas stored separately from values:
+A lambda value carries its closure (issue #157): `JValue::Lambda(Rc<StoredLambda>)`.
+The `Rc` provides the lifetime — a closure escaping its defining scope (returned
+from a block, nested in an array/object, captured by another closure) stays alive
+for as long as any value references it. There is no side table and no escape
+analysis; dangling lambda references are unrepresentable.
 
 ```rust
-// Create lambda
-let lambda_id = ctx.next_lambda_id();
-let stored = StoredLambda {
+// Create lambda: the value IS the closure
+let lambda_value = JValue::Lambda(Rc::new(StoredLambda {
     params: vec!["x".into()],
-    body: Rc::new(body_ast),
+    body: body_ast,
     captured_env: capture_free_vars(ctx, &body_ast),
-};
-ctx.lambdas.insert(lambda_id, stored);
+    // ...
+}));
 
-// Lambda value
-let lambda_value = JValue::Lambda {
-    lambda_id,
-    params: vec!["x".into()],
-    name: None,
-    signature: None,
-};
-
-// Call lambda
-let stored = ctx.lambdas.get(&lambda_id).unwrap();
-ctx.push_scope_with_bindings(stored.captured_env.clone());
-ctx.bind("x", argument);
-let result = evaluate(ctx, &stored.body)?;
-ctx.pop_scope();
+// Call lambda: no lookup — the value carries everything
+if let JValue::Lambda(stored) = &callable {
+    ctx.push_scope();
+    // bind captured_env, then self_name (if any), then params
+    let result = evaluate(ctx, &stored.body)?;
+    ctx.pop_scope();
+}
 ```
+
+### Recursion: Late-Bound Letrec
+
+`$f := function($n){ $n = 0 ? 0 : $f($n - 1) }` must call itself even after
+`$f` has escaped its defining scope. The closure does not store a reference to
+itself (that would be an `Rc` cycle, i.e. a leak); instead it records its own
+`self_name` at definition, and each invocation binds that name to the closure
+being invoked. Free-variable capture is a by-value snapshot at definition time
+(not jsonata-js's live frames); `self_name` binds after `captured_env`, so a
+rebinding `$f := function(){ ...$f()... }` recurses into itself rather than
+the captured previous `$f`.
 
 ### Selective Capture
 

--- a/scripts/bump-changelog.sh
+++ b/scripts/bump-changelog.sh
@@ -35,8 +35,15 @@ if ! echo "$UNRELEASED_BODY" | grep -q '^- '; then
     exit 1
 fi
 
+# Optional release name (e.g. RELEASE_NAME='Conform-ata' produced
+# '## [2.2.8] "Conform-ata" - 2026-08-25'). Empty keeps the plain heading.
+NAME_SEGMENT=""
+if [ -n "${RELEASE_NAME:-}" ]; then
+    NAME_SEGMENT=" \"$RELEASE_NAME\""
+fi
+
 TMP="$(mktemp)"
-awk -v version="$VERSION" -v date="$DATE" '
+awk -v version="$VERSION" -v name_segment="$NAME_SEGMENT" -v date="$DATE" '
     /^## \[Unreleased\]$/ {
         print "## [Unreleased]"
         print ""
@@ -52,11 +59,11 @@ awk -v version="$VERSION" -v date="$DATE" '
         print ""
         print "### Security"
         print ""
-        print "## [" version "] - " date
+        print "## [" version "]" name_segment " - " date
         next
     }
     { print }
 ' "$CHANGELOG" > "$TMP"
 
 mv "$TMP" "$CHANGELOG"
-echo "Bumped $CHANGELOG: [Unreleased] -> [$VERSION] - $DATE (fresh [Unreleased] template inserted above it)"
+echo "Bumped $CHANGELOG: [Unreleased] -> [$VERSION]$NAME_SEGMENT - $DATE (fresh [Unreleased] template inserted above it)"

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2465,6 +2465,37 @@ impl Drop for LiveLambdaToken {
     }
 }
 
+/// How a partial application (`$f(1, ?)`) reaches the function it applies.
+#[derive(Clone, Debug)]
+pub(crate) enum PartialTarget {
+    /// A user-defined function, captured as a closure value at creation time —
+    /// this is what lets the partial outlive the scope that defined its target.
+    Lambda(Rc<StoredLambda>),
+    /// A builtin or host function, resolved BY NAME at each invocation.
+    /// These are global and cannot dangle, and name resolution preserves
+    /// call-time shadowing (`$up := $uppercase(?); $uppercase := ...` — the
+    /// later user binding wins, matching jsonata-js's environment chain).
+    Named { name: String, is_builtin: bool },
+}
+
+/// A partial application, carried inside a `StoredLambda` in place of a body.
+///
+/// `$add(10, ?)` becomes params `["__p0"]` plus this struct: at invocation the
+/// full argument list is rebuilt — bound values in their original positions,
+/// call arguments filling the placeholder positions in order — and the target
+/// is applied to it.
+#[derive(Clone, Debug)]
+pub(crate) struct PartialApplication {
+    pub target: PartialTarget,
+    /// `(position, value)` for arguments fixed at creation time (values, not
+    /// expressions: `$add($x, ?)` snapshots `$x` when the partial is built).
+    pub bound_args: Vec<(usize, JValue)>,
+    /// Positions of the `?` placeholders, filled from call arguments in order.
+    pub placeholder_positions: Vec<usize>,
+    /// Argument count of the underlying call (bound + placeholders).
+    pub total_args: usize,
+}
+
 /// Lambda storage
 /// Stores the AST of a lambda function along with its parameters, optional signature,
 /// and captured environment for closures.
@@ -2493,6 +2524,11 @@ pub struct StoredLambda {
     /// invocation, so recursion works after the defining scope has popped
     /// (classic letrec, late-bound instead of stored — no `Rc` cycle).
     pub self_name: Option<String>,
+    /// `Some` iff this lambda is a partial application: invocation applies the
+    /// carried target instead of evaluating `body` (which is inert).
+    /// `Rc` so invocation can detach a handle from the borrowed closure with a
+    /// refcount bump.
+    pub(crate) partial: Option<Rc<PartialApplication>>,
     /// Keeps `live_lambda_count` accurate; see that function.
     pub live_token: LiveLambdaToken,
 }
@@ -2510,6 +2546,7 @@ impl StoredLambda {
             captured_data: None,
             thunk: false,
             self_name: None,
+            partial: None,
             live_token: LiveLambdaToken::new(),
         }
     }
@@ -3014,6 +3051,13 @@ impl Evaluator {
         args: &[JValue],
         data: &JValue,
     ) -> Result<JValue, EvaluatorError> {
+        // A partial application carries its own invocation recipe; no scope,
+        // signature, or body evaluation of its own.
+        if let Some(partial) = &stored.partial {
+            let partial = Rc::clone(partial);
+            return self.invoke_partial(&partial, args, data);
+        }
+
         // Compiled fast path: skip scope push/pop and tree-walking for simple lambdas.
         // Conditions: has compiled body, no signature (can't skip validation), no thunk,
         // and no captured lambda/builtin values (those require Context for runtime lookup).
@@ -4013,6 +4057,7 @@ impl Evaluator {
                     captured_data: Some(data.clone()),
                     thunk: *thunk,
                     self_name: None,
+                    partial: None,
                     live_token: LiveLambdaToken::new(),
                 };
                 Ok(JValue::Lambda(Rc::new(stored_lambda)))
@@ -4118,6 +4163,7 @@ impl Evaluator {
                         captured_data: None, // Transform takes $ as parameter
                         thunk: false,
                         self_name: None,
+                        partial: None,
                         live_token: LiveLambdaToken::new(),
                     };
                     Ok(JValue::Lambda(Rc::new(transform_lambda)))
@@ -6620,6 +6666,7 @@ impl Evaluator {
                     // body's recursive `$f(...)` resolves to THIS closure at
                     // every invocation, wherever the value has traveled.
                     self_name: Some(var_name.clone()),
+                    partial: None,
                     live_token: LiveLambdaToken::new(),
                 };
                 let lambda_value = JValue::Lambda(Rc::new(stored_lambda));
@@ -6693,6 +6740,7 @@ impl Evaluator {
                         captured_data: Some(data.clone()),
                         thunk: false,
                         self_name: Some(var_name.clone()),
+                        partial: None,
                         live_token: LiveLambdaToken::new(),
                     };
                     let lambda_value = JValue::Lambda(Rc::new(stored_lambda));
@@ -8429,6 +8477,7 @@ impl Evaluator {
                     captured_data: captured_data.cloned(),
                     thunk,
                     self_name: None,
+                    partial: None,
                     live_token: LiveLambdaToken::new(),
                 }),
             };
@@ -8476,92 +8525,6 @@ impl Evaluator {
             for (i, param) in params.iter().enumerate() {
                 let value = values.get(i).cloned().unwrap_or(JValue::Undefined);
                 self.context.bind(param.clone(), value);
-            }
-        }
-
-        // Check if this is a partial application (body is a special marker string)
-        if let AstNode::String(body_str) = body {
-            if body_str.starts_with("__partial_call:") {
-                // Parse the partial call info
-                let parts: Vec<&str> = body_str.split(':').collect();
-                if parts.len() >= 4 {
-                    let func_name = parts[1];
-                    let is_builtin = parts[2] == "true";
-                    let total_args: usize = parts[3].parse().unwrap_or(0);
-
-                    // Get placeholder positions from captured env
-                    let placeholder_positions: Vec<usize> = if let Some(env) = captured_env {
-                        if let Some(JValue::Array(positions)) = env.get("__placeholder_positions") {
-                            positions
-                                .iter()
-                                .filter_map(|v| v.as_f64().map(|n| n as usize))
-                                .collect()
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    };
-
-                    // Reconstruct the full argument list
-                    let mut full_args: Vec<JValue> = vec![JValue::Null; total_args];
-
-                    // Fill in bound arguments from captured environment
-                    if let Some(env) = captured_env {
-                        for (key, value) in env {
-                            if key.starts_with("__bound_arg_") {
-                                if let Ok(pos) = key[12..].parse::<usize>() {
-                                    if pos < total_args {
-                                        full_args[pos] = value.clone();
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Fill in placeholder positions with provided values
-                    for (i, &pos) in placeholder_positions.iter().enumerate() {
-                        if pos < total_args {
-                            let value = values.get(i).cloned().unwrap_or(JValue::Null);
-                            full_args[pos] = value;
-                        }
-                    }
-
-                    // If the partial captured its target as a closure value
-                    // (a user-defined function), invoke it directly — this is
-                    // what lets a partial application escape the scope that
-                    // defined the function it applies. Builtins/host fns fall
-                    // through to the name-based call below (they are global
-                    // and cannot dangle).
-                    if let Some(JValue::Lambda(target)) =
-                        captured_env.and_then(|env| env.get("__partial_target"))
-                    {
-                        let target = Rc::clone(target);
-                        self.context.pop_scope();
-                        return self.invoke_stored_lambda(&target, &full_args, data);
-                    }
-
-                    // Pop lambda scope, then push a new scope for temp args
-                    self.context.pop_scope();
-                    self.context.push_scope();
-
-                    // Build AST nodes for the function call arguments
-                    let mut temp_args: Vec<AstNode> = Vec::new();
-                    for (i, value) in full_args.iter().enumerate() {
-                        let temp_name = format!("__temp_arg_{}", i);
-                        self.context.bind(temp_name.clone(), value.clone());
-                        temp_args.push(AstNode::Variable(temp_name));
-                    }
-
-                    // Call the original function
-                    let result =
-                        self.evaluate_function_call(func_name, &temp_args, is_builtin, data);
-
-                    // Pop temp scope
-                    self.context.pop_scope();
-
-                    return result;
-                }
             }
         }
 
@@ -8769,6 +8732,7 @@ impl Evaluator {
                         captured_data: Some(data.clone()),
                         thunk: *thunk,
                         self_name: Some(var_name.clone()),
+                        partial: None,
                         live_token: LiveLambdaToken::new(),
                     };
                     let lambda_value = JValue::Lambda(Rc::new(stored_lambda));
@@ -10172,57 +10136,83 @@ impl Evaluator {
             .map(|(i, _)| format!("__p{}", i))
             .collect();
 
-        // Create a stored lambda that represents this partial application.
-        // The body is a marker that invoke_lambda_with_env interprets specially.
+        // A user-defined target is captured as a closure value so the partial
+        // still works after the target's defining scope pops; builtins and
+        // host fns stay name-resolved (they are global and cannot dangle, and
+        // by-name resolution preserves call-time shadowing).
+        let target = match self.context.lookup_lambda_value(name) {
+            Some(rc) => PartialTarget::Lambda(Rc::clone(rc)),
+            None => PartialTarget::Named {
+                name: name.to_string(),
+                is_builtin,
+            },
+        };
+
         let stored_lambda = StoredLambda {
             params: param_names,
-            body: AstNode::String(format!(
-                "__partial_call:{}:{}:{}",
-                name,
-                is_builtin,
-                args.len()
-            )),
-            compiled_body: None, // Partial application uses a special body marker
+            body: AstNode::Null, // Inert: invocation dispatches on `partial`
+            compiled_body: None,
             signature: None,
-            captured_env: {
-                let mut env = self.capture_current_environment();
-                // Store the bound arguments in the captured environment
-                for (pos, value) in &bound_args {
-                    env.insert(format!("__bound_arg_{}", pos), value.clone());
-                }
-                // Store placeholder positions
-                env.insert(
-                    "__placeholder_positions".to_string(),
-                    JValue::array(
-                        placeholder_positions
-                            .iter()
-                            .map(|p| JValue::Number(*p as f64))
-                            .collect::<Vec<_>>(),
-                    ),
-                );
-                // Store total argument count
-                env.insert(
-                    "__total_args".to_string(),
-                    JValue::Number(args.len() as f64),
-                );
-                // A user-defined target is captured as a value so the partial
-                // still works after the target's defining scope pops; builtins
-                // and host fns stay name-resolved (they are global).
-                if let Some(target) = self.context.lookup_lambda_value(name) {
-                    env.insert(
-                        "__partial_target".to_string(),
-                        JValue::Lambda(Rc::clone(target)),
-                    );
-                }
-                env
-            },
-            captured_data: Some(data.clone()),
+            captured_env: HashMap::new(),
+            captured_data: None, // Targets evaluate against the call-site data
             thunk: false,
             self_name: None,
+            partial: Some(Rc::new(PartialApplication {
+                target,
+                bound_args,
+                placeholder_positions,
+                total_args: args.len(),
+            })),
             live_token: LiveLambdaToken::new(),
         };
 
         Ok(JValue::Lambda(Rc::new(stored_lambda)))
+    }
+
+    /// Invoke a partial application: rebuild the full argument list (bound
+    /// values in their creation-time positions, call arguments filling the
+    /// placeholder positions in order, anything else Null) and apply the
+    /// target.
+    fn invoke_partial(
+        &mut self,
+        partial: &PartialApplication,
+        values: &[JValue],
+        data: &JValue,
+    ) -> Result<JValue, EvaluatorError> {
+        let mut full_args: Vec<JValue> = vec![JValue::Null; partial.total_args];
+        for (pos, value) in &partial.bound_args {
+            if *pos < partial.total_args {
+                full_args[*pos] = value.clone();
+            }
+        }
+        for (i, &pos) in partial.placeholder_positions.iter().enumerate() {
+            if pos < partial.total_args {
+                full_args[pos] = values.get(i).cloned().unwrap_or(JValue::Null);
+            }
+        }
+
+        match &partial.target {
+            PartialTarget::Lambda(stored) => {
+                let stored = Rc::clone(stored);
+                self.invoke_stored_lambda(&stored, &full_args, data)
+            }
+            PartialTarget::Named { name, is_builtin } => {
+                // Route through evaluate_function_call so builtins, host fns,
+                // late shadowing bindings and per-function special cases all
+                // behave exactly as a direct call would. It takes AST
+                // arguments, so pass the values via temporary bindings.
+                self.context.push_scope();
+                let mut temp_args: Vec<AstNode> = Vec::with_capacity(full_args.len());
+                for (i, value) in full_args.iter().enumerate() {
+                    let temp_name = format!("__temp_arg_{}", i);
+                    self.context.bind(temp_name.clone(), value.clone());
+                    temp_args.push(AstNode::Variable(temp_name));
+                }
+                let result = self.evaluate_function_call(name, &temp_args, *is_builtin, data);
+                self.context.pop_scope();
+                result
+            }
+        }
     }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2412,8 +2412,8 @@ enum LambdaResult {
     JValue(JValue),
     /// Tail call - need to continue with another lambda invocation
     TailCall {
-        /// The lambda to call (boxed to reduce enum size)
-        lambda: Box<StoredLambda>,
+        /// The lambda to call (shared handle; cloning is a refcount bump)
+        lambda: Rc<StoredLambda>,
         /// Arguments for the call
         args: Vec<JValue>,
         /// Data context for the call
@@ -2421,9 +2421,57 @@ enum LambdaResult {
     },
 }
 
+thread_local! {
+    static LIVE_LAMBDAS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Number of `StoredLambda` instances currently alive on this thread.
+///
+/// The snapshot-capture closure design cannot form `Rc` cycles (a closure can
+/// only capture values that existed before it did, and self-reference is
+/// late-bound at invocation rather than stored), so this count must return to
+/// its prior level once evaluation results are dropped. Exposed so tests can
+/// assert that repeated evaluation does not leak closures.
+pub fn live_lambda_count() -> usize {
+    LIVE_LAMBDAS.with(|c| c.get())
+}
+
+/// Marker owned by every `StoredLambda`, maintaining `live_lambda_count`.
+#[derive(Debug)]
+pub struct LiveLambdaToken(());
+
+impl LiveLambdaToken {
+    fn new() -> Self {
+        LIVE_LAMBDAS.with(|c| c.set(c.get() + 1));
+        LiveLambdaToken(())
+    }
+}
+
+impl Default for LiveLambdaToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for LiveLambdaToken {
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for LiveLambdaToken {
+    fn drop(&mut self) {
+        LIVE_LAMBDAS.with(|c| c.set(c.get() - 1));
+    }
+}
+
 /// Lambda storage
 /// Stores the AST of a lambda function along with its parameters, optional signature,
-/// and captured environment for closures
+/// and captured environment for closures.
+///
+/// Carried directly inside `JValue::Lambda(Rc<StoredLambda>)` (issue #157):
+/// the value IS the closure, so its lifetime is the `Rc`'s and no side table,
+/// escape analysis, or scope-pop migration is needed.
 #[derive(Clone, Debug)]
 pub struct StoredLambda {
     pub params: Vec<String>,
@@ -2432,25 +2480,50 @@ pub struct StoredLambda {
     /// `None` if the body is not compilable (transform, partial-app, thunk, etc.).
     pub(crate) compiled_body: Option<CompiledExpr>,
     pub signature: Option<String>,
-    /// Captured environment bindings for closures
+    /// Captured environment bindings for closures: a by-value snapshot of the
+    /// free variables at definition time (this engine's long-standing capture
+    /// semantics — NOT jsonata-js's live frames).
     pub captured_env: HashMap<String, JValue>,
     /// Captured data context for lexical scoping of bare field names
     pub captured_data: Option<JValue>,
     /// Whether this lambda's body contains tail calls that can be optimized
     pub thunk: bool,
+    /// The variable name this lambda was bound to at definition time
+    /// (`$f := function ...`). Bound to the closure itself at every
+    /// invocation, so recursion works after the defining scope has popped
+    /// (classic letrec, late-bound instead of stored — no `Rc` cycle).
+    pub self_name: Option<String>,
+    /// Keeps `live_lambda_count` accurate; see that function.
+    pub live_token: LiveLambdaToken,
+}
+
+impl StoredLambda {
+    /// Minimal instance for tests that need a lambda-shaped `JValue`.
+    #[cfg(test)]
+    pub(crate) fn test_stub() -> Self {
+        StoredLambda {
+            params: Vec::new(),
+            body: AstNode::Null,
+            compiled_body: None,
+            signature: None,
+            captured_env: HashMap::new(),
+            captured_data: None,
+            thunk: false,
+            self_name: None,
+            live_token: LiveLambdaToken::new(),
+        }
+    }
 }
 
 /// A single scope in the scope stack
 struct Scope {
     bindings: HashMap<String, JValue>,
-    lambdas: HashMap<String, Rc<StoredLambda>>,
 }
 
 impl Scope {
     fn new() -> Self {
         Scope {
             bindings: HashMap::new(),
-            lambdas: HashMap::new(),
         }
     }
 }
@@ -2484,28 +2557,10 @@ impl Context {
         }
     }
 
-    /// Pop scope but preserve specified lambdas by moving them to the current
-    /// top scope. The side table holds `Rc<StoredLambda>`, so migration is a
-    /// refcount bump, not a deep clone of the lambda's body AST.
-    fn pop_scope_preserving_lambdas(&mut self, lambda_ids: &[String]) {
-        if self.scope_stack.len() > 1 {
-            let popped = self.scope_stack.pop().unwrap();
-            if !lambda_ids.is_empty() {
-                let top = self.scope_stack.last_mut().unwrap();
-                for id in lambda_ids {
-                    if let Some(stored) = popped.lambdas.get(id) {
-                        top.lambdas.insert(id.clone(), Rc::clone(stored));
-                    }
-                }
-            }
-        }
-    }
-
-    /// Clear all bindings and lambdas in the top scope without deallocating
+    /// Clear all bindings in the top scope without deallocating
     fn clear_current_scope(&mut self) {
         let top = self.scope_stack.last_mut().unwrap();
         top.bindings.clear();
-        top.lambdas.clear();
     }
 
     pub fn bind(&mut self, name: String, value: JValue) {
@@ -2516,24 +2571,10 @@ impl Context {
             .insert(name, value);
     }
 
-    pub fn bind_lambda(&mut self, name: String, lambda: StoredLambda) {
-        self.bind_lambda_rc(name, Rc::new(lambda));
-    }
-
-    /// Bind an already-shared lambda (e.g. one migrating up a popped scope).
-    fn bind_lambda_rc(&mut self, name: String, lambda: Rc<StoredLambda>) {
-        self.scope_stack
-            .last_mut()
-            .unwrap()
-            .lambdas
-            .insert(name, lambda);
-    }
-
     pub fn unbind(&mut self, name: &str) {
         // Remove from top scope only
         let top = self.scope_stack.last_mut().unwrap();
         top.bindings.remove(name);
-        top.lambdas.remove(name);
     }
 
     pub fn lookup(&self, name: &str) -> Option<&JValue> {
@@ -2546,21 +2587,13 @@ impl Context {
         None
     }
 
-    pub fn lookup_lambda(&self, name: &str) -> Option<&StoredLambda> {
-        self.lookup_lambda_rc(name).map(|rc| rc.as_ref())
-    }
-
-    /// Like `lookup_lambda`, but hands out the shared handle (an Rc clone is
-    /// a refcount bump — this is what makes by-reference invocation and
-    /// scope-pop preservation cheap).
-    fn lookup_lambda_rc(&self, name: &str) -> Option<&Rc<StoredLambda>> {
-        // Walk scope stack from top to bottom
-        for scope in self.scope_stack.iter().rev() {
-            if let Some(lambda) = scope.lambdas.get(name) {
-                return Some(lambda);
-            }
+    /// Look up `name` and, if it is bound to a lambda value, hand out the
+    /// shared closure handle (an Rc clone is a refcount bump).
+    fn lookup_lambda_value(&self, name: &str) -> Option<&Rc<StoredLambda>> {
+        match self.lookup(name) {
+            Some(JValue::Lambda(rc)) => Some(rc),
+            _ => None,
         }
-        None
     }
 
     pub fn set_parent(&mut self, data: JValue) {
@@ -2826,12 +2859,6 @@ pub struct Evaluator {
     context: Context,
     recursion_depth: usize,
     max_recursion_depth: usize,
-    /// Monotonic counter for generating unique lambda IDs. Each evaluation of a
-    /// Lambda AST node creates a new closure *instance* and must get a fresh ID -
-    /// using the AST node's pointer address (as before) collided whenever the same
-    /// lambda expression was evaluated more than once (e.g. each level of Y-combinator
-    /// or other repeated recursion), aliasing unrelated closures that shared an id.
-    next_lambda_id: u64,
     /// Set whenever `create_tuple_stream` builds a `{"@":.., "__tuple__":true}`
     /// wrapper during this top-level `evaluate()` call. Reset at the start of
     /// `evaluate()` and checked at the end to decide whether the (recursive,
@@ -2866,7 +2893,6 @@ impl Evaluator {
             // Limit recursion depth to prevent stack overflow
             // True TCO would allow deeper recursion but requires parser-level thunk marking
             max_recursion_depth: 302,
-            next_lambda_id: 0,
             tuple_stream_created: false,
             keep_tuple_stream: false,
             options: EvaluatorOptions::default(),
@@ -2880,7 +2906,6 @@ impl Evaluator {
             context,
             recursion_depth: 0,
             max_recursion_depth: 302,
-            next_lambda_id: 0,
             tuple_stream_created: false,
             keep_tuple_stream: false,
             options: EvaluatorOptions::default(),
@@ -2896,7 +2921,6 @@ impl Evaluator {
             context,
             recursion_depth: 0,
             max_recursion_depth: 302,
-            next_lambda_id: 0,
             tuple_stream_created: false,
             keep_tuple_stream: false,
             options,
@@ -2976,19 +3000,17 @@ impl Evaluator {
         Ok(())
     }
 
-    /// Allocate a fresh, process-unique-per-Evaluator id for a new lambda instance.
-    fn fresh_lambda_id(&mut self) -> u64 {
-        let id = self.next_lambda_id;
-        self.next_lambda_id += 1;
-        id
-    }
-
     /// Invoke a stored lambda with its captured environment and data.
     /// This is the standard way to call a StoredLambda, handling the
     /// captured_env and captured_data extraction boilerplate.
+    ///
+    /// Takes the shared handle so the closure's `self_name` (if any) can be
+    /// bound to the closure itself for the duration of the call — that is
+    /// what makes `$f := function(){ ...$f()... }` work after `$f` has
+    /// escaped its defining scope (late-bound letrec, no stored self-`Rc`).
     fn invoke_stored_lambda(
         &mut self,
-        stored: &StoredLambda,
+        stored: &Rc<StoredLambda>,
         args: &[JValue],
         data: &JValue,
     ) -> Result<JValue, EvaluatorError> {
@@ -3030,15 +3052,14 @@ impl Evaluator {
             captured_env,
             captured_data,
             stored.thunk,
+            Some(stored),
         )
     }
 
-    /// Look up a StoredLambda from a JValue that may be a lambda marker.
-    /// Returns the cloned StoredLambda if the value is a JValue::Lambda variant
-    /// with a valid lambda_id that references a stored lambda.
+    /// Extract the shared closure handle from a JValue, if it is a lambda.
     fn lookup_lambda_from_value(&self, value: &JValue) -> Option<Rc<StoredLambda>> {
-        if let JValue::Lambda { lambda_id, .. } = value {
-            return self.context.lookup_lambda_rc(lambda_id).cloned();
+        if let JValue::Lambda(rc) = value {
+            return Some(Rc::clone(rc));
         }
         None
     }
@@ -3050,13 +3071,10 @@ impl Evaluator {
         match func_node {
             AstNode::Lambda { params, .. } => params.len(),
             AstNode::Variable(var_name) => {
-                // Check if this variable holds a stored lambda
-                if let Some(stored_lambda) = self.context.lookup_lambda(var_name) {
-                    return stored_lambda.params.len();
-                }
-                // Also check if it's a lambda value in bindings (e.g., from partial application)
+                // Check if this variable holds a lambda value (user-defined
+                // function, closure, or partial application)
                 if let Some(value) = self.context.lookup(var_name) {
-                    if let Some(stored_lambda) = self.lookup_lambda_from_value(value) {
+                    if let JValue::Lambda(stored_lambda) = value {
                         return stored_lambda.params.len();
                     }
                     // `$f := $uppercase` stores a `JValue::Builtin`, so the
@@ -3562,20 +3580,6 @@ impl Evaluator {
                     }
                 }
 
-                // Then check if this is a stored lambda (user-defined functions)
-                if let Some(stored_lambda) = self.context.lookup_lambda(name) {
-                    // Return a lambda representation that can be passed to higher-order functions
-                    // Include _lambda_id pointing to the stored lambda so it can be found
-                    // when captured in closures
-                    let lambda_repr = JValue::lambda(
-                        name.as_str(),
-                        stored_lambda.params.clone(),
-                        Some(name.to_string()),
-                        stored_lambda.signature.clone(),
-                    );
-                    return Ok(lambda_repr);
-                }
-
                 // Check if this is a built-in function reference (only if not shadowed)
                 if self.is_builtin_function(name) {
                     // Return a marker for built-in functions
@@ -3980,10 +3984,9 @@ impl Evaluator {
                     result = self.evaluate_internal(expr, data)?;
                 }
 
-                // Before popping, preserve any lambdas referenced by the result
-                // This is essential for closures returned from blocks (IIFE pattern)
-                let lambdas_to_keep = self.extract_lambda_ids(&result);
-                self.context.pop_scope_preserving_lambdas(&lambdas_to_keep);
+                // Closures escaping the block (IIFE pattern) carry their own
+                // storage inside the value, so popping is unconditional.
+                self.context.pop_scope();
 
                 Ok(result)
             }
@@ -3995,8 +3998,6 @@ impl Evaluator {
                 signature,
                 thunk,
             } => {
-                let lambda_id = format!("__lambda_{}_{}", params.len(), self.fresh_lambda_id());
-
                 let compiled_body = if !thunk {
                     let var_refs: Vec<&str> = params.iter().map(|s| s.as_str()).collect();
                     try_compile_expr_with_allowed_vars(body, &var_refs)
@@ -4011,17 +4012,10 @@ impl Evaluator {
                     captured_env: self.capture_environment_for(body, params),
                     captured_data: Some(data.clone()),
                     thunk: *thunk,
+                    self_name: None,
+                    live_token: LiveLambdaToken::new(),
                 };
-                self.context.bind_lambda(lambda_id.clone(), stored_lambda);
-
-                let lambda_obj = JValue::lambda(
-                    lambda_id.as_str(),
-                    params.clone(),
-                    None::<String>,
-                    signature.clone(),
-                );
-
-                Ok(lambda_obj)
+                Ok(JValue::Lambda(Rc::new(stored_lambda)))
             }
 
             // Wildcard: collect all values from current object
@@ -4107,8 +4101,10 @@ impl Evaluator {
                     // Execute the transformation
                     self.execute_transform(location, update, delete.as_deref(), data)
                 } else {
-                    // Return a lambda representation
-                    // The transform will be executed when the lambda is invoked
+                    // Return a function value; the transform executes when the
+                    // lambda is invoked (with $ bound to its argument). Being an
+                    // ordinary value, it can be bound to a variable, passed
+                    // around, and applied via `~>` like in jsonata-js.
                     let transform_lambda = StoredLambda {
                         params: vec!["$".to_string()],
                         body: AstNode::Transform {
@@ -4121,14 +4117,10 @@ impl Evaluator {
                         captured_env: HashMap::new(),
                         captured_data: None, // Transform takes $ as parameter
                         thunk: false,
+                        self_name: None,
+                        live_token: LiveLambdaToken::new(),
                     };
-
-                    // Store with a generated unique name
-                    let lambda_name = format!("__transform_{}", self.fresh_lambda_id());
-                    self.context.bind_lambda(lambda_name, transform_lambda);
-
-                    // Return lambda marker
-                    Ok(JValue::string("<lambda>"))
+                    Ok(JValue::Lambda(Rc::new(transform_lambda)))
                 }
             }
 
@@ -6624,19 +6616,15 @@ impl Evaluator {
                     captured_env,
                     captured_data: Some(data.clone()),
                     thunk: *thunk,
+                    // Named definition: the closure knows its own name so the
+                    // body's recursive `$f(...)` resolves to THIS closure at
+                    // every invocation, wherever the value has traveled.
+                    self_name: Some(var_name.clone()),
+                    live_token: LiveLambdaToken::new(),
                 };
-                let lambda_params = stored_lambda.params.clone();
-                let lambda_sig = stored_lambda.signature.clone();
-                self.context.bind_lambda(var_name.clone(), stored_lambda);
-
-                // Return a lambda marker value (include _lambda_id so it can be found later)
-                let lambda_repr = JValue::lambda(
-                    var_name.as_str(),
-                    lambda_params,
-                    Some(var_name.clone()),
-                    lambda_sig,
-                );
-                return Ok(lambda_repr);
+                let lambda_value = JValue::Lambda(Rc::new(stored_lambda));
+                self.context.bind(var_name, lambda_value.clone());
+                return Ok(lambda_value);
             }
 
             // Check if RHS is a pure function composition (ChainPipe between function references)
@@ -6656,7 +6644,7 @@ impl Evaluator {
                     // LHS is a function reference like $trim or $sum
                     AstNode::Variable(name)
                         if self.is_builtin_function(name)
-                            || self.context.lookup_lambda(name).is_some() =>
+                            || self.context.lookup_lambda_value(name).is_some() =>
                     {
                         true
                     }
@@ -6704,29 +6692,19 @@ impl Evaluator {
                         captured_env: self.capture_current_environment(),
                         captured_data: Some(data.clone()),
                         thunk: false,
+                        self_name: Some(var_name.clone()),
+                        live_token: LiveLambdaToken::new(),
                     };
-                    self.context.bind_lambda(var_name.clone(), stored_lambda);
-
-                    // Return a lambda marker value (include _lambda_id for later lookup)
-                    let lambda_repr = JValue::lambda(
-                        var_name.as_str(),
-                        vec!["$".to_string()],
-                        Some(var_name.clone()),
-                        None::<String>,
-                    );
-                    return Ok(lambda_repr);
+                    let lambda_value = JValue::Lambda(Rc::new(stored_lambda));
+                    self.context.bind(var_name, lambda_value.clone());
+                    return Ok(lambda_value);
                 }
                 // If not function composition, fall through to normal evaluation below
             }
 
-            // Evaluate the RHS
+            // Evaluate the RHS. A lambda value carries its own closure, so
+            // aliasing (`$g := $f`) is just binding the value.
             let value = self.evaluate_internal(rhs, data)?;
-
-            // If the value is a lambda, alias the shared stored lambda under
-            // the new variable name (refcount bump, not a copy)
-            if let Some(stored) = self.lookup_lambda_from_value(&value) {
-                self.context.bind_lambda_rc(var_name.clone(), stored);
-            }
 
             // Bind even if undefined (null) so inner scopes can shadow outer variables
             self.context.bind(var_name, value.clone());
@@ -6982,19 +6960,18 @@ impl Evaluator {
             return self.create_partial_application(name, args, is_builtin, data);
         }
 
-        // FIRST check if this variable holds a function value (lambda or builtin reference)
-        // This is critical for:
-        // 1. Allowing function parameters to shadow stored lambdas
-        //    (e.g., Y-combinator pattern: function($g){$g($g)} where parameter $g shadows outer $g)
-        // 2. Calling built-in functions passed as parameters
-        //    (e.g., λ($f){$f(5)}($sum) where $f is bound to $sum reference)
+        // FIRST check if this variable holds a function value (lambda or builtin
+        // reference). User-defined functions, closures, partial applications and
+        // parameters holding function values are all ordinary bindings now, so
+        // one lookup covers them — and parameter shadowing (Y-combinator's
+        // function($g){$g($g)}) falls out of plain scope order.
         if let Some(value) = self.context.lookup(name).cloned() {
-            if let Some(stored_lambda) = self.lookup_lambda_from_value(&value) {
+            if let JValue::Lambda(stored_lambda) = &value {
                 let mut evaluated_args = Vec::with_capacity(args.len());
                 for arg in args {
                     evaluated_args.push(self.evaluate_internal(arg, data)?);
                 }
-                return self.invoke_stored_lambda(&stored_lambda, &evaluated_args, data);
+                return self.invoke_stored_lambda(stored_lambda, &evaluated_args, data);
             }
             if let JValue::Builtin { name: builtin_name } = &value {
                 // This is a built-in function reference (e.g., $f bound to $sum),
@@ -7007,16 +6984,6 @@ impl Evaluator {
                 }
                 return self.call_builtin_with_values(builtin_name, &evaluated_args, data, false);
             }
-        }
-
-        // THEN check if this is a stored lambda (user-defined function by name)
-        // This only applies if not shadowed by a binding above
-        if let Some(stored_lambda) = self.context.lookup_lambda(name).cloned() {
-            let mut evaluated_args = Vec::with_capacity(args.len());
-            for arg in args {
-                evaluated_args.push(self.evaluate_internal(arg, data)?);
-            }
-            return self.invoke_stored_lambda(&stored_lambda, &evaluated_args, data);
         }
 
         // THEN a host-registered custom function (register_fn / register_fn_override).
@@ -7071,12 +7038,8 @@ impl Evaluator {
                     return Ok(JValue::Bool(true)); // Built-in function exists
                 }
 
-                // Check if it's a stored lambda
-                if self.context.lookup_lambda(var_name).is_some() {
-                    return Ok(JValue::Bool(true)); // Lambda exists
-                }
-
-                // Check if the variable is defined
+                // Check if the variable is defined (lambda values are ordinary
+                // bindings, so this covers user-defined functions too)
                 if let Some(val) = self.context.lookup(var_name) {
                     // A variable bound to the undefined marker doesn't "exist"
                     if val.is_undefined() {
@@ -7657,7 +7620,7 @@ impl Evaluator {
                             }
                             // Stored lambda variable fast path: $var with pre-compiled body
                             if let AstNode::Variable(var_name) = &args[1] {
-                                if let Some(stored) = self.context.lookup_lambda(var_name) {
+                                if let Some(stored) = self.context.lookup_lambda_value(var_name) {
                                     if let Some(ref ce) = stored.compiled_body.clone() {
                                         let param_name = stored.params[0].clone();
                                         let captured_data = stored.captured_data.clone();
@@ -7801,7 +7764,7 @@ impl Evaluator {
                     }
                     // Stored lambda variable fast path: $var with pre-compiled body
                     if let AstNode::Variable(var_name) = &args[1] {
-                        if let Some(stored) = self.context.lookup_lambda(var_name) {
+                        if let Some(stored) = self.context.lookup_lambda_value(var_name) {
                             if let Some(ref ce) = stored.compiled_body.clone() {
                                 let param_name = stored.params[0].clone();
                                 let captured_data = stored.captured_data.clone();
@@ -7962,7 +7925,7 @@ impl Evaluator {
                     }
                     // Stored lambda variable fast path: $var with pre-compiled body
                     if let AstNode::Variable(var_name) = &args[1] {
-                        if let Some(stored) = self.context.lookup_lambda(var_name) {
+                        if let Some(stored) = self.context.lookup_lambda_value(var_name) {
                             if stored.params.len() == 2 {
                                 if let Some(ref ce) = stored.compiled_body.clone() {
                                     let acc_param = stored.params[0].clone();
@@ -8234,14 +8197,11 @@ impl Evaluator {
                 }
             }
             AstNode::Variable(var_name) => {
-                // Check if this variable holds a stored lambda
-                if let Some(stored_lambda) = self.context.lookup_lambda(var_name).cloned() {
-                    self.invoke_stored_lambda(&stored_lambda, values, data)
-                } else if let Some(value) = self.context.lookup(var_name).cloned() {
-                    // Check if this variable holds a lambda value
-                    // This handles lambdas passed as bound arguments in partial applications
-                    if let Some(stored) = self.lookup_lambda_from_value(&value) {
-                        return self.invoke_stored_lambda(&stored, values, data);
+                if let Some(value) = self.context.lookup(var_name).cloned() {
+                    // A lambda value covers user-defined functions, closures and
+                    // partial applications alike
+                    if let JValue::Lambda(stored) = &value {
+                        return self.invoke_stored_lambda(stored, values, data);
                     }
                     // `$f := $uppercase` binds a `JValue::Builtin`, which is
                     // not a lambda and so fell through to "evaluate as a plain
@@ -8433,10 +8393,17 @@ impl Evaluator {
         data: &JValue,
         thunk: bool,
     ) -> Result<JValue, EvaluatorError> {
-        self.invoke_lambda_with_env(params, body, signature, values, data, None, None, thunk)
+        self.invoke_lambda_with_env(
+            params, body, signature, values, data, None, None, thunk, None,
+        )
     }
 
-    /// Invoke a lambda with optional captured environment (for closures)
+    /// Invoke a lambda with optional captured environment (for closures).
+    ///
+    /// `self_rc` is the shared closure handle when the caller is invoking a
+    /// `StoredLambda` value; if that closure has a `self_name`, the name is
+    /// bound to the closure itself for the call (late-bound letrec).
+    #[allow(clippy::too_many_arguments)]
     fn invoke_lambda_with_env(
         &mut self,
         params: &[String],
@@ -8447,17 +8414,23 @@ impl Evaluator {
         captured_env: Option<&HashMap<String, JValue>>,
         captured_data: Option<&JValue>,
         thunk: bool,
+        self_rc: Option<&Rc<StoredLambda>>,
     ) -> Result<JValue, EvaluatorError> {
         // If this is a thunk (has tail calls), use TCO trampoline
         if thunk {
-            let stored = StoredLambda {
-                params: params.to_vec(),
-                body: body.clone(),
-                compiled_body: None, // Thunks use TCO, not the compiled fast path
-                signature: signature.cloned(),
-                captured_env: captured_env.cloned().unwrap_or_default(),
-                captured_data: captured_data.cloned(),
-                thunk,
+            let stored = match self_rc {
+                Some(rc) => Rc::clone(rc),
+                None => Rc::new(StoredLambda {
+                    params: params.to_vec(),
+                    body: body.clone(),
+                    compiled_body: None, // Thunks use TCO, not the compiled fast path
+                    signature: signature.cloned(),
+                    captured_env: captured_env.cloned().unwrap_or_default(),
+                    captured_data: captured_data.cloned(),
+                    thunk,
+                    self_name: None,
+                    live_token: LiveLambdaToken::new(),
+                }),
             };
             return self.invoke_lambda_with_tco(&stored, values, data);
         }
@@ -8470,6 +8443,17 @@ impl Evaluator {
         if let Some(env) = captured_env {
             for (name, value) in env {
                 self.context.bind(name.clone(), value.clone());
+            }
+        }
+
+        // Late-bound self-reference: shadows any captured binding of the same
+        // name (a rebinding `$f := function(){ ...$f()... }` must recurse into
+        // itself, not the captured previous $f); parameters bind after this
+        // and shadow it in turn.
+        if let Some(rc) = self_rc {
+            if let Some(self_name) = &rc.self_name {
+                self.context
+                    .bind(self_name.clone(), JValue::Lambda(Rc::clone(rc)));
             }
         }
 
@@ -8543,6 +8527,20 @@ impl Evaluator {
                         }
                     }
 
+                    // If the partial captured its target as a closure value
+                    // (a user-defined function), invoke it directly — this is
+                    // what lets a partial application escape the scope that
+                    // defined the function it applies. Builtins/host fns fall
+                    // through to the name-based call below (they are global
+                    // and cannot dangle).
+                    if let Some(JValue::Lambda(target)) =
+                        captured_env.and_then(|env| env.get("__partial_target"))
+                    {
+                        let target = Rc::clone(target);
+                        self.context.pop_scope();
+                        return self.invoke_stored_lambda(&target, &full_args, data);
+                    }
+
                     // Pop lambda scope, then push a new scope for temp args
                     self.context.pop_scope();
                     self.context.push_scope();
@@ -8570,26 +8568,10 @@ impl Evaluator {
         // Evaluate lambda body (normal case)
         // Use captured_data for lexical scoping if available, otherwise use call-site data
         let body_data = captured_data.unwrap_or(data);
-        let result = self.evaluate_internal(body, body_data)?;
-
-        // Pop lambda scope, preserving any lambdas referenced by the return value
-        // Fast path: scalar results can never contain lambda references
-        let is_scalar = matches!(
-            &result,
-            JValue::Number(_)
-                | JValue::Bool(_)
-                | JValue::String(_)
-                | JValue::Null
-                | JValue::Undefined
-        );
-        if is_scalar {
-            self.context.pop_scope();
-        } else {
-            let lambdas_to_keep = self.extract_lambda_ids(&result);
-            self.context.pop_scope_preserving_lambdas(&lambdas_to_keep);
-        }
-
-        Ok(result)
+        let result = self.evaluate_internal(body, body_data);
+        // A returned closure carries its own storage; popping is unconditional.
+        self.context.pop_scope();
+        result
     }
 
     /// Invoke a lambda with tail call optimization using a trampoline
@@ -8597,11 +8579,11 @@ impl Evaluator {
     /// growing the stack, enabling deep recursion for tail-recursive functions.
     fn invoke_lambda_with_tco(
         &mut self,
-        stored_lambda: &StoredLambda,
+        stored_lambda: &Rc<StoredLambda>,
         initial_args: &[JValue],
         data: &JValue,
     ) -> Result<JValue, EvaluatorError> {
-        let mut current_lambda = stored_lambda.clone();
+        let mut current_lambda = Rc::clone(stored_lambda);
         let mut current_args = initial_args.to_vec();
         let mut current_data = data.clone();
 
@@ -8648,16 +8630,15 @@ impl Evaluator {
                 LambdaResult::JValue(v) => break v,
                 LambdaResult::TailCall { lambda, args, data } => {
                     // Continue with the tail call - no stack growth
-                    current_lambda = *lambda;
+                    current_lambda = lambda;
                     current_args = args;
                     current_data = data;
                 }
             }
         };
 
-        // Pop the persistent TCO scope, preserving lambdas referenced by the result
-        let lambdas_to_keep = self.extract_lambda_ids(&result);
-        self.context.pop_scope_preserving_lambdas(&lambdas_to_keep);
+        // Pop the persistent TCO scope; escaping closures carry their own storage.
+        self.context.pop_scope();
 
         Ok(result)
     }
@@ -8668,7 +8649,7 @@ impl Evaluator {
     /// manages the persistent scope for the trampoline loop.
     fn invoke_lambda_body_for_tco(
         &mut self,
-        lambda: &StoredLambda,
+        lambda: &Rc<StoredLambda>,
         values: &[JValue],
         data: &JValue,
     ) -> Result<LambdaResult, EvaluatorError> {
@@ -8683,6 +8664,13 @@ impl Evaluator {
         // Apply captured environment
         for (name, value) in &lambda.captured_env {
             self.context.bind(name.clone(), value.clone());
+        }
+
+        // Late-bound self-reference (shadows a captured binding of the same
+        // name; parameters shadow it in turn)
+        if let Some(self_name) = &lambda.self_name {
+            self.context
+                .bind(self_name.clone(), JValue::Lambda(Rc::clone(lambda)));
         }
 
         // Bind parameters
@@ -8780,11 +8768,12 @@ impl Evaluator {
                         captured_env,
                         captured_data: Some(data.clone()),
                         thunk: *thunk,
+                        self_name: Some(var_name.clone()),
+                        live_token: LiveLambdaToken::new(),
                     };
-                    self.context.bind_lambda(var_name, stored_lambda);
-                    let lambda_repr =
-                        JValue::lambda("anon", params.clone(), None::<String>, None::<String>);
-                    return Ok(LambdaResult::JValue(lambda_repr));
+                    let lambda_value = JValue::Lambda(Rc::new(stored_lambda));
+                    self.context.bind(var_name, lambda_value.clone());
+                    return Ok(LambdaResult::JValue(lambda_value));
                 }
 
                 // Evaluate the RHS
@@ -8795,15 +8784,15 @@ impl Evaluator {
 
             // Function call - this is where TCO happens
             AstNode::Function { name, args, .. } => {
-                // Check if this is a call to a stored lambda (user function)
-                if let Some(stored_lambda) = self.context.lookup_lambda(name).cloned() {
+                // Check if this is a call to a lambda value (user function)
+                if let Some(stored_lambda) = self.context.lookup_lambda_value(name).cloned() {
                     if stored_lambda.thunk {
                         let mut evaluated_args = Vec::with_capacity(args.len());
                         for arg in args {
                             evaluated_args.push(self.evaluate_internal(arg, data)?);
                         }
                         return Ok(LambdaResult::TailCall {
-                            lambda: Box::new(stored_lambda),
+                            lambda: stored_lambda,
                             args: evaluated_args,
                             data: data.clone(),
                         });
@@ -8820,19 +8809,18 @@ impl Evaluator {
                 let callable = self.evaluate_internal(procedure, data)?;
 
                 // Check if it's a lambda with TCO
-                if let JValue::Lambda { lambda_id, .. } = &callable {
-                    if let Some(stored_lambda) = self.context.lookup_lambda(lambda_id).cloned() {
-                        if stored_lambda.thunk {
-                            let mut evaluated_args = Vec::with_capacity(args.len());
-                            for arg in args {
-                                evaluated_args.push(self.evaluate_internal(arg, data)?);
-                            }
-                            return Ok(LambdaResult::TailCall {
-                                lambda: Box::new(stored_lambda),
-                                args: evaluated_args,
-                                data: data.clone(),
-                            });
+                if let JValue::Lambda(stored_lambda) = &callable {
+                    if stored_lambda.thunk {
+                        let stored_lambda = Rc::clone(stored_lambda);
+                        let mut evaluated_args = Vec::with_capacity(args.len());
+                        for arg in args {
+                            evaluated_args.push(self.evaluate_internal(arg, data)?);
                         }
+                        return Ok(LambdaResult::TailCall {
+                            lambda: stored_lambda,
+                            args: evaluated_args,
+                            data: data.clone(),
+                        });
                     }
                 }
                 // Not a thunk - evaluate normally
@@ -9937,61 +9925,6 @@ impl Evaluator {
         }
     }
 
-    /// Extract lambda IDs from a value (used for closure preservation)
-    /// Finds any lambda_id references in the value so they can be preserved
-    /// when exiting a block scope
-    fn extract_lambda_ids(&self, value: &JValue) -> Vec<String> {
-        // Fast path: scalars can never contain lambda references
-        match value {
-            JValue::Number(_)
-            | JValue::Bool(_)
-            | JValue::String(_)
-            | JValue::Null
-            | JValue::Undefined
-            | JValue::Regex { .. }
-            | JValue::Builtin { .. } => return Vec::new(),
-            _ => {}
-        }
-        let mut ids = Vec::new();
-        self.collect_lambda_ids(value, &mut ids);
-        ids
-    }
-
-    fn collect_lambda_ids(&self, value: &JValue, ids: &mut Vec<String>) {
-        match value {
-            JValue::Lambda { lambda_id, .. } => {
-                let id_str = lambda_id.to_string();
-                if !ids.contains(&id_str) {
-                    ids.push(id_str);
-                    // Transitively follow the stored lambda's captured_env
-                    // to find all referenced lambdas. This is critical for
-                    // closures like the Y-combinator where returned lambdas
-                    // capture other lambdas in their environment.
-                    if let Some(stored) = self.context.lookup_lambda(lambda_id) {
-                        let env_values: Vec<JValue> =
-                            stored.captured_env.values().cloned().collect();
-                        for env_value in &env_values {
-                            self.collect_lambda_ids(env_value, ids);
-                        }
-                    }
-                }
-            }
-            JValue::Object(map) => {
-                // Recurse into object values
-                for v in map.values() {
-                    self.collect_lambda_ids(v, ids);
-                }
-            }
-            JValue::Array(arr) => {
-                // Recurse into array elements
-                for v in arr.iter() {
-                    self.collect_lambda_ids(v, ids);
-                }
-            }
-            _ => {}
-        }
-    }
-
     /// Addition
     /// Get human-readable type name for error messages
     fn type_name(value: &JValue) -> &'static str {
@@ -10198,12 +10131,11 @@ impl Evaluator {
         data: &JValue,
     ) -> Result<JValue, EvaluatorError> {
         // First, look up the function to ensure it exists
-        let is_lambda = self.context.lookup_lambda(name).is_some()
-            || (self
-                .context
-                .lookup(name)
-                .map(|v| matches!(v, JValue::Lambda { .. }))
-                .unwrap_or(false));
+        let is_lambda = self
+            .context
+            .lookup(name)
+            .map(|v| matches!(v, JValue::Lambda { .. }))
+            .unwrap_or(false);
 
         // Built-in functions must be called with $ prefix for partial application
         // Without $, it's an error (T1007) suggesting the user forgot the $
@@ -10240,19 +10172,10 @@ impl Evaluator {
             .map(|(i, _)| format!("__p{}", i))
             .collect();
 
-        // Store the partial application info as a special lambda
-        // When invoked, it will call the original function with bound + placeholder args
-        let partial_id = format!(
-            "__partial_{}_{}_{}",
-            name,
-            placeholder_positions.len(),
-            bound_args.len()
-        );
-
-        // Create a stored lambda that represents this partial application
-        // The body is a marker that we'll interpret specially during invocation
+        // Create a stored lambda that represents this partial application.
+        // The body is a marker that invoke_lambda_with_env interprets specially.
         let stored_lambda = StoredLambda {
-            params: param_names.clone(),
+            params: param_names,
             body: AstNode::String(format!(
                 "__partial_call:{}:{}:{}",
                 name,
@@ -10282,23 +10205,24 @@ impl Evaluator {
                     "__total_args".to_string(),
                     JValue::Number(args.len() as f64),
                 );
+                // A user-defined target is captured as a value so the partial
+                // still works after the target's defining scope pops; builtins
+                // and host fns stay name-resolved (they are global).
+                if let Some(target) = self.context.lookup_lambda_value(name) {
+                    env.insert(
+                        "__partial_target".to_string(),
+                        JValue::Lambda(Rc::clone(target)),
+                    );
+                }
                 env
             },
             captured_data: Some(data.clone()),
             thunk: false,
+            self_name: None,
+            live_token: LiveLambdaToken::new(),
         };
 
-        self.context.bind_lambda(partial_id.clone(), stored_lambda);
-
-        // Return a lambda object that can be invoked
-        let lambda_obj = JValue::lambda(
-            partial_id.as_str(),
-            param_names,
-            Some(name.to_string()),
-            None::<String>,
-        );
-
-        Ok(lambda_obj)
+        Ok(JValue::Lambda(Rc::new(stored_lambda)))
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -25,12 +25,11 @@ pub enum JValue {
 
     // Internal types (previously tagged objects)
     Undefined,
-    Lambda {
-        lambda_id: Rc<str>,
-        params: Rc<Vec<String>>,
-        name: Option<Rc<str>>,
-        signature: Option<Rc<str>>,
-    },
+    /// A function value carrying its closure directly (issue #157). The `Rc`
+    /// provides the closure's lifetime: a lambda escaping its defining scope
+    /// stays alive for as long as any value references it, with no side table
+    /// or escape analysis involved.
+    Lambda(Rc<crate::evaluator::StoredLambda>),
     Builtin {
         name: Rc<str>,
     },
@@ -258,21 +257,6 @@ impl JValue {
     }
 
     #[inline]
-    pub fn lambda(
-        lambda_id: impl Into<Rc<str>>,
-        params: Vec<String>,
-        name: Option<impl Into<Rc<str>>>,
-        signature: Option<impl Into<Rc<str>>>,
-    ) -> Self {
-        JValue::Lambda {
-            lambda_id: lambda_id.into(),
-            params: Rc::new(params),
-            name: name.map(|n| n.into()),
-            signature: signature.map(|s| s.into()),
-        }
-    }
-
-    #[inline]
     pub fn builtin(name: impl Into<Rc<str>>) -> Self {
         JValue::Builtin { name: name.into() }
     }
@@ -383,7 +367,9 @@ impl PartialEq for JValue {
             (JValue::String(a), JValue::String(b)) => a == b,
             (JValue::Array(a), JValue::Array(b)) => a == b,
             (JValue::Object(a), JValue::Object(b)) => a == b,
-            (JValue::Lambda { lambda_id: a, .. }, JValue::Lambda { lambda_id: b, .. }) => a == b,
+            // Function identity, like JS: two lambda values are equal only if
+            // they are the same closure instance.
+            (JValue::Lambda(a), JValue::Lambda(b)) => Rc::ptr_eq(a, b),
             (JValue::Builtin { name: a }, JValue::Builtin { name: b }) => a == b,
             (
                 JValue::Regex {
@@ -452,7 +438,7 @@ impl fmt::Display for JValue {
                 }
                 write!(f, "}}")
             }
-            JValue::Lambda { lambda_id, .. } => write!(f, "\"<lambda:{}>\"", lambda_id),
+            JValue::Lambda(_) => write!(f, "\"<lambda>\""),
             JValue::Builtin { name } => write!(f, "\"<builtin:{}>\"", name),
             JValue::Regex { pattern, flags } => write!(f, "\"<regex:/{}/{}>\"", pattern, flags),
             #[cfg(feature = "python")]
@@ -875,8 +861,9 @@ mod tests {
         assert!(JValue::string("hello").is_string());
         assert!(JValue::array(vec![]).is_array());
         assert!(JValue::object(IndexMap::new()).is_object());
-        assert!(JValue::lambda("id", vec![], None::<&str>, None::<&str>).is_lambda());
-        assert!(JValue::lambda("id", vec![], None::<&str>, None::<&str>).is_function());
+        let lambda = JValue::Lambda(Rc::new(crate::evaluator::StoredLambda::test_stub()));
+        assert!(lambda.is_lambda());
+        assert!(lambda.is_function());
         assert!(JValue::builtin("sum").is_builtin());
         assert!(JValue::builtin("sum").is_function());
         assert!(JValue::regex(".*", "i").is_regex());

--- a/tests/lambda_closure_suite.rs
+++ b/tests/lambda_closure_suite.rs
@@ -1,0 +1,449 @@
+// Letrec / closure stress suite (issue #157, prerequisite work).
+//
+// Pins the CURRENT behavior of lambda storage, closure capture, recursion,
+// escaping closures, rebinding, partial application, transforms-as-values and
+// the TCO trampoline, so the JValue::Lambda redesign (carrying the closure in
+// the value instead of a lambda_id tag into a per-scope side table) has a
+// behavioral baseline to diff against.
+//
+// Tests whose current behavior DIVERGES from jsonata-js are grouped in the
+// `divergent_from_reference` module at the bottom, each with a comment stating
+// what the reference implementation (jsonata-js 2.x, verified directly with
+// node against tests/jsonata-js/src/jsonata.js) returns. The redesign is
+// expected to change some of these; when it does, the assertions there should
+// be updated deliberately, in the same commit, with the rationale.
+
+use jsonata_core::{evaluator::Evaluator, parser::parse, value::JValue};
+
+/// Evaluate `expr` against `{}` and return the result.
+fn eval(expr: &str) -> Result<JValue, String> {
+    let ast = parse(expr).map_err(|e| format!("parse error: {e:?}"))?;
+    let mut evaluator = Evaluator::new();
+    let data = JValue::from_json_str("{}").unwrap();
+    evaluator.evaluate(&ast, &data).map_err(|e| format!("{e}"))
+}
+
+/// Evaluate and compare against an expected JSON literal.
+fn assert_eval(expr: &str, expected_json: &str) {
+    let result = eval(expr).unwrap_or_else(|e| panic!("{expr}\n  unexpected error: {e}"));
+    let expected = JValue::from_json_str(expected_json).unwrap();
+    assert_eq!(result, expected, "expression: {expr}");
+}
+
+/// Evaluate and expect an error whose message contains `fragment`.
+fn assert_error_contains(expr: &str, fragment: &str) {
+    match eval(expr) {
+        Ok(v) => panic!("{expr}\n  expected error containing {fragment:?}, got value {v}"),
+        Err(msg) => assert!(
+            msg.contains(fragment),
+            "{expr}\n  expected error containing {fragment:?}, got: {msg}"
+        ),
+    }
+}
+
+// ── Direct recursion ─────────────────────────────────────────────────────────
+
+#[test]
+fn direct_recursion_factorial() {
+    assert_eval(
+        "( $f := function($x){ $x <= 1 ? 1 : $x * $f($x-1) }; $f(5) )",
+        "120",
+    );
+}
+
+#[test]
+fn direct_recursion_building_arrays() {
+    assert_eval(
+        "( $fn := function($m){ $m = 0 ? [] : $append($fn($m-1), [$m]) }; $fn(4) )",
+        "[1,2,3,4]",
+    );
+}
+
+#[test]
+fn deep_tail_recursion_uses_tco() {
+    // 50k frames would overflow the real stack; the TCO trampoline must kick in.
+    assert_eval(
+        "( $count := function($n, $acc){ $n = 0 ? $acc : $count($n-1, $acc+1) }; $count(50000, 0) )",
+        "50000",
+    );
+}
+
+// ── Mutual recursion / late binding ──────────────────────────────────────────
+
+#[test]
+fn mutual_recursion_in_scope() {
+    assert_eval(
+        "( $even := function($n){ $n = 0 ? true : $odd($n-1) }; \
+           $odd := function($n){ $n = 0 ? false : $even($n-1) }; $even(10) )",
+        "true",
+    );
+}
+
+#[test]
+fn late_bound_name_resolves_at_call_time() {
+    // $f2 is not yet bound when $f is defined; the body resolves it by name
+    // at call time through the live scope. Matches jsonata-js.
+    assert_eval(
+        "( $f := function(){ $f2() }; $f2 := function(){ \"late\" }; $f() )",
+        "\"late\"",
+    );
+}
+
+// ── Closures escaping their defining scope ───────────────────────────────────
+
+#[test]
+fn closure_escapes_block() {
+    assert_eval("( $g := ( $f := function($x){ $x + 1 }; $f ); $g(41) )", "42");
+}
+
+#[test]
+fn closure_escapes_nested_blocks() {
+    assert_eval(
+        "( $mk := function(){ ( $h := function($x){ $x * 2 }; $h ) }; $mk()(21) )",
+        "42",
+    );
+}
+
+#[test]
+fn closures_escape_inside_array() {
+    assert_eval(
+        "( $fs := ( $a := function(){ 1 }; $b := function(){ 2 }; [$a, $b] ); \
+           $x := $fs[0]; $y := $fs[1]; [$x(), $y()] )",
+        "[1,2]",
+    );
+}
+
+#[test]
+fn closure_escapes_inside_object() {
+    assert_eval(
+        "( $obj := ( $inc := function($x){ $x + 1 }; { \"fn\": $inc } ); \
+           $z := $obj.fn; $z(41) )",
+        "42",
+    );
+}
+
+#[test]
+fn escaped_closure_keeps_captured_local() {
+    assert_eval(
+        "( $outer := function(){ ( $a := 5; $b := function(){ $a * 10 }; $b ) }; $outer()() )",
+        "50",
+    );
+}
+
+#[test]
+fn escaped_recursive_closure_with_captured_local() {
+    // Recursion by self-name must survive the defining scope popping, together
+    // with the captured $x.
+    assert_eval(
+        "( $g := ( $x := 3; $f := function($n){ $n = 0 ? 0 : $x + $f($n - 1) }; $f ); $g(4) )",
+        "12",
+    );
+}
+
+#[test]
+fn escaped_closure_used_as_hof_callback() {
+    assert_eval(
+        "( $f := ( $inc := function($x){ $x + 1 }; $inc ); $map([1,2,3], $f) )",
+        "[2,3,4]",
+    );
+}
+
+#[test]
+fn factory_closures_capture_independently() {
+    assert_eval(
+        "( $mk := function($m){ function($x){ $x * $m } }; \
+           $double := $mk(2); $triple := $mk(3); [$double(5), $triple(5)] )",
+        "[10,15]",
+    );
+}
+
+// closure_captured_in_other_closures_environment lives in
+// divergent_from_reference below: the current escape-analysis GC loses the
+// inner captured lambda.
+
+// ── Higher-order functions / parameters ──────────────────────────────────────
+
+#[test]
+fn lambda_passed_as_parameter_and_called() {
+    assert_eval(
+        "( $apply := function($f, $v){ $f($v) }; $apply(function($x){$x+100}, 1) )",
+        "101",
+    );
+}
+
+#[test]
+fn y_combinator_fixed_point() {
+    assert_eval(
+        "( $y := function($f){ (function($x){ $x($x) })(function($x){ $f(function($y){ ($x($x))($y) }) }) }; \
+           $fac := $y(function($self){ function($n){ $n <= 1 ? 1 : $n * $self($n-1) } }); $fac(6) )",
+        "720",
+    );
+}
+
+#[test]
+fn hof_builtins_with_lambda_callbacks() {
+    assert_eval("$map([1,2,3], function($v){ $v * 10 })", "[10,20,30]");
+    assert_eval("$filter([1,2,3,4], function($v){ $v % 2 = 0 })", "[2,4]");
+    assert_eval("$reduce([1,2,3,4], function($a,$b){ $a + $b })", "10");
+    assert_eval(
+        "( $cmp := function($l, $r){ $l > $r }; $sort([3,1,2], $cmp) )",
+        "[1,2,3]",
+    );
+    assert_eval(
+        "$sift({\"a\": 1, \"bb\": 2, \"c\": 3}, function($v, $k){ $length($k) = 1 })",
+        "{\"a\":1,\"c\":3}",
+    );
+    assert_eval(
+        "$each({\"a\":1,\"b\":2}, function($v,$k){ $k & \"=\" & $v })",
+        "[\"a=1\",\"b=2\"]",
+    );
+    assert_eval("$single([1,2,3], function($v){ $v = 2 })", "2");
+}
+
+#[test]
+fn stored_lambda_by_name_as_hof_callback() {
+    assert_eval(
+        "( $f := function($x){ $x + 1 }; $map([1,2,3], $f) )",
+        "[2,3,4]",
+    );
+}
+
+// ── Signatures through stored lambdas ────────────────────────────────────────
+
+#[test]
+fn signature_enforced_on_stored_lambda() {
+    assert_eval("( $f := function($x)<n:n>{ $x * 2 }; $f(21) )", "42");
+    assert_error_contains("( $f := function($x)<n:n>{ $x * 2 }; $f(\"nope\") )", "T0410");
+}
+
+// ── Partial application ──────────────────────────────────────────────────────
+
+#[test]
+fn partial_application_of_lambda() {
+    assert_eval(
+        "( $add := function($a,$b){$a+$b}; $inc := $add(1, ?); $inc(41) )",
+        "42",
+    );
+}
+
+#[test]
+fn partial_application_of_builtin() {
+    assert_eval(
+        "( $first := $substringBefore(?, \" \"); $first(\"Hello World\") )",
+        "\"Hello\"",
+    );
+}
+
+// ── Function composition (~>) ────────────────────────────────────────────────
+
+#[test]
+fn composition_of_builtins() {
+    assert_eval("( $u := $trim ~> $uppercase; $u(\"  hi \") )", "\"HI\"");
+}
+
+#[test]
+fn composition_of_lambdas() {
+    assert_eval(
+        "( $f := function($x){$x+1}; $g := function($x){$x*2}; $h := $f ~> $g; $h(5) )",
+        "12",
+    );
+}
+
+#[test]
+fn composition_with_self() {
+    assert_eval("( $sq := function($x){$x*$x}; $sq2 := $sq ~> $sq; $sq2(3) )", "81");
+}
+
+#[test]
+fn chain_pipe_into_map_with_function_reference() {
+    assert_eval(
+        "( $double := function($x){$x*2}; [1,2,3] ~> $map($double) )",
+        "[2,4,6]",
+    );
+}
+
+// ── Transforms ───────────────────────────────────────────────────────────────
+
+#[test]
+fn transform_applied_via_chain_pipe_literal() {
+    assert_eval("{\"a\":1} ~> |$|{\"b\":2}|", "{\"a\":1,\"b\":2}");
+}
+
+// ── Rebinding, aliasing, shadowing ───────────────────────────────────────────
+
+#[test]
+fn alias_survives_non_lambda_rebinding() {
+    // $g grabbed the old closure; rebinding $f to a number must not break $g.
+    assert_eval(
+        "( $f := function(){ \"old\" }; $g := $f; $f := 42; [$g(), $f] )",
+        "[\"old\",42]",
+    );
+}
+
+#[test]
+fn rebinding_lambda_name_replaces_it_in_call_position() {
+    assert_eval(
+        "( $f := function(){ \"old\" }; $f := function(){ \"new\" }; $f() )",
+        "\"new\"",
+    );
+}
+
+#[test]
+fn parameter_shadows_outer_lambda_of_same_name() {
+    assert_eval(
+        "( $g := function(){ \"outer\" }; $call := function($g){ $g() }; \
+           $call(function(){ \"inner\" }) )",
+        "\"inner\"",
+    );
+}
+
+#[test]
+fn plain_value_capture_is_a_snapshot() {
+    // NOTE: jsonata-js returns 2 here (closures hold their defining frame by
+    // reference, so a later := in the same frame is visible). This engine has
+    // always captured plain values by snapshot at definition time; that
+    // pre-existing divergence is orthogonal to the closure-storage redesign
+    // and is pinned here so the redesign doesn't silently move it.
+    assert_eval("( $x := 1; $g := function(){ $x }; $x := 2; $g() )", "1");
+}
+
+// ── Function values as data ──────────────────────────────────────────────────
+
+#[test]
+fn string_of_lambda_is_empty_string() {
+    assert_eval("$string(function($x){$x})", "\"\"");
+}
+
+#[test]
+fn lambdas_never_compare_equal() {
+    assert_eval("( $f := function($x){$x}; $f = $f )", "false");
+    assert_eval("( $f := function($x){$x}; $g := $f; $f = $g )", "false");
+    assert_eval("( $f := function($x){$x}; $g := function($x){$x}; $f = $g )", "false");
+}
+
+#[test]
+fn exists_on_function_values() {
+    assert_eval("( $f := function(){1}; $exists($f) )", "true");
+    assert_eval("$exists($undefined_thing)", "false");
+}
+
+// ── Divergences from jsonata-js (verified against the reference with node) ───
+//
+// Each test here pins what THIS engine currently does. The reference behavior
+// is stated in the comment. Some of these are id-collision/dangling-tag
+// artifacts of the side-table design and are expected to change with the
+// value-carried closure redesign; update them deliberately when that lands.
+
+mod divergent_from_reference {
+    use super::*;
+
+    #[test]
+    fn alias_then_lambda_rebinding() {
+        // Reference: ["old","new"] — $g copied the closure value; rebinding $f
+        // doesn't affect it. Current engine: the alias's tag resolves by NAME
+        // "f" through the side table, so $g() picks up the REBOUND lambda.
+        assert_eval(
+            "( $f := function(){ \"old\" }; $g := $f; $f := function(){ \"new\" }; [$g(), $f()] )",
+            "[\"new\",\"new\"]",
+        );
+    }
+
+    #[test]
+    fn calling_name_rebound_to_non_function() {
+        // Reference: T1006 (attempted to invoke a non-function; $f is 42).
+        // Current engine: the stale side-table entry under "f" survives the
+        // rebinding, so the OLD lambda is silently called.
+        assert_eval("( $f := function(){ 1 }; $f := 42; $f() )", "1");
+    }
+
+    #[test]
+    fn escaped_mutual_recursion() {
+        // Reference: "mutual-esc" — the escaped closure's frame keeps $g
+        // alive. Current engine: $g was not captured at $f's definition (it
+        // didn't exist yet) and the block scope holding it has popped, so the
+        // call dangles: T1006.
+        assert_error_contains(
+            "( $esc := ( $f := function(){ $g() }; $g := function(){ \"mutual-esc\" }; $f ); $esc() )",
+            "T1006",
+        );
+    }
+
+    #[test]
+    fn escaped_partial_application() {
+        // Reference: 42 — the partial holds the function it applies. Current
+        // engine: the partial re-resolves "$add" BY NAME at invocation time,
+        // and the defining scope has popped: T1006.
+        assert_error_contains(
+            "( $p := ( $add := function($a,$b){$a+$b}; $add(10, ?) ); $p(32) )",
+            "T1006",
+        );
+    }
+
+    #[test]
+    fn transform_bound_to_variable_then_called() {
+        // Reference: {"a":1,"b":2} — a transform is an ordinary function
+        // value. Current engine: evaluating a bare transform yields the string
+        // "<lambda>" plus a side-table entry the string doesn't reference, so
+        // the call fails: T1006.
+        assert_error_contains("( $t := |$|{\"b\":2}|; $t({\"a\":1}) )", "T1006");
+    }
+
+    #[test]
+    fn transform_bound_to_variable_via_chain_pipe() {
+        // Reference: {"a":1,"b":2}. Current engine: same "<lambda>" string
+        // problem as above: T1006.
+        assert_error_contains("( $t := |$|{\"b\":2}|; {\"a\":1} ~> $t )", "T1006");
+    }
+
+    #[test]
+    fn captured_lambda_name_rebound_to_lambda_resolves_live() {
+        // Reference: "B" (live frame). Current engine: also "B", but only
+        // because the captured tag resolves by NAME through the side table —
+        // the same accident that breaks alias_then_lambda_rebinding above.
+        // A pure snapshot-capture design would return "A" here; if the
+        // redesign changes this, this is the place to document it.
+        assert_eval(
+            "( $f := function(){ \"A\" }; $g := function(){ $f() }; $f := function(){ \"B\" }; $g() )",
+            "\"B\"",
+        );
+    }
+
+    #[test]
+    fn captured_lambda_name_rebound_to_non_lambda() {
+        // Reference: an error (the reference tries to call 42). Current
+        // engine: the stale side-table entry under "f" makes $g() call the
+        // ORIGINAL lambda: "A".
+        assert_eval(
+            "( $f := function(){ \"A\" }; $g := function(){ $f() }; $f := 42; $g() )",
+            "\"A\"",
+        );
+    }
+
+    #[test]
+    fn closure_captured_in_other_closures_environment() {
+        // Reference: 17 — the escaping anonymous closure keeps its captured
+        // $sq alive. Current engine: the escape-analysis walk loses $sq
+        // across the double scope pop (block exit + lambda return), so the
+        // inner call dangles: T1006. This is the latent bug class issue #157
+        // describes; the value-carried redesign makes it unrepresentable.
+        assert_error_contains(
+            "( $mk := function(){ ( $sq := function($x){ $x * $x }; function($y){ $sq($y) + 1 } ) }; \
+               $mk()(4) )",
+            "T1006",
+        );
+    }
+
+    #[test]
+    fn recursive_closure_called_through_alias_after_rebinding() {
+        // Reference: "replaced" (the body's $f resolves through the live
+        // frame, finding the rebound lambda). Current engine: same result,
+        // via the name-tag accident. A snapshot + self-reference design
+        // yields "done" (the recursive self-call always reaches the original
+        // closure); if the redesign changes this, update deliberately.
+        assert_eval(
+            "( $f := function($x){ $x = 0 ? \"done\" : $f($x - 1) }; \
+               $f2 := $f; $f := function($x){ \"replaced\" }; $f2(2) )",
+            "\"replaced\"",
+        );
+    }
+}

--- a/tests/lambda_closure_suite.rs
+++ b/tests/lambda_closure_suite.rs
@@ -233,6 +233,83 @@ fn partial_application_of_lambda() {
 }
 
 #[test]
+fn partial_application_arguments_evaluate_at_creation() {
+    // The bound argument is a value snapshot: rebinding $x later must not
+    // change what the partial applies.
+    assert_eval(
+        "( $x := 1; $add := function($a,$b){$a+$b}; $p := $add($x, ?); $x := 100; $p(1) )",
+        "2",
+    );
+}
+
+#[test]
+fn partial_application_multiple_placeholders() {
+    assert_eval("( $p := $substring(?, 1); $p(\"hello\") )", "\"ello\"");
+    assert_eval("( $p := $substring(?, 1, ?); $p(\"hello\", 3) )", "\"ell\"");
+}
+
+#[test]
+fn partial_of_partial() {
+    assert_eval(
+        "( $add := function($a,$b){$a+$b}; $p1 := $add(10, ?); $p2 := $p1(?); $p2(5) )",
+        "15",
+    );
+}
+
+#[test]
+fn partial_of_lambda_captures_target_at_creation() {
+    // The partial holds the closure it applies, so rebinding $add afterwards
+    // does not change it. Matches jsonata-js (partialApplyProcedure evaluates
+    // the target to a function value when the partial is built).
+    assert_eval(
+        "( $add := function($a,$b){$a+$b}; $p := $add(1, ?); $add := function($a,$b){0}; $p(2) )",
+        "3",
+    );
+}
+
+#[test]
+fn partial_of_builtin_sees_later_shadowing() {
+    // A builtin-named partial resolves its target BY NAME at invocation time,
+    // so a user binding that shadows the builtin afterwards wins. (Matches
+    // jsonata-js, where the partial's generated thunk resolves through the
+    // environment chain.)
+    assert_eval(
+        "( $up := $uppercase(?); $uppercase := function($x){ \"shadowed\" }; $up(\"a\") )",
+        "\"shadowed\"",
+    );
+}
+
+#[test]
+fn partial_of_builtin_reference_binding() {
+    // $f := $sum stores a builtin reference; partially applying through it
+    // resolves the builtin at invocation.
+    assert_eval("( $f := $sum; $p := $f(?); $p([1,2,3]) )", "6");
+}
+
+#[test]
+fn partial_of_unknown_name_fails_at_invocation() {
+    // Creating the partial succeeds (the sigil form defers resolution);
+    // invoking it reports the missing function.
+    assert_error_contains("( $p := $notreal(?); $p(1) )", "T1006");
+}
+
+#[test]
+fn partial_as_hof_callback() {
+    assert_eval(
+        "( $add := function($a,$b){$a+$b}; $inc := $add(1, ?); $map([1,2,3], $inc) )",
+        "[2,3,4]",
+    );
+}
+
+#[test]
+fn partial_composed_with_chain_pipe() {
+    assert_eval(
+        "( $sub := $substringBefore(?, \" \"); $sub2 := $sub ~> $uppercase; $sub2(\"Hello World\") )",
+        "\"HELLO\"",
+    );
+}
+
+#[test]
 fn partial_application_of_builtin() {
     assert_eval(
         "( $first := $substringBefore(?, \" \"); $first(\"Hello World\") )",

--- a/tests/lambda_closure_suite.rs
+++ b/tests/lambda_closure_suite.rs
@@ -93,7 +93,10 @@ fn late_bound_name_resolves_at_call_time() {
 
 #[test]
 fn closure_escapes_block() {
-    assert_eval("( $g := ( $f := function($x){ $x + 1 }; $f ); $g(41) )", "42");
+    assert_eval(
+        "( $g := ( $f := function($x){ $x + 1 }; $f ); $g(41) )",
+        "42",
+    );
 }
 
 #[test]
@@ -213,7 +216,10 @@ fn stored_lambda_by_name_as_hof_callback() {
 #[test]
 fn signature_enforced_on_stored_lambda() {
     assert_eval("( $f := function($x)<n:n>{ $x * 2 }; $f(21) )", "42");
-    assert_error_contains("( $f := function($x)<n:n>{ $x * 2 }; $f(\"nope\") )", "T0410");
+    assert_error_contains(
+        "( $f := function($x)<n:n>{ $x * 2 }; $f(\"nope\") )",
+        "T0410",
+    );
 }
 
 // ── Partial application ──────────────────────────────────────────────────────
@@ -251,7 +257,10 @@ fn composition_of_lambdas() {
 
 #[test]
 fn composition_with_self() {
-    assert_eval("( $sq := function($x){$x*$x}; $sq2 := $sq ~> $sq; $sq2(3) )", "81");
+    assert_eval(
+        "( $sq := function($x){$x*$x}; $sq2 := $sq ~> $sq; $sq2(3) )",
+        "81",
+    );
 }
 
 #[test]
@@ -318,7 +327,10 @@ fn string_of_lambda_is_empty_string() {
 fn lambdas_never_compare_equal() {
     assert_eval("( $f := function($x){$x}; $f = $f )", "false");
     assert_eval("( $f := function($x){$x}; $g := $f; $f = $g )", "false");
-    assert_eval("( $f := function($x){$x}; $g := function($x){$x}; $f = $g )", "false");
+    assert_eval(
+        "( $f := function($x){$x}; $g := function($x){$x}; $f = $g )",
+        "false",
+    );
 }
 
 #[test]
@@ -327,41 +339,99 @@ fn exists_on_function_values() {
     assert_eval("$exists($undefined_thing)", "false");
 }
 
+// ── Fixed by the value-carried closure redesign (#157) ───────────────────────
+//
+// Before the redesign these were dangling-tag / id-collision artifacts of the
+// lambda side table (the pre-redesign pins are in this suite's git history).
+// They now match jsonata-js, verified directly against the reference with node.
+
+mod fixed_by_redesign {
+    use super::*;
+
+    #[test]
+    fn alias_survives_lambda_rebinding() {
+        // $g copied the closure value; rebinding $f doesn't affect it.
+        // (Previously ["new","new"]: the alias's tag resolved by NAME "f"
+        // through the side table, picking up the rebound lambda.)
+        assert_eval(
+            "( $f := function(){ \"old\" }; $g := $f; $f := function(){ \"new\" }; [$g(), $f()] )",
+            "[\"old\",\"new\"]",
+        );
+    }
+
+    #[test]
+    fn calling_name_rebound_to_non_function_is_an_error() {
+        // $f is 42; calling it is T1006. (Previously the stale side-table
+        // entry under "f" survived the rebinding and the OLD lambda was
+        // silently called, returning 1.)
+        assert_error_contains("( $f := function(){ 1 }; $f := 42; $f() )", "T1006");
+    }
+
+    #[test]
+    fn escaped_partial_application() {
+        // The partial captures the closure it applies, so it survives the
+        // defining scope. (Previously it re-resolved "$add" by name at
+        // invocation time: T1006.)
+        assert_eval(
+            "( $p := ( $add := function($a,$b){$a+$b}; $add(10, ?) ); $p(32) )",
+            "42",
+        );
+    }
+
+    #[test]
+    fn transform_bound_to_variable_then_called() {
+        // A transform is an ordinary function value. (Previously evaluating a
+        // bare transform yielded the string "<lambda>" plus a side-table entry
+        // the string didn't reference: T1006.)
+        assert_eval(
+            "( $t := |$|{\"b\":2}|; $t({\"a\":1}) )",
+            "{\"a\":1,\"b\":2}",
+        );
+    }
+
+    #[test]
+    fn transform_bound_to_variable_via_chain_pipe() {
+        assert_eval(
+            "( $t := |$|{\"b\":2}|; {\"a\":1} ~> $t )",
+            "{\"a\":1,\"b\":2}",
+        );
+    }
+
+    #[test]
+    fn closure_captured_in_other_closures_environment() {
+        // The escaping anonymous closure carries its captured $sq inside the
+        // value. (Previously the escape-analysis walk lost $sq across the
+        // double scope pop — block exit + lambda return — and the inner call
+        // dangled: T1006. That bug class is now unrepresentable.)
+        assert_eval(
+            "( $mk := function(){ ( $sq := function($x){ $x * $x }; function($y){ $sq($y) + 1 } ) }; \
+               $mk()(4) )",
+            "17",
+        );
+    }
+}
+
 // ── Divergences from jsonata-js (verified against the reference with node) ───
 //
-// Each test here pins what THIS engine currently does. The reference behavior
-// is stated in the comment. Some of these are id-collision/dangling-tag
-// artifacts of the side-table design and are expected to change with the
-// value-carried closure redesign; update them deliberately when that lands.
+// jsonata-js closures hold their defining environment frame BY REFERENCE, so a
+// later `:=` rebinding in that frame is visible through previously-defined
+// closures. This engine captures free variables by VALUE SNAPSHOT at
+// definition time (and always has, for plain values — see
+// plain_value_capture_is_a_snapshot above). The redesign makes that snapshot
+// rule uniform for lambda-valued variables too, where the old side table
+// sometimes resolved them live by accident. Live-frame semantics would require
+// closures to hold their defining frame (`Rc` cycles and per-cycle leaks —
+// rejected in #157 for the long-lived Python interpreter case).
 
 mod divergent_from_reference {
     use super::*;
 
     #[test]
-    fn alias_then_lambda_rebinding() {
-        // Reference: ["old","new"] — $g copied the closure value; rebinding $f
-        // doesn't affect it. Current engine: the alias's tag resolves by NAME
-        // "f" through the side table, so $g() picks up the REBOUND lambda.
-        assert_eval(
-            "( $f := function(){ \"old\" }; $g := $f; $f := function(){ \"new\" }; [$g(), $f()] )",
-            "[\"new\",\"new\"]",
-        );
-    }
-
-    #[test]
-    fn calling_name_rebound_to_non_function() {
-        // Reference: T1006 (attempted to invoke a non-function; $f is 42).
-        // Current engine: the stale side-table entry under "f" survives the
-        // rebinding, so the OLD lambda is silently called.
-        assert_eval("( $f := function(){ 1 }; $f := 42; $f() )", "1");
-    }
-
-    #[test]
     fn escaped_mutual_recursion() {
-        // Reference: "mutual-esc" — the escaped closure's frame keeps $g
-        // alive. Current engine: $g was not captured at $f's definition (it
-        // didn't exist yet) and the block scope holding it has popped, so the
-        // call dangles: T1006.
+        // Reference: "mutual-esc" — the escaped closure's live frame keeps $g
+        // reachable. Snapshot capture: $g did not exist when $f was defined,
+        // so nothing captured it; after the defining scope pops the call
+        // dangles: T1006. (Same behavior as before the redesign.)
         assert_error_contains(
             "( $esc := ( $f := function(){ $g() }; $g := function(){ \"mutual-esc\" }; $f ); $esc() )",
             "T1006",
@@ -369,50 +439,21 @@ mod divergent_from_reference {
     }
 
     #[test]
-    fn escaped_partial_application() {
-        // Reference: 42 — the partial holds the function it applies. Current
-        // engine: the partial re-resolves "$add" BY NAME at invocation time,
-        // and the defining scope has popped: T1006.
-        assert_error_contains(
-            "( $p := ( $add := function($a,$b){$a+$b}; $add(10, ?) ); $p(32) )",
-            "T1006",
-        );
-    }
-
-    #[test]
-    fn transform_bound_to_variable_then_called() {
-        // Reference: {"a":1,"b":2} — a transform is an ordinary function
-        // value. Current engine: evaluating a bare transform yields the string
-        // "<lambda>" plus a side-table entry the string doesn't reference, so
-        // the call fails: T1006.
-        assert_error_contains("( $t := |$|{\"b\":2}|; $t({\"a\":1}) )", "T1006");
-    }
-
-    #[test]
-    fn transform_bound_to_variable_via_chain_pipe() {
-        // Reference: {"a":1,"b":2}. Current engine: same "<lambda>" string
-        // problem as above: T1006.
-        assert_error_contains("( $t := |$|{\"b\":2}|; {\"a\":1} ~> $t )", "T1006");
-    }
-
-    #[test]
-    fn captured_lambda_name_rebound_to_lambda_resolves_live() {
-        // Reference: "B" (live frame). Current engine: also "B", but only
-        // because the captured tag resolves by NAME through the side table —
-        // the same accident that breaks alias_then_lambda_rebinding above.
-        // A pure snapshot-capture design would return "A" here; if the
-        // redesign changes this, this is the place to document it.
+    fn captured_lambda_name_rebound_to_lambda() {
+        // Reference: "B" (live frame sees the rebinding). Snapshot capture:
+        // $g captured $f's value at definition — "A". (Before the redesign
+        // this returned "B", but only via the same name-tag accident that
+        // broke alias_survives_lambda_rebinding.)
         assert_eval(
             "( $f := function(){ \"A\" }; $g := function(){ $f() }; $f := function(){ \"B\" }; $g() )",
-            "\"B\"",
+            "\"A\"",
         );
     }
 
     #[test]
     fn captured_lambda_name_rebound_to_non_lambda() {
-        // Reference: an error (the reference tries to call 42). Current
-        // engine: the stale side-table entry under "f" makes $g() call the
-        // ORIGINAL lambda: "A".
+        // Reference: an error (the live frame's $f is 42; calling it fails).
+        // Snapshot capture: $g captured the original closure — "A".
         assert_eval(
             "( $f := function(){ \"A\" }; $g := function(){ $f() }; $f := 42; $g() )",
             "\"A\"",
@@ -420,30 +461,49 @@ mod divergent_from_reference {
     }
 
     #[test]
-    fn closure_captured_in_other_closures_environment() {
-        // Reference: 17 — the escaping anonymous closure keeps its captured
-        // $sq alive. Current engine: the escape-analysis walk loses $sq
-        // across the double scope pop (block exit + lambda return), so the
-        // inner call dangles: T1006. This is the latent bug class issue #157
-        // describes; the value-carried redesign makes it unrepresentable.
-        assert_error_contains(
-            "( $mk := function(){ ( $sq := function($x){ $x * $x }; function($y){ $sq($y) + 1 } ) }; \
-               $mk()(4) )",
-            "T1006",
-        );
-    }
-
-    #[test]
     fn recursive_closure_called_through_alias_after_rebinding() {
-        // Reference: "replaced" (the body's $f resolves through the live
-        // frame, finding the rebound lambda). Current engine: same result,
-        // via the name-tag accident. A snapshot + self-reference design
-        // yields "done" (the recursive self-call always reaches the original
-        // closure); if the redesign changes this, update deliberately.
+        // Reference: "replaced" (the body's recursive $f resolves through the
+        // live frame, finding the rebound lambda). Snapshot + late-bound
+        // self-reference: a recursive function always calls ITSELF — "done".
         assert_eval(
             "( $f := function($x){ $x = 0 ? \"done\" : $f($x - 1) }; \
                $f2 := $f; $f := function($x){ \"replaced\" }; $f2(2) )",
-            "\"replaced\"",
+            "\"done\"",
         );
     }
+}
+
+// ── Memory: no closure leaks ─────────────────────────────────────────────────
+
+#[test]
+fn repeated_evaluation_does_not_leak_closures() {
+    use jsonata_core::evaluator::live_lambda_count;
+
+    // Shapes that exercised the old escape-analysis GC hardest: escaping
+    // closures, closures capturing closures, self-recursion, aliasing,
+    // partial application. Snapshot capture cannot form Rc cycles (a closure
+    // only captures values that existed before it did; self-reference is
+    // late-bound at invocation, never stored), so every closure must be freed
+    // once the evaluation's result is dropped.
+    let exprs = [
+        "( $f := function($x){ $x <= 1 ? 1 : $x * $f($x-1) }; $f(10) )",
+        "( $mk := function(){ ( $sq := function($x){ $x * $x }; function($y){ $sq($y) + 1 } ) }; $mk()(4) )",
+        "( $g := ( $x := 3; $f := function($n){ $n = 0 ? 0 : $x + $f($n - 1) }; $f ); $g(4) )",
+        "( $p := ( $add := function($a,$b){$a+$b}; $add(10, ?) ); $p(32) )",
+        "( $f := function(){ \"old\" }; $g := $f; $f := function(){ \"new\" }; [$g(), $f()] )",
+        "( $y := function($f){ (function($x){ $x($x) })(function($x){ $f(function($y){ ($x($x))($y) }) }) }; \
+           $fac := $y(function($self){ function($n){ $n <= 1 ? 1 : $n * $self($n-1) } }); $fac(6) )",
+    ];
+
+    let baseline = live_lambda_count();
+    for _ in 0..100 {
+        for expr in &exprs {
+            let _ = eval(expr).unwrap();
+        }
+    }
+    assert_eq!(
+        live_lambda_count(),
+        baseline,
+        "closures leaked across repeated evaluations"
+    );
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1173,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "jsonatapy"
-version = "2.2.7"
+version = "2.2.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Description

Implements the #157 redesign in three commits, following the issue's own roadmap (stress suite first, then the redesign, then the follow-up cleanup it exposed):

1. **`test:` letrec/closure stress suite** — pins recursion (direct, mutual, 50k-deep TCO, Y-combinator), closures escaping blocks bare/in arrays/in objects/in other closures' environments, rebinding and aliasing, partial application, `~>` composition, transforms, signatures, function-value comparisons. Written and green against `main` first; behaviors diverging from jsonata-js were pinned separately with the reference behavior (verified directly with node) documented per test.
2. **`refactor:` value-carried closures** — `JValue::Lambda` is now `Rc<StoredLambda>`: the value *is* the closure, `Rc` provides its lifetime. Deletes `Scope.lambdas`, `bind_lambda`/`lookup_lambda`, `pop_scope_preserving_lambdas`, `extract_lambda_ids`/`collect_lambda_ids` (the O(result size) escape walk on every block exit and lambda return), the dual-map halves of `unbind`/`clear_current_scope`, and the lambda-id counter. Recursion is late-bound letrec: `$f := function ...` records `self_name`, and each invocation binds it to the invoked closure — no stored self-reference, therefore **no `Rc` cycles** (a new `live_lambda_count()` probe plus a suite test proves repeated evaluation of the cycle-prone shapes frees every closure).
3. **`refactor:` typed `PartialApplication`** — replaces the `"__partial_call:name:bool:n"` marker-string body (parsed with `split(':')` per invocation) and the `__bound_arg_N`/`__placeholder_positions`/`__total_args` values smuggled through `captured_env`, plus the full-environment snapshot partials took at creation for no reason. Targets are typed: `PartialTarget::Lambda` (user function captured as a closure at creation) / `PartialTarget::Named` (builtins/host fns, name-resolved at call time to preserve shadowing).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)
- [ ] Documentation update
- [x] Test coverage improvement
- [ ] CI/CD improvement
- [ ] Dependency update

(“Breaking” applies to the Rust-crate API surface and to documented edge-case semantics — see Breaking Changes below. The Python API is unchanged.)

## Related Issues

Fixes #157
Relates to #159

## Changes Made

- `JValue::Lambda { lambda_id, params, name, signature }` → `JValue::Lambda(Rc<StoredLambda>)`; function equality is closure identity (`Rc::ptr_eq`) instead of id-string equality
- Deleted the per-scope lambda side table and the escape-analysis GC; every scope pop is now unconditional — dangling lambda references are unrepresentable
- `StoredLambda` gains `self_name` (late-bound letrec) and `partial` (typed partial application); construction of both is documented in `docs/development/architecture.md`
- `evaluate_function_call`/`apply_function`/TCO resolution collapsed from three lookup tiers to one bindings lookup
- Transforms (`|...|...|`) evaluate to ordinary function values instead of a stray `"<lambda>"` string plus an unreferenced side-table entry
- Partials capture user-defined targets as closures at creation; builtin/host targets stay name-resolved
- `tests/lambda_closure_suite.rs`: 52 tests (recursion, escapes, rebinding, partials, memory guard) with per-test reference-behavior documentation
- CHANGELOG and architecture doc updated; `uv.lock` version sync (2.2.7 → 2.2.8, catching up with the manifests)

## Testing

### Test Environment

- Python version: 3.13 (uv-managed venv, maturin release build)
- Operating System: Linux (dev container)
- jsonatapy version: 2.2.8 (this branch)

### Test Checklist

- [x] All existing tests pass (`cargo test --all-features`: 468; `pytest tests/python/`: 25,071 passed)
- [x] New tests added for bug fixes/features (52-test closure suite)
- [x] Reference test suite still passes (1,682/1,682 cases; 4 pre-existing strict xfails unchanged)
- [x] Tested manually with provided examples (CLI probes for every touched corner)
- [x] Edge cases considered and tested (rebinding, aliasing, escapes, partial-of-partial, shadowing)
- [x] Performance impact assessed (see below)

### Test Cases

```python
import jsonatapy

# Escaped closure capturing another closure — dangled (T1006) before, now correct:
expr = jsonatapy.compile(
    "( $mk := function(){ ( $sq := function($x){ $x * $x }; function($y){ $sq($y) + 1 } ) }; $mk()(4) )")
assert expr.evaluate({}) == 17

# Transform bound to a variable — T1006 before, now callable and pipeable:
expr = jsonatapy.compile('( $t := |$|{"b":2}|; $t({"a":1}) )')
assert expr.evaluate({}) == {"a": 1, "b": 2}

# Partial application escaping its target's defining scope — T1006 before:
expr = jsonatapy.compile("( $p := ( $add := function($a,$b){$a+$b}; $add(10, ?) ); $p(32) )")
assert expr.evaluate({}) == 42
```

## Documentation

- [x] Code is self-documenting with clear variable names
- [x] Added/updated docstrings for public APIs
- [x] Added/updated inline comments for complex logic
- [ ] Updated README.md (if needed) — not needed
- [x] Updated CHANGELOG.md
- [ ] Added/updated examples in docs/ (if applicable) — architecture doc updated instead
- [x] Rustdoc comments added for Rust code
- [ ] Python type hints added/updated — no Python surface change

## Compatibility

- [x] Behavior matches JavaScript JSONata reference implementation — for every case the reference suite covers, plus five previously-divergent corners now fixed (see below); remaining live-frame divergences are documented in #159
- [x] Tested against JSONata playground — equivalent: divergence cases verified directly against `tests/jsonata-js/src/jsonata.js` with node
- [ ] No breaking changes to public API — Rust crate API changed (see below); Python/C APIs unchanged
- [ ] Backward compatible with previous versions — edge-case semantics deliberately changed toward the reference (see below)

### JavaScript Reference Verification

**JavaScript (jsonata-js) behavior:**
```javascript
// ( $f := function(){ "old" }; $g := $f; $f := function(){ "new" }; [$g(), $f()] )
// → ["old","new"]
// ( $t := |$|{"b":2}|; $t({"a":1}) )  → {"a":1,"b":2}
// ( $f := function(){ 1 }; $f := 42; $f() )  → T1006
```

**jsonatapy behavior (this branch):**
```python
# All three now match. Before this PR: ["new","new"] (alias followed the rebound
# name), T1006 (transform value was an inert string), and 1 (stale side-table
# entry silently invoked).
```

## Breaking Changes

- [x] This PR introduces breaking changes

**Breaking changes:**
- Rust crate API: `JValue::Lambda` variant shape changed; `JValue::lambda(...)` constructor removed; `StoredLambda` gained fields (constructing it externally now requires them). Python and C APIs are unchanged.
- Edge-case semantics (all toward the reference, each pinned in the suite): calling a name rebound to a non-function now raises T1006 instead of silently invoking a stale lambda; `$g := $f` aliases survive `$f` being rebound; transforms and escaped partials work as values. Two corners moved from accidental-live to uniform snapshot capture (`captured lambda name rebound after capture` now sees the captured value) — documented with rationale in `divergent_from_reference` and #159.

**Migration guide:**
- Rust callers matching on `JValue::Lambda { .. }` with `..` are unaffected; callers destructuring `lambda_id`/`params` should read them from the carried `StoredLambda`. No action for Python/C users.

## Performance Impact

- [ ] Performance benchmarks run — not run (criterion suite); rationale below
- [x] No significant performance regression
- [ ] Performance improvement measured and documented

**Benchmark results:**
```
Not benchmarked in isolation: #157 notes the perf motivation was already
retired by cbdca68 (side table held Rc). This change strictly removes work
from the hot paths it touches: the O(result size) escape walk on every block
exit / lambda return is deleted, one map insert per binding instead of two,
one lookup tier instead of three. Added per named-lambda invocation: one
HashMap insert (the self_name bind). The Python perf-gate tests
(tests/python/test_perf.py) pass unchanged.
```

## Code Quality

- [x] Code follows project style guidelines
- [x] `cargo fmt` applied
- [x] `cargo clippy -- -D warnings` passes with no warnings (`--all-targets --all-features`)
- [ ] Python code formatted with `black` — no Python files touched
- [x] No new compiler warnings
- [x] Removed debug/print statements

## Additional Notes

The suite's git history is part of the deliverable: commit 1 pins the *old* behavior (including the divergences), and each behavioral change in commits 2–3 flips the corresponding assertion in the same commit with the rationale in the test comment. `git log -p tests/lambda_closure_suite.rs` reads as the behavioral changelog of the redesign.

## Reviewer Guidelines

**Focus areas for review:**
- The self-binding order in `invoke_lambda_with_env` / `invoke_lambda_body_for_tco` (captured env → self_name → params) — it is load-bearing for rebound recursive definitions
- `divergent_from_reference` in the suite: confirm you agree these corners should stay snapshot-semantics (the alternative is #159)

**Questions for reviewers:**
- Should the release after this be 2.2.9 or 2.3.0? The Python surface is unchanged, but edge-case behavior moved.

## Checklist

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa

---
_Generated by [Claude Code](https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa)_