### PR TITLE
fix(docs): publish the released docs line with its own benchmark numbers, and allow refreshing it without a release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,22 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Docs version to deploy (dev, or a released line like 2.2 to refresh it from main)'
+        required: false
+        type: string
+        default: 'dev'
+      alias:
+        description: 'Alias to (re)point at that version, e.g. stable. Leave empty for none.'
+        required: false
+        type: string
+        default: ''
+      set_default:
+        description: 'Also make that alias the site default (needs an alias)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: docs-deploy
@@ -37,5 +53,41 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Deploy dev docs
-        run: mike deploy dev --push
+      - name: Deploy docs
+        run: |
+          # A push to main publishes the `dev` version ONLY. The released
+          # line (2.x, aliased `stable`, which is the site default and so
+          # the page nearly every reader lands on) is otherwise written
+          # exclusively by release.yml, from the release tag -- so anything
+          # that lands on main after a tag (a doc fix, or a regenerated
+          # docs/performance.md from a benchmark run) stayed invisible on
+          # the default docs URL until the NEXT release cut. That is how
+          # `stable` ended up serving a 2.2.8-era performance page while
+          # main, and `dev`, had the current one.
+          #
+          # The dispatch inputs make refreshing a released line a one-click
+          # operation instead of requiring a release or a hand-run
+          # `mike deploy` against gh-pages.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+            ALIAS="${{ github.event.inputs.alias }}"
+          else
+            VERSION="dev"
+            ALIAS=""
+          fi
+          VERSION="${VERSION:-dev}"
+
+          echo "Deploying docs version '$VERSION'${ALIAS:+ with alias '$ALIAS'}"
+          if [ -n "$ALIAS" ]; then
+            mike deploy "$VERSION" "$ALIAS" --update-aliases --push
+          else
+            mike deploy "$VERSION" --push
+          fi
+
+          if [ "${{ github.event.inputs.set_default }}" = "true" ]; then
+            if [ -z "$ALIAS" ]; then
+              echo "::error::set_default was requested without an alias - nothing to set as default"
+              exit 1
+            fi
+            mike set-default "$ALIAS" --push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1023,8 +1023,15 @@ jobs:
   deploy-release-docs:
     name: Deploy Release Documentation
     runs-on: ubuntu-latest
-    needs: [validate-version, create-github-release]
-    if: needs.create-github-release.result == 'success' && github.event.inputs.dry_run != 'true'
+    # Waits for benchmark-and-record: that job regenerates
+    # docs/performance.md with THIS release's numbers and commits it to
+    # main, which necessarily happens after the tag exists. Running the two
+    # in parallel (as before) meant the docs deploy could only ever see the
+    # pre-benchmark tag content. `!cancelled()` keeps a failed or skipped
+    # benchmark from blocking the docs publish - docs still go out, just
+    # with whatever performance page main currently has.
+    needs: [validate-version, create-github-release, benchmark-and-record]
+    if: ${{ !cancelled() && needs.create-github-release.result == 'success' && github.event.inputs.dry_run != 'true' }}
     timeout-minutes: 10
 
     permissions:
@@ -1036,6 +1043,22 @@ jobs:
         with:
           ref: refs/tags/v${{ needs.validate-version.outputs.version }}
           fetch-depth: 0
+
+      # The tag can never contain this release's own performance numbers:
+      # benchmark-and-record generates them from the tagged build and
+      # commits docs/performance.md to main afterwards. Deploying the tag
+      # verbatim therefore published the PREVIOUS release's performance
+      # page under the new version, permanently. Take just that one file
+      # from main; every other page stays at the exact tagged content.
+      - name: Take the regenerated performance page from main
+        run: |
+          git fetch origin main
+          if git checkout FETCH_HEAD -- docs/performance.md; then
+            echo "docs/performance.md taken from main:"
+            git --no-pager diff --stat HEAD -- docs/performance.md || true
+          else
+            echo "::warning::could not take docs/performance.md from main - deploying the tagged copy"
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
## Description

`https://txjmb.github.io/jsonata-core/stable/performance/` still shows version 2.2.8 and no `jsonata-core (pure Rust)` column. **This is not a docs-generation bug** — `docs/performance.md` on main is correct (2.2.9, new column, real numbers), and so is the `dev` docs version. It's two independent publishing defects.

`/stable/` is a symlink to the `2.2` docs version, and I checked the deployed gh-pages bytes:

| Deployed version | Version shown | "pure Rust" occurrences |
|---|---|---|
| `dev` (updated by every push to main) | 2.2.9 | 8 |
| `2.2` = `stable` (**site default**) | **2.2.8** | **0** |

**Defect 1 — the released docs can never contain their own release's benchmarks.** `deploy-release-docs` checks out the release **tag** and runs *in parallel* with `benchmark-and-record`. That benchmark job generates the release's numbers and commits `docs/performance.md` to main — which can only happen *after* the tag exists. So the tag is always one release behind, permanently. Verified against the real artifact:

```
v2.2.9 tag's docs/performance.md  ->  version cell: 2.2.8, "pure Rust" hits: 0
```

…which is exactly what `/stable/performance/` serves today.

**Defect 2 — nothing but a release can write the released line.** `docs.yml` only ever runs `mike deploy dev`. So a doc fix or a re-run benchmark regeneration that lands on main stays invisible on the default docs URL until the next release cut. That's why your `benchmark-manual` run with `record: true` genuinely did work (it produced commit `46ab68e` and updated `dev`) yet changed nothing at the URL you were looking at.

## Changes Made

- **`release.yml`**: `deploy-release-docs` now `needs` `benchmark-and-record`, and a new step takes *only* `docs/performance.md` from main before building. Every other page stays at exact tagged content. The job's `if` gained `!cancelled()` so a failed or skipped benchmark can't block the docs publish.
- **`docs.yml`**: `workflow_dispatch` gains `version` / `alias` / `set_default` inputs, making "refresh `stable` from main" a one-click dispatch instead of a release or a hand-run `mike deploy` against gh-pages. Push-to-main behavior is unchanged (dev only), and a dispatch with default inputs reproduces the old dispatch behavior exactly.

## Testing

- Both workflows parse as valid YAML; parsed `needs` and step order confirmed programmatically.
- **The restore mechanic proven on a real `v2.2.9` worktree**: before → `2.2.8` / 0 hits; after `git checkout FETCH_HEAD -- docs/performance.md` → `2.2.9` / 9 hits, with **exactly one** path differing from the tag.
- Deploy-step branch logic dry-run for all four paths: push, bare dispatch, `2.2 + stable`, and `2.2 + stable + set_default` — plus the `set_default`-without-alias error path.

## After merging

To fix the currently-published page (this PR prevents recurrence but doesn't itself republish): **Actions → Documentation → Run workflow** with `version: 2.2`, `alias: stable`, `set_default: false`. That rebuilds the released line from current main, which carries the correct performance page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa

---
_Generated by [Claude Code](https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa)_