### PR TITLE
fix(release): build the aarch64 Linux wheel in the manylinux_2_28 cross image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,12 +228,18 @@ jobs:
       matrix:
         platform:
           # Linux
-          - { os: 'Linux', runner: ubuntu-latest, target: x86_64-unknown-linux-gnu }
-          - { os: 'Linux', runner: ubuntu-latest, target: aarch64-unknown-linux-gnu }
+          - { os: 'Linux', runner: ubuntu-latest, target: x86_64-unknown-linux-gnu, manylinux: auto }
+          # aarch64 needs the manylinux_2_28 cross image: `auto` resolves to the
+          # manylinux2014 image, whose gcc 4.8 cross-toolchain cannot compile
+          # libmimalloc-sys's C sources (rejects -Wno-error=date-time, a gcc 4.9+
+          # flag family) — this broke the first 2.2.9 dispatch, the first release
+          # to carry the mimalloc feature. Trade-off: aarch64 wheels require
+          # glibc >= 2.28 (Ubuntu 18.10+/Debian 10+/RHEL 8+).
+          - { os: 'Linux', runner: ubuntu-latest, target: aarch64-unknown-linux-gnu, manylinux: 2_28 }
           # Windows
-          - { os: 'Windows', runner: windows-latest, target: x86_64-pc-windows-msvc }
+          - { os: 'Windows', runner: windows-latest, target: x86_64-pc-windows-msvc, manylinux: auto }
           # macOS (self-hosted Mac Mini, native ARM64 build)
-          - { os: 'macOS', runner: [self-hosted, macOS, ARM64], target: aarch64-apple-darwin }
+          - { os: 'macOS', runner: [self-hosted, macOS, ARM64], target: aarch64-apple-darwin, manylinux: auto }
 
     steps:
       - name: Checkout
@@ -285,7 +291,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
           sccache: 'true'
-          manylinux: auto
+          manylinux: ${{ matrix.platform.manylinux }}
 
       - name: Build wheels (macOS)
         if: matrix.platform.os == 'macOS'


### PR DESCRIPTION
## Description

Unblocks the failed 2.2.9 "Perform-ata" release dispatch ([run #66](https://github.com/txjmb/jsonata-core/actions/runs/33348468876)). One job failed — **Build wheels on Linux for aarch64-unknown-linux-gnu** — and every publish job was correctly gated off, so nothing partial went out (main did receive the version-bump commit and the `v2.2.9` tag).

**Root cause:** `libmimalloc-sys v0.1.49`'s C build passes `-Wno-error=date-time` (a gcc 4.9+ flag family), and the manylinux2014 cross image that `manylinux: auto` resolves to for aarch64 ships a **gcc 4.8** cross-toolchain, which rejects it:

```
cc1: error: -Werror=date-time: no option -Wdate-time
```

This is the first release carrying the `mimalloc` feature (added post-2.2.8 in `130684d`), so mimalloc's C sources had never been cross-compiled for aarch64 by this pipeline before — a latent break on main, unrelated to the #160 diff.

**Fix:** move the `manylinux` value into the platform matrix; only aarch64 changes, to the `manylinux_2_28` cross image (gcc 11+). Verified locally that `cargo build --release --target aarch64-unknown-linux-gnu --features mimalloc --lib` cross-compiles cleanly under a modern gcc (13.3), while the flag is structurally impossible on gcc 4.8.

**Trade-off (flagging for your review):** aarch64 wheels become `manylinux_2_28` — they require glibc ≥ 2.28 (Ubuntu 18.10+ / Debian 10+ / RHEL 8+). If manylinux2014 aarch64 support matters, the alternative is building the aarch64 wheel without the mimalloc feature instead; say so and I'll switch the approach.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test coverage improvement
- [x] CI/CD improvement
- [ ] Dependency update

## Related Issues

Relates to #160 (the release this unblocks)

## Changes Made

- `release.yml` build-wheels matrix entries gain a `manylinux` field: `auto` everywhere except `2_28` for `aarch64-unknown-linux-gnu`; the maturin-action step reads `matrix.platform.manylinux` (the value is ignored on Windows/macOS)

## Testing

- Reproduced the failure mechanism from [the run's logs](https://github.com/txjmb/jsonata-core/actions/runs/33348468876/job/99357115326); confirmed `libmimalloc-sys` is absent from the v2.2.8 lockfile lineage (first-ever aarch64 mimalloc cross-compile)
- `cargo build --release --target aarch64-unknown-linux-gnu --features mimalloc --lib` with gcc 13.3 cross-toolchain: succeeds
- `release.yml` parses as valid YAML

## Re-run procedure after merging (from the workflow's own guard)

The `v2.2.9` tag currently points at `5a2a8b5` (the bump commit); merging this moves main past it, and the update-version job's stale-tag guard will (correctly) refuse to build. Re-point the tag at the new main HEAD, then re-dispatch:

```bash
git tag -d v2.2.9 && git push origin :refs/tags/v2.2.9 \
  && git tag -a v2.2.9 -m 'Release v2.2.9' <new-main-HEAD> && git push origin v2.2.9
```

then **Actions → Release → Run workflow** on `main` with `version: 2.2.9`, `release_name: Perform-ata`. (The changelog and manifest bumps are already on main; the workflow's re-run guards skip them.) I can handle the tag re-point on your go-ahead — it's a push outside my designated branch, so I won't do it unprompted. The workflow dispatch itself needs you either way (my token gets 403 on `workflow_dispatch`).

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa

---
_Generated by [Claude Code](https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa)_