### PR TITLE
docs(readme): add an auto-generated performance chart from the realistic-workload benchmarks

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -100,11 +100,13 @@ jobs:
           echo "results_file=$RESULTS_FILE" >> $GITHUB_OUTPUT
           echo "Benchmark results saved to: $RESULTS_FILE"
 
-      - name: Update docs/performance.md (local copy)
+      - name: Update docs/performance.md and the README chart (local copies)
         run: |
           python benchmarks/python/generate_performance_doc.py \
             "benchmarks/${{ steps.run_benchmark.outputs.results_file }}" \
             docs/performance.md
+          python benchmarks/python/generate_readme_chart.py \
+            "benchmarks/${{ steps.run_benchmark.outputs.results_file }}"
 
       - name: Upload results as artifact
         uses: actions/upload-artifact@v7
@@ -113,9 +115,10 @@ jobs:
           path: |
             benchmarks/results/*.json
             docs/performance.md
+            docs/assets/realistic-workload-*.svg
           retention-days: 30
 
-      - name: Commit docs/performance.md and save results (only if record=true)
+      - name: Commit performance docs and save results (only if record=true)
         if: github.event.inputs.record == 'true'
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
@@ -136,12 +139,20 @@ jobs:
           git fetch origin main
           git worktree add /tmp/performance-doc-commit FETCH_HEAD
           cp docs/performance.md /tmp/performance-doc-commit/docs/performance.md
+
+          # The README chart is generated straight INTO the worktree rather
+          # than copied from this checkout: the dispatch ref may not be main,
+          # and copying a whole README across would clobber whatever else has
+          # landed there. The generator only rewrites its own marked block.
+          python "$(pwd)/benchmarks/python/generate_readme_chart.py" \
+            "$RESULTS_FILE" /tmp/performance-doc-commit
+
           cd /tmp/performance-doc-commit
-          if git diff --quiet -- docs/performance.md; then
-            echo "docs/performance.md unchanged - skipping commit"
+          if git diff --quiet -- docs/performance.md README.md docs/assets; then
+            echo "performance docs unchanged - skipping commit"
           else
-            git add docs/performance.md
-            git commit -m "docs(benchmarks): update performance.md (manual run, ${SHORT_SHA})"
+            git add docs/performance.md README.md docs/assets
+            git commit -m "docs(benchmarks): update performance.md and README chart (manual run, ${SHORT_SHA})"
             git push origin HEAD:main
           fi
           cd -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -854,13 +854,15 @@ jobs:
           echo "results_file=$RESULTS_FILE" >> $GITHUB_OUTPUT
           echo "Benchmark results saved to: $RESULTS_FILE"
 
-      - name: Update docs/performance.md
+      - name: Update docs/performance.md and the README chart
         run: |
           python benchmarks/python/generate_performance_doc.py \
             "benchmarks/${{ steps.run_benchmark.outputs.results_file }}" \
             docs/performance.md
+          python benchmarks/python/generate_readme_chart.py \
+            "benchmarks/${{ steps.run_benchmark.outputs.results_file }}"
 
-      - name: Commit updated docs/performance.md
+      - name: Commit updated performance docs
         run: |
           # This job runs on the self-hosted Mac Mini specifically because
           # its measurements are far more consistent than a shared cloud
@@ -893,12 +895,22 @@ jobs:
 
           cp docs/performance.md /tmp/performance-doc-commit/docs/performance.md
 
+          # The README performance chart is generated straight INTO the
+          # worktree rather than copied from this checkout: this job's own
+          # checkout is a detached HEAD at the release tag, so copying its
+          # whole README to main would revert anything that landed on main
+          # after the tag was cut. The generator only rewrites the marked
+          # block, leaving the rest of main's README alone.
+          python "$(pwd)/benchmarks/python/generate_readme_chart.py" \
+            "$(pwd)/benchmarks/${{ steps.run_benchmark.outputs.results_file }}" \
+            /tmp/performance-doc-commit
+
           cd /tmp/performance-doc-commit
-          if git diff --quiet -- docs/performance.md; then
-            echo "docs/performance.md unchanged - skipping commit"
+          if git diff --quiet -- docs/performance.md README.md docs/assets; then
+            echo "performance docs unchanged - skipping commit"
           else
-            git add docs/performance.md
-            git commit -m "docs(benchmarks): update performance.md for v${{ needs.validate-version.outputs.version }}"
+            git add docs/performance.md README.md docs/assets
+            git commit -m "docs(benchmarks): update performance.md and README chart for v${{ needs.validate-version.outputs.version }}"
             git push origin HEAD:main
           fi
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,25 @@ See [official JSONata docs](https://docs.jsonata.org/) for the full language ref
 
 ## Performance
 
+<!-- BEGIN generated performance chart -->
+<!-- Regenerated from the latest benchmark run by
+     benchmarks/python/generate_readme_chart.py. Do not hand-edit this block
+     or the SVGs it points at; edit the generator instead. -->
+<a href="https://txjmb.github.io/jsonata-core/stable/performance/">
+  <picture>
+    <source media="(prefers-color-scheme: dark)"
+            srcset="https://raw.githubusercontent.com/txjmb/jsonata-core/main/docs/assets/realistic-workload-dark.svg">
+    <img width="880"
+         alt="Realistic-workload benchmark on a 100-product dataset, lower is better: jsonatapy is 7.5x faster than the jsonata-js reference on the geometric mean of 5 e-commerce queries, and the pure-Rust jsonata-core engine is faster still."
+         src="https://raw.githubusercontent.com/txjmb/jsonata-core/main/docs/assets/realistic-workload-light.svg">
+  </picture>
+</a>
+
+*Click the chart for the full category-by-category tables, including jsonata-python
+and jsonata-rs, which are left off the chart because at 68 ms–9 s they would
+flatten everything else into a sliver.*
+<!-- END generated performance chart -->
+
 `jsonata-core` passes **1682/1682** JSONata reference tests and is the fastest JSONata
 implementation available in either Rust or Python:
 

--- a/benchmarks/python/generate_readme_chart.py
+++ b/benchmarks/python/generate_readme_chart.py
@@ -307,6 +307,9 @@ def resolve_version():
 
         return f"v{jsonatapy.__version__}"
     except ImportError:
+        # Not installed - a local run against a checked-out results file.
+        # Fall through to the manifest below rather than failing: the
+        # version is a footer stamp, not something worth aborting over.
         pass
     manifest = Path(__file__).resolve().parents[2] / "Cargo.toml"
     try:
@@ -315,6 +318,9 @@ def resolve_version():
             if m:
                 return f"v{m.group(1)}"
     except OSError:
+        # No readable Cargo.toml either (the script was copied out of the
+        # tree, or the checkout is partial). "dev" below is the honest
+        # answer at that point.
         pass
     return "dev"
 

--- a/benchmarks/python/generate_readme_chart.py
+++ b/benchmarks/python/generate_readme_chart.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Regenerate the README performance chart from a benchmark_results_*.json file.
+
+Usage: generate_readme_chart.py <results.json> [repo_root]
+
+Writes docs/assets/realistic-workload-{light,dark}.svg under repo_root and
+rewrites the marked chart block in repo_root/README.md. repo_root defaults
+to this checkout; the benchmark jobs pass the worktree they are about to
+commit from, so the README the chart lands in is the one being committed --
+never this checkout's, which may be a different ref. The README embeds the
+SVGs through a <picture>
+element so the viewer's GitHub theme picks one, wrapped in a link to
+https://txjmb.github.io/jsonata-core/stable/performance/ (the SVG itself
+carries no link -- GitHub renders it as an image, so the anchor has to be
+in the README markup around it).
+
+Source data: the "Realistic Workload" category - the five e-commerce dataset
+queries, the closest thing the suite has to what a caller actually runs.
+
+Design notes (these are deliberate, not defaults):
+
+- Form is emphasis, not three competing categoricals: jsonatapy and
+  jsonata-core carry hues, the jsonata-js reference is de-emphasis gray. It
+  is context, not a fourth competitor.
+- jsonata-python and jsonata-rs are deliberately NOT plotted. At 5-9 s and
+  130-320 ms against jsonatapy's 2-15 ms they would flatten every bar that
+  matters into a sliver. The footer says so and links the full table rather
+  than quietly dropping them.
+- Values are labelled at every bar tip and there are no gridlines: direct
+  labels come before gridlines, and a benchmark chart whose numbers are the
+  point should show them.
+- Presentation attributes only - no <style>, no script, no external font.
+  GitHub sanitizes SVG and renders it as an image, so anything else is
+  silently dropped. The font is a system stack resolved on the reader's
+  machine.
+- Palettes are the validated categorical slots 1-2 plus a de-emphasis gray,
+  stepped per mode (checked with the data-viz validator: all gates pass in
+  both modes; the grays clear 3:1 on their surface).
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+CATEGORY = "Realistic Workload"
+DOCS_URL = "https://txjmb.github.io/jsonata-core/stable/performance/"
+# Absolute, not repo-relative: README.md is also the PyPI long_description
+# and the crates.io readme, and PyPI does not resolve relative links.
+RAW_BASE = "https://raw.githubusercontent.com/txjmb/jsonata-core/main/docs/assets"
+
+# The generator owns everything between these two markers, so the headline
+# multiple quoted in the alt text can never drift from the SVGs beside it -
+# the same staleness trap that CHANGELOG.md and docs/performance.md were
+# each pulled out of earlier in this project.
+BEGIN = "<!-- BEGIN generated performance chart -->"
+END = "<!-- END generated performance chart -->"
+
+# Spelled as escapes so ruff's RUF001 (ambiguous-unicode) stays quiet on
+# typography we actually want in the rendered SVG.
+TIMES = "\u00d7"
+EN_DASH = "\u2013"
+
+FONT = "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif"
+
+THEMES = {
+    "light": {
+        "surface": "#fcfcfb",
+        "text_primary": "#0b0b0b",
+        "text_secondary": "#52514e",
+        "series": {"py": "#2a78d6", "core": "#eb6834", "js": "#8a8880"},
+    },
+    "dark": {
+        "surface": "#1a1a19",
+        "text_primary": "#ffffff",
+        "text_secondary": "#c3c2b7",
+        "series": {"py": "#3987e5", "core": "#d95926", "js": "#8f8e86"},
+    },
+}
+
+# Drawn top-to-bottom within each group. Order is fixed: colour follows the
+# entity, never its rank, so a run where one gets faster never repaints them.
+SERIES = [
+    ("py", "jsonatapy (Python)", "jsonatapy_ms"),
+    ("core", "jsonata-core (pure Rust)", "jsonata_core_ms"),
+    ("js", "jsonata-js (reference)", "js_ms"),
+]
+
+# Geometry
+WIDTH = 880
+PAD_X = 24
+LABEL_W = 196  # left gutter: workload names (grows if a name needs it)
+VALUE_W = 58  # right gutter: value at bar tip
+BAR_H = 14  # <= 24px cap
+BAR_GAP = 2  # surface gap between adjacent bars
+GROUP_GAP = 20
+HEADER_H = 132
+FOOTER_H = 34
+
+
+def fmt_ms(v):
+    return f"{v:.1f} ms" if v < 100 else f"{v:.0f} ms"
+
+
+def geometric_mean(values):
+    prod = 1.0
+    for v in values:
+        prod *= v
+    return prod ** (1.0 / len(values))
+
+
+def load_rows(results_path):
+    with open(results_path) as f:
+        data = json.load(f)
+    rows = []
+    for r in data.get("results", []):
+        if r.get("category") != CATEGORY:
+            continue
+        if not r.get("jsonatapy_ms") or not r.get("js_ms"):
+            continue
+        rows.append(r)
+    return rows, data
+
+
+def build_svg(rows, meta, theme_name, version):
+    t = THEMES[theme_name]
+    surface, ink, ink2 = t["surface"], t["text_primary"], t["text_secondary"]
+
+    # Only plot series actually present in the data - an older results file
+    # predates the jsonata-core column and must still render.
+    active = [s for s in SERIES if any(r.get(s[2]) for r in rows)]
+
+    group_h = len(active) * BAR_H + (len(active) - 1) * BAR_GAP
+    # Grow the gutter rather than clip: a future benchmark name longer than
+    # today's longest must not run off the left edge.
+    label_w = max(LABEL_W, max(len(r["name"]) for r in rows) * 6.6 + 20)
+    plot_x = PAD_X + label_w
+    plot_w = WIDTH - plot_x - VALUE_W - PAD_X
+    height = HEADER_H + len(rows) * (group_h + GROUP_GAP) - GROUP_GAP + FOOTER_H
+
+    vmax = max(r[s[2]] for r in rows for s in active if r.get(s[2]))
+    scale = plot_w / vmax
+
+    speedup = geometric_mean([r["js_ms"] / r["jsonatapy_ms"] for r in rows])
+
+    o = []
+    add = o.append
+    add(
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" '
+        f'height="{height:.0f}" viewBox="0 0 {WIDTH} {height:.0f}" '
+        f'font-family="{FONT}" role="img" '
+        f'aria-label="JSONata realistic-workload benchmark: jsonatapy is '
+        f'{speedup:.1f} times faster than jsonata-js on average, lower is better">'
+    )
+    add(f'<rect width="{WIDTH}" height="{height:.0f}" fill="{surface}"/>')
+
+    # ── Header ──────────────────────────────────────────────────────────
+    add(
+        f'<text x="{PAD_X}" y="30" font-size="15" font-weight="600" '
+        f'fill="{ink}">Realistic workloads — 100-product dataset, lower is better</text>'
+    )
+    add(
+        f'<text x="{PAD_X}" y="72" font-size="34" font-weight="700" '
+        f'fill="{ink}">{speedup:.1f}{TIMES} faster</text>'
+    )
+    add(
+        f'<text x="{PAD_X}" y="92" font-size="11.5" fill="{ink2}">'
+        f"than the jsonata-js reference — geometric mean across the "
+        f"{len(rows)} workloads below</text>"
+    )
+
+    # Legend (always present for >= 2 series)
+    lx = PAD_X
+    for key, label, _ in active:
+        add(
+            f'<rect x="{lx}" y="{HEADER_H - 26}" width="9" height="9" rx="2" '
+            f'fill="{t["series"][key]}"/>'
+        )
+        add(
+            f'<text x="{lx + 14}" y="{HEADER_H - 18}" font-size="11.5" '
+            f'fill="{ink2}">{escape(label)}</text>'
+        )
+        lx += 16 + len(label) * 6.0 + 20
+
+    # ── Groups ──────────────────────────────────────────────────────────
+    y = HEADER_H
+    for r in rows:
+        add(
+            f'<text x="{plot_x - 12}" y="{y + group_h / 2 + 4:.1f}" '
+            f'font-size="12" text-anchor="end" fill="{ink}">'
+            f"{escape(r['name'])}</text>"
+        )
+        by = y
+        for key, _, field in active:
+            v = r.get(field)
+            if v:
+                w = max(v * scale, 3.0)
+                # 4px rounded data-end, square at the baseline
+                rad = min(4.0, w)
+                add(
+                    f'<path d="M{plot_x} {by} H{plot_x + w - rad:.1f} '
+                    f"a{rad:.1f} {rad:.1f} 0 0 1 {rad:.1f} {rad:.1f} "
+                    f"V{by + BAR_H - rad:.1f} "
+                    f"a{rad:.1f} {rad:.1f} 0 0 1 -{rad:.1f} {rad:.1f} "
+                    f'H{plot_x} Z" fill="{t["series"][key]}"/>'
+                )
+                add(
+                    f'<text x="{plot_x + w + 7:.1f}" y="{by + BAR_H - 3.5}" '
+                    f'font-size="10.5" fill="{ink2}">{fmt_ms(v)}</text>'
+                )
+            by += BAR_H + BAR_GAP
+        y += group_h + GROUP_GAP
+
+    # ── Footer ──────────────────────────────────────────────────────────
+    date = str(meta.get("timestamp", ""))[:10]
+    foot = (
+        f"jsonatapy {version} · min of {meta.get('repeat_trials', 5)} trials on "
+        f"dedicated Apple Silicon · {date} · "
+        f"jsonata-python and jsonata-rs omitted for scale — full results in the docs"
+    )
+    add(
+        f'<text x="{PAD_X}" y="{height - 12:.0f}" font-size="10" '
+        f'fill="{ink2}">{escape(foot)}</text>'
+    )
+    add("</svg>")
+    return "\n".join(o) + "\n"
+
+
+README_BLOCK = """{begin}
+<!-- Regenerated from the latest benchmark run by
+     benchmarks/python/generate_readme_chart.py. Do not hand-edit this block
+     or the SVGs it points at; edit the generator instead. -->
+<a href="{docs_url}">
+  <picture>
+    <source media="(prefers-color-scheme: dark)"
+            srcset="{raw_base}/realistic-workload-dark.svg">
+    <img width="{width}"
+         alt="{alt}"
+         src="{raw_base}/realistic-workload-light.svg">
+  </picture>
+</a>
+
+*Click the chart for the full category-by-category tables, including jsonata-python
+and jsonata-rs, which are left off the chart because at {omitted_range} they would
+flatten everything else into a sliver.*
+{end}"""
+
+
+def omitted_range(rows):
+    """Human range for the two implementations the chart leaves out."""
+    vals = [r[f] for r in rows for f in ("jsonata_python_ms", "jsonata_rs_ms") if r.get(f)]
+    if not vals:
+        return "their far larger times"
+    lo, hi = min(vals), max(vals)
+
+    def one(v):
+        return f"{v / 1000:.0f} s" if v >= 1000 else f"{v:.0f} ms"
+
+    return f"{one(lo)}{EN_DASH}{one(hi)}"
+
+
+def update_readme(readme_path, rows, speedup):
+    """Rewrite the marked block in README.md, alt text and all.
+
+    Returns True if the file changed. Missing markers is an error, not a
+    silent no-op: a benchmark job that quietly stops updating the README is
+    exactly how the chart would go stale without anyone noticing.
+    """
+    if not readme_path.exists():
+        raise SystemExit(f"::error::{readme_path} does not exist")
+    text = readme_path.read_text()
+    start, stop = text.find(BEGIN), text.find(END)
+    if start == -1 or stop == -1:
+        raise SystemExit(f"::error::{readme_path} is missing the {BEGIN} / {END} markers")
+    alt = (
+        f"Realistic-workload benchmark on a 100-product dataset, lower is "
+        f"better: jsonatapy is {speedup:.1f}x faster than the jsonata-js "
+        f"reference on the geometric mean of {len(rows)} e-commerce queries, "
+        f"and the pure-Rust jsonata-core engine is faster still."
+    )
+    block = README_BLOCK.format(
+        begin=BEGIN,
+        end=END,
+        docs_url=DOCS_URL,
+        raw_base=RAW_BASE,
+        width=WIDTH,
+        alt=escape(alt, {'"': "&quot;"}),
+        omitted_range=omitted_range(rows),
+    )
+    new = text[:start] + block + text[stop + len(END) :]
+    if new == text:
+        return False
+    readme_path.write_text(new)
+    return True
+
+
+def resolve_version():
+    """Version to stamp in the footer.
+
+    Prefers the installed extension (the generator's real home is a
+    benchmark job, where the wheel it just measured is importable); falls
+    back to the crate manifest so a local run still stamps something true.
+    """
+    try:
+        import jsonatapy
+
+        return f"v{jsonatapy.__version__}"
+    except ImportError:
+        pass
+    manifest = Path(__file__).resolve().parents[2] / "Cargo.toml"
+    try:
+        for line in manifest.read_text().splitlines():
+            m = re.match(r'^version\s*=\s*"([^"]+)"', line)
+            if m:
+                return f"v{m.group(1)}"
+    except OSError:
+        pass
+    return "dev"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: generate_readme_chart.py <results.json> [repo_root]", file=sys.stderr)
+        return 2
+    results_path = Path(sys.argv[1])
+    repo_root = (
+        Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else Path(__file__).resolve().parents[2]
+    )
+    out_dir = repo_root / "docs" / "assets"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows, meta = load_rows(results_path)
+    if not rows:
+        print(
+            f"::error::no '{CATEGORY}' rows with both jsonatapy and jsonata-js "
+            f"timings in {results_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    version = resolve_version()
+
+    for theme in ("light", "dark"):
+        path = out_dir / f"realistic-workload-{theme}.svg"
+        path.write_text(build_svg(rows, meta, theme, version))
+        print(f"Wrote {path}")
+
+    readme = repo_root / "README.md"
+    speedup = geometric_mean([r["js_ms"] / r["jsonatapy_ms"] for r in rows])
+    changed = update_readme(readme, rows, speedup)
+    print(f"{'Updated' if changed else 'Unchanged'} {readme}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/assets/realistic-workload-dark.svg
+++ b/docs/assets/realistic-workload-dark.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="476" viewBox="0 0 880 476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif" role="img" aria-label="JSONata realistic-workload benchmark: jsonatapy is 7.5 times faster than jsonata-js on average, lower is better">
+<rect width="880" height="476" fill="#1a1a19"/>
+<text x="24" y="30" font-size="15" font-weight="600" fill="#ffffff">Realistic workloads — 100-product dataset, lower is better</text>
+<text x="24" y="72" font-size="34" font-weight="700" fill="#ffffff">7.5× faster</text>
+<text x="24" y="92" font-size="11.5" fill="#c3c2b7">than the jsonata-js reference — geometric mean across the 5 workloads below</text>
+<rect x="24" y="106" width="9" height="9" rx="2" fill="#3987e5"/>
+<text x="38" y="114" font-size="11.5" fill="#c3c2b7">jsonatapy (Python)</text>
+<rect x="168.0" y="106" width="9" height="9" rx="2" fill="#d95926"/>
+<text x="182.0" y="114" font-size="11.5" fill="#c3c2b7">jsonata-core (pure Rust)</text>
+<rect x="348.0" y="106" width="9" height="9" rx="2" fill="#8f8e86"/>
+<text x="362.0" y="114" font-size="11.5" fill="#c3c2b7">jsonata-js (reference)</text>
+<text x="223.39999999999998" y="159.0" font-size="12" text-anchor="end" fill="#ffffff">Filter by category</text>
+<path d="M235.39999999999998 132 H286.2 a4.0 4.0 0 0 1 4.0 4.0 V142.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#3987e5"/>
+<text x="297.2" y="142.5" font-size="10.5" fill="#c3c2b7">8.7 ms</text>
+<path d="M235.39999999999998 148 H248.4 a4.0 4.0 0 0 1 4.0 4.0 V158.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#d95926"/>
+<text x="259.4" y="158.5" font-size="10.5" fill="#c3c2b7">2.7 ms</text>
+<path d="M235.39999999999998 164 H557.2 a4.0 4.0 0 0 1 4.0 4.0 V174.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8f8e86"/>
+<text x="568.2" y="174.5" font-size="10.5" fill="#c3c2b7">51.5 ms</text>
+<text x="223.39999999999998" y="225.0" font-size="12" text-anchor="end" fill="#ffffff">Calculate total value</text>
+<path d="M235.39999999999998 198 H276.9 a4.0 4.0 0 0 1 4.0 4.0 V208.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#3987e5"/>
+<text x="287.9" y="208.5" font-size="10.5" fill="#c3c2b7">7.2 ms</text>
+<path d="M235.39999999999998 214 H267.0 a4.0 4.0 0 0 1 4.0 4.0 V224.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#d95926"/>
+<text x="278.0" y="224.5" font-size="10.5" fill="#c3c2b7">5.6 ms</text>
+<path d="M235.39999999999998 230 H466.9 a4.0 4.0 0 0 1 4.0 4.0 V240.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8f8e86"/>
+<text x="477.9" y="240.5" font-size="10.5" fill="#c3c2b7">37.3 ms</text>
+<text x="223.39999999999998" y="291.0" font-size="12" text-anchor="end" fill="#ffffff">Complex transformation</text>
+<path d="M235.39999999999998 264 H323.5 a4.0 4.0 0 0 1 4.0 4.0 V274.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#3987e5"/>
+<text x="334.5" y="274.5" font-size="10.5" fill="#c3c2b7">14.6 ms</text>
+<path d="M235.39999999999998 280 H293.1 a4.0 4.0 0 0 1 4.0 4.0 V290.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#d95926"/>
+<text x="304.1" y="290.5" font-size="10.5" fill="#c3c2b7">9.8 ms</text>
+<path d="M235.39999999999998 296 H794.0 a4.0 4.0 0 0 1 4.0 4.0 V306.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8f8e86"/>
+<text x="805.0" y="306.5" font-size="10.5" fill="#c3c2b7">89.0 ms</text>
+<text x="223.39999999999998" y="357.0" font-size="12" text-anchor="end" fill="#ffffff">Group by category (aggregate)</text>
+<path d="M235.39999999999998 330 H297.5 a4.0 4.0 0 0 1 4.0 4.0 V340.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#3987e5"/>
+<text x="308.5" y="340.5" font-size="10.5" fill="#c3c2b7">10.5 ms</text>
+<path d="M235.39999999999998 346 H282.5 a4.0 4.0 0 0 1 4.0 4.0 V356.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#d95926"/>
+<text x="293.5" y="356.5" font-size="10.5" fill="#c3c2b7">8.1 ms</text>
+<path d="M235.39999999999998 362 H790.3 a4.0 4.0 0 0 1 4.0 4.0 V372.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8f8e86"/>
+<text x="801.3" y="372.5" font-size="10.5" fill="#c3c2b7">88.5 ms</text>
+<text x="223.39999999999998" y="423.0" font-size="12" text-anchor="end" fill="#ffffff">Top rated products</text>
+<path d="M235.39999999999998 396 H247.3 a4.0 4.0 0 0 1 4.0 4.0 V406.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#3987e5"/>
+<text x="258.3" y="406.5" font-size="10.5" fill="#c3c2b7">2.5 ms</text>
+<path d="M235.39999999999998 412 H244.3 a4.0 4.0 0 0 1 4.0 4.0 V422.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#d95926"/>
+<text x="255.3" y="422.5" font-size="10.5" fill="#c3c2b7">2.0 ms</text>
+<path d="M235.39999999999998 428 H466.2 a4.0 4.0 0 0 1 4.0 4.0 V438.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8f8e86"/>
+<text x="477.2" y="438.5" font-size="10.5" fill="#c3c2b7">37.2 ms</text>
+<text x="24" y="464" font-size="10" fill="#c3c2b7">jsonatapy v2.2.9 · min of 5 trials on dedicated Apple Silicon · 2026-08-31 · jsonata-python and jsonata-rs omitted for scale — full results in the docs</text>
+</svg>

--- a/docs/assets/realistic-workload-light.svg
+++ b/docs/assets/realistic-workload-light.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="476" viewBox="0 0 880 476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif" role="img" aria-label="JSONata realistic-workload benchmark: jsonatapy is 7.5 times faster than jsonata-js on average, lower is better">
+<rect width="880" height="476" fill="#fcfcfb"/>
+<text x="24" y="30" font-size="15" font-weight="600" fill="#0b0b0b">Realistic workloads — 100-product dataset, lower is better</text>
+<text x="24" y="72" font-size="34" font-weight="700" fill="#0b0b0b">7.5× faster</text>
+<text x="24" y="92" font-size="11.5" fill="#52514e">than the jsonata-js reference — geometric mean across the 5 workloads below</text>
+<rect x="24" y="106" width="9" height="9" rx="2" fill="#2a78d6"/>
+<text x="38" y="114" font-size="11.5" fill="#52514e">jsonatapy (Python)</text>
+<rect x="168.0" y="106" width="9" height="9" rx="2" fill="#eb6834"/>
+<text x="182.0" y="114" font-size="11.5" fill="#52514e">jsonata-core (pure Rust)</text>
+<rect x="348.0" y="106" width="9" height="9" rx="2" fill="#8a8880"/>
+<text x="362.0" y="114" font-size="11.5" fill="#52514e">jsonata-js (reference)</text>
+<text x="223.39999999999998" y="159.0" font-size="12" text-anchor="end" fill="#0b0b0b">Filter by category</text>
+<path d="M235.39999999999998 132 H286.2 a4.0 4.0 0 0 1 4.0 4.0 V142.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#2a78d6"/>
+<text x="297.2" y="142.5" font-size="10.5" fill="#52514e">8.7 ms</text>
+<path d="M235.39999999999998 148 H248.4 a4.0 4.0 0 0 1 4.0 4.0 V158.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#eb6834"/>
+<text x="259.4" y="158.5" font-size="10.5" fill="#52514e">2.7 ms</text>
+<path d="M235.39999999999998 164 H557.2 a4.0 4.0 0 0 1 4.0 4.0 V174.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8a8880"/>
+<text x="568.2" y="174.5" font-size="10.5" fill="#52514e">51.5 ms</text>
+<text x="223.39999999999998" y="225.0" font-size="12" text-anchor="end" fill="#0b0b0b">Calculate total value</text>
+<path d="M235.39999999999998 198 H276.9 a4.0 4.0 0 0 1 4.0 4.0 V208.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#2a78d6"/>
+<text x="287.9" y="208.5" font-size="10.5" fill="#52514e">7.2 ms</text>
+<path d="M235.39999999999998 214 H267.0 a4.0 4.0 0 0 1 4.0 4.0 V224.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#eb6834"/>
+<text x="278.0" y="224.5" font-size="10.5" fill="#52514e">5.6 ms</text>
+<path d="M235.39999999999998 230 H466.9 a4.0 4.0 0 0 1 4.0 4.0 V240.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8a8880"/>
+<text x="477.9" y="240.5" font-size="10.5" fill="#52514e">37.3 ms</text>
+<text x="223.39999999999998" y="291.0" font-size="12" text-anchor="end" fill="#0b0b0b">Complex transformation</text>
+<path d="M235.39999999999998 264 H323.5 a4.0 4.0 0 0 1 4.0 4.0 V274.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#2a78d6"/>
+<text x="334.5" y="274.5" font-size="10.5" fill="#52514e">14.6 ms</text>
+<path d="M235.39999999999998 280 H293.1 a4.0 4.0 0 0 1 4.0 4.0 V290.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#eb6834"/>
+<text x="304.1" y="290.5" font-size="10.5" fill="#52514e">9.8 ms</text>
+<path d="M235.39999999999998 296 H794.0 a4.0 4.0 0 0 1 4.0 4.0 V306.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8a8880"/>
+<text x="805.0" y="306.5" font-size="10.5" fill="#52514e">89.0 ms</text>
+<text x="223.39999999999998" y="357.0" font-size="12" text-anchor="end" fill="#0b0b0b">Group by category (aggregate)</text>
+<path d="M235.39999999999998 330 H297.5 a4.0 4.0 0 0 1 4.0 4.0 V340.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#2a78d6"/>
+<text x="308.5" y="340.5" font-size="10.5" fill="#52514e">10.5 ms</text>
+<path d="M235.39999999999998 346 H282.5 a4.0 4.0 0 0 1 4.0 4.0 V356.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#eb6834"/>
+<text x="293.5" y="356.5" font-size="10.5" fill="#52514e">8.1 ms</text>
+<path d="M235.39999999999998 362 H790.3 a4.0 4.0 0 0 1 4.0 4.0 V372.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8a8880"/>
+<text x="801.3" y="372.5" font-size="10.5" fill="#52514e">88.5 ms</text>
+<text x="223.39999999999998" y="423.0" font-size="12" text-anchor="end" fill="#0b0b0b">Top rated products</text>
+<path d="M235.39999999999998 396 H247.3 a4.0 4.0 0 0 1 4.0 4.0 V406.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#2a78d6"/>
+<text x="258.3" y="406.5" font-size="10.5" fill="#52514e">2.5 ms</text>
+<path d="M235.39999999999998 412 H244.3 a4.0 4.0 0 0 1 4.0 4.0 V422.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#eb6834"/>
+<text x="255.3" y="422.5" font-size="10.5" fill="#52514e">2.0 ms</text>
+<path d="M235.39999999999998 428 H466.2 a4.0 4.0 0 0 1 4.0 4.0 V438.0 a4.0 4.0 0 0 1 -4.0 4.0 H235.39999999999998 Z" fill="#8a8880"/>
+<text x="477.2" y="438.5" font-size="10.5" fill="#52514e">37.2 ms</text>
+<text x="24" y="464" font-size="10" fill="#52514e">jsonatapy v2.2.9 · min of 5 trials on dedicated Apple Silicon · 2026-08-31 · jsonata-python and jsonata-rs omitted for scale — full results in the docs</text>
+</svg>


### PR DESCRIPTION
## Description

The README's performance section was three prose bullets and a link. This puts the numbers on screen: a horizontal grouped bar chart of the five **Realistic Workload** e-commerce queries, with a hero figure (geometric mean speedup vs the jsonata-js reference) above it, wrapped in a link to the full performance page in the docs.

`benchmarks/python/generate_readme_chart.py` owns the whole thing. It reads the same `benchmark_results_*.json` that `generate_performance_doc.py` reads, writes `docs/assets/realistic-workload-{light,dark}.svg`, and rewrites a marked block in `README.md` — alt text and hero figure included, so the number quoted in the markup can never drift from the number drawn in the SVG. That is the same staleness trap `CHANGELOG.md` and `docs/performance.md` were each pulled out of earlier in this project's history.

> **Note on reviewing this PR:** the chart will not render in the branch view of README.md — only the caption below it will. The image URLs are pinned to `main`, and `docs/assets/` does not exist on `main` until this merges. Verified that both SVGs are present on this branch at the expected path; GitHub's own `download_url` for them is the same URL shape with the commit SHA in place of `main`. To see the chart before merging, open the two files under `docs/assets/` directly.

## Type of Change

- [x] Documentation update
- [x] CI/CD improvement

## Related Issues

None — follow-on to the 2.2.9 benchmark/docs work (#164).

## Changes Made

- **New `benchmarks/python/generate_readme_chart.py`** — generates the two SVGs and rewrites the marked README block from a benchmark results file.
- **`README.md`** — the performance section now opens with the linked chart, inside `<!-- BEGIN generated performance chart -->` / `<!-- END … -->` markers that the generator owns.
- **`.github/workflows/release.yml`** — `benchmark-and-record` runs the chart generator and commits the SVGs and README alongside `docs/performance.md`.
- **`.github/workflows/benchmark-manual.yml`** — same, on `record=true`; the SVGs are also added to the uploaded artifact.

Both workflows generate straight **into** the `/tmp/performance-doc-commit` worktree rather than copying this checkout's README across. `release.yml`'s checkout is a detached HEAD at the release tag, and `benchmark-manual` can be dispatched on any ref, so copying a whole README to main would revert anything that landed after. The generator only rewrites its own marked block.

### Chart decisions, deliberate rather than default

- **Emphasis form, not three competing categoricals.** jsonatapy and jsonata-core carry hue; jsonata-js is de-emphasis gray — it is context, not a fourth competitor. Palettes validated per mode against their own surface (lightness band, chroma floor, CVD separation, normal-vision floor, contrast — all pass in light and dark).
- **jsonata-python and jsonata-rs are not plotted.** At 68 ms – 9 s against jsonatapy's 2–15 ms they flatten every bar that matters into a sliver. The caption says so and links the full table rather than quietly dropping them.
- **Every bar is labelled and there are no gridlines.** A static README image has no axis and no tooltip, so a direct label is the only way a value is readable at all.
- **Presentation attributes only** — no `<style>`, no script, no external font or asset reference. Element inventory is `svg`/`rect`/`path`/`text`, which is what survives GitHub's SVG sanitizer.
- **Absolute `raw.githubusercontent` URLs rather than repo-relative paths**, because `README.md` is also the PyPI `long_description` and the crates.io readme. crates.io rewrites relative links to the repo; PyPI does not, so a relative path would render as a permanently broken image on the jsonatapy package page. The cost is the pre-merge branch preview noted above.

## Testing

### Test Environment

- Python version: 3.12
- Operating System: Linux (generation is platform-independent; the benchmark data is from the self-hosted macOS ARM64 runner)
- jsonatapy version: 2.2.9

### What was verified

- **Idempotent** — re-running produces byte-identical SVGs and reports the README unchanged.
- **Worktree targeting** — simulated a worktree whose README carried an unrelated later edit; only the marked block changed, the later edit survived.
- **Degraded path** — a results file predating the `jsonata-core` column renders a correct two-series chart (height and legend adapt).
- **Error paths fail loudly, not silently** — a README missing the markers, and a results file with no usable rows, each exit non-zero with a `::error::` annotation. A benchmark job that quietly stops updating the chart is exactly how it would go stale unnoticed.
- **Rendered and eyeballed** both themes at natural size for label collisions, geometry and overflow.
- **`<picture>` source selection proven** by inverting the media query and confirming the browser served the other file.
- **SVG sanitizer-safety** — element inventory checked, both files parse as well-formed XML, zero occurrences of `style=`/`<script`/`foreignObject`/`xlink`/`href=`.
- `ruff format --check` and `ruff check` clean; both workflows parse as valid YAML.

No Rust or Python library code is touched, so `cargo test` / `pytest` behavior is unchanged.

## Documentation

- [x] Code is self-documenting with clear variable names
- [x] Added/updated docstrings for public APIs
- [x] Added/updated inline comments for complex logic
- [x] Updated README.md

CHANGELOG.md is deliberately not updated: this changes no shipped library behavior.

## Compatibility

- [x] No breaking changes to public API
- [x] Backward compatible with previous versions

## Performance Impact

No runtime impact — documentation and CI only. The chart *reports* performance; it does not affect it.

## Code Quality

- [x] Code follows project style guidelines
- [x] Python code formatted (`ruff format`, the project's formatter)
- [x] No new warnings
- [x] No debug/print statements beyond the generator's intentional progress output

## Reviewer Guidelines

**Focus areas for review:**

- The two workflow diffs — specifically that generating into the worktree (rather than copying the README) is the right call for both jobs.
- Whether pinning image URLs to `main` is the trade you want, given it costs the branch preview. The alternative is repo-relative paths, which fixes previews but breaks the image on PyPI.

**Questions for reviewers:**

- Should the chart also appear at the top of `docs/performance.md`? It is currently README-only.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_0122V7pehAzzg8M3zargDpAa)_